### PR TITLE
fix: guard osascript with platform check to prevent crash on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,69 @@
 <div align="center">
   <img src="client/public/favicon.svg" width="64" height="64" alt="sagent logo">
   <h1>sagent</h1>
-  <p>多模型 AI 聊天 + 桌面 Agent，支持浏览器自动化、文件操作、终端命令、macOS 控制。</p>
+  <p>Multi-model AI chat + desktop Agent with browser automation, file operations, terminal commands, and macOS control.</p>
 </div>
 
-> **仅支持 macOS**。Agent 需要操控本地浏览器和系统，目前只在 Mac 上测试通过。
+> **macOS only.** The Agent needs to control the local browser and system, currently tested on Mac only.
 >
-> 前端适配移动端 — 手机、平板、电脑浏览器都能用，随时随地查看 Agent 进度、继续对话。
+> 🌐 **中文版**: [README_ZH.md](README_ZH.md)
 
-## 快速开始
+## Quick Start
 
 ```bash
 git clone https://github.com/longxiazy/sagent && cd sagent
-cp .env.example .env                    # 编辑填入 API Key
+cp .env.example .env  # Fill in your API Key
 npm install && cd client && npm install && cd ..
 npm run sandbox
 ```
 
-打开 http://localhost:5173
+Open http://localhost:5173
 
-## 安全：沙盒策略
+## Security: Sandbox Policy
 
-通过 `npm run sandbox` 启动时，Agent 在 macOS 沙盒内运行，权限由 `sandbox.sb` 文件控制。
+When started with `npm run sandbox`, the Agent runs inside the macOS sandbox, with permissions controlled by `sandbox.sb`.
 
-你可以自定义 `sandbox.sb` 来调整 Agent 的权限边界。修改该文件可能导致 Agent 部分功能无权限执行（如无法访问网络、无法打开浏览器等）。
+You can customize `sandbox.sb` to adjust the Agent's permission boundary. Modifying the file may cause some Agent functions to lose permission (e.g., unable to access the network, unable to open the browser, etc.).
 
-危险操作（删文件、装包、执行终端命令）会弹窗确认，你不点同意 Agent 就没法继续。
+Dangerous operations (deleting files, installing packages, executing terminal commands) will pop up a confirmation dialog — the Agent cannot proceed without your approval.
 
-## 多设备查看
+## Multi-Device View
 
-局域网内其他设备（手机、iPad）打开 `http://<Mac的IP>:5173` 可以实时查看 Agent 的执行进度。
+Other devices on the LAN (phone, iPad) can open `http://<Mac-IP>:5173` to view the Agent's execution progress in real time.
 
-- **Agent 运行中**：其他设备进入后只能看 agent 执行流程，聊天区为空，等待 agent 完成后显示最终结果
-- **聊天记录**：各设备独立，不共享历史会话
-- **同时只能跑一个 Agent**：新请求会收到 409 提示
+- **Agent running**: Other devices can only watch the agent execution flow; the chat area is empty until the agent completes
+- **Chat history**: Each device is independent; history is not shared
+- **Only one Agent at a time**: New requests will receive a 409 error
 
-## 配置
+## Configuration
 
-编辑 `.env`：
+Edit `.env`:
 
 ```bash
-# API Key（至少填一个）
-NVIDIA_API_KEY=nvapi-...              # MiniMax、Kimi、Qwen、GLM、DeepSeek 等
+# API Keys (fill at least one)
+NVIDIA_API_KEY=nvapi-...  # MiniMax, Kimi, Qwen, GLM, DeepSeek, etc.
 
-# Agent 行为（可选）
-AGENT_MAX_STEPS=32         # 单次任务最大步数，默认 32
-AGENT_RESUME=true          # 后端重启后自动恢复未完成的 Agent 任务
-
+# Agent behavior (optional)
+AGENT_MAX_STEPS=32   # Max steps per task, default 8
+AGENT_RESUME=true    # Auto-resume interrupted tasks after backend restart
 ```
 
-## 后端重启恢复
+## Recovery After Backend Restart
 
-Agent 每完成一步都会将状态写入 `data/checkpoints/` 目录（原子写入，防崩溃损坏）。
+Each completed step is written to `data/checkpoints/` (atomic writes, crash-safe).
 
-当后端进程重启时：
+When the backend restarts:
 
-- **`AGENT_RESUME=true`（默认）**：自动检测未完成的 checkpoint，恢复上次的 runId、步骤历史，从断点继续执行。前端刷新后也能通过 SSE 重连接上恢复中的任务。
-- **`AGENT_RESUME=false`**：启动时清除所有 checkpoint，不恢复任何中断的任务。
+- **`AGENT_RESUME=true` (default)**: Automatically detects unfinished checkpoints, restores the last runId and step history, and resumes from the breakpoint. The frontend can also reconnect via SSE after refresh to resume the task.
+- **`AGENT_RESUME=false`**: Clears all checkpoints on startup; does not resume any interrupted tasks.
 
-正常运行完成的任务会自动清理 checkpoint，无需手动维护。
+Successfully completed tasks automatically clean up their checkpoints — no manual maintenance needed.
 
-## 常用命令
+## Common Commands
 
 ```bash
-npm run build        # 构建前端
-
-npm run sandbox      # 沙盒模式启动（推荐）
-npm run dev          # 无沙盒启动
-
-npm run stop         # 停止前后端
+npm run build  # Build frontend
+npm run sandbox  # Start with sandbox (recommended)
+npm run dev   # Start without sandbox
+npm run stop  # Stop frontend and backend
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,0 +1,72 @@
+<div align="center">
+  <img src="client/public/favicon.svg" width="64" height="64" alt="sagent logo">
+  <h1>sagent</h1>
+  <p>多模型 AI 聊天 + 桌面 Agent，支持浏览器自动化、文件操作、终端命令、macOS 控制。</p>
+</div>
+
+> **仅支持 macOS**。Agent 需要操控本地浏览器和系统，目前只在 Mac 上测试通过。
+>
+> 前端适配移动端 — 手机、平板、电脑浏览器都能用，随时随地查看 Agent 进度、继续对话。
+
+## 快速开始
+
+```bash
+git clone https://github.com/longxiazy/sagent && cd sagent
+cp .env.example .env                    # 编辑填入 API Key
+npm install && cd client && npm install && cd ..
+npm run sandbox
+```
+
+打开 http://localhost:5173
+
+## 安全：沙盒策略
+
+通过 `npm run sandbox` 启动时，Agent 在 macOS 沙盒内运行，权限由 `sandbox.sb` 文件控制。
+
+你可以自定义 `sandbox.sb` 来调整 Agent 的权限边界。修改该文件可能导致 Agent 部分功能无权限执行（如无法访问网络、无法打开浏览器等）。
+
+危险操作（删文件、装包、执行终端命令）会弹窗确认，你不点同意 Agent 就没法继续。
+
+## 多设备查看
+
+局域网内其他设备（手机、iPad）打开 `http://<Mac的IP>:5173` 可以实时查看 Agent 的执行进度。
+
+- **Agent 运行中**：其他设备进入后只能看 agent 执行流程，聊天区为空，等待 agent 完成后显示最终结果
+- **聊天记录**：各设备独立，不共享历史会话
+- **同时只能跑一个 Agent**：新请求会收到 409 提示
+
+## 配置
+
+编辑 `.env`：
+
+```bash
+# API Key（至少填一个）
+NVIDIA_API_KEY=nvapi-...              # MiniMax、Kimi、Qwen、GLM、DeepSeek 等
+
+# Agent 行为（可选）
+AGENT_MAX_STEPS=32         # 单次任务最大步数，默认 32
+AGENT_RESUME=true          # 后端重启后自动恢复未完成的 Agent 任务
+
+```
+
+## 后端重启恢复
+
+Agent 每完成一步都会将状态写入 `data/checkpoints/` 目录（原子写入，防崩溃损坏）。
+
+当后端进程重启时：
+
+- **`AGENT_RESUME=true`（默认）**：自动检测未完成的 checkpoint，恢复上次的 runId、步骤历史，从断点继续执行。前端刷新后也能通过 SSE 重连接上恢复中的任务。
+- **`AGENT_RESUME=false`**：启动时清除所有 checkpoint，不恢复任何中断的任务。
+
+正常运行完成的任务会自动清理 checkpoint，无需手动维护。
+
+## 常用命令
+
+```bash
+npm run build        # 构建前端
+
+npm run sandbox      # 沙盒模式启动（推荐）
+npm run dev          # 无沙盒启动
+
+npm run stop         # 停止前后端
+```

--- a/agent/policy/approvals.js
+++ b/agent/policy/approvals.js
@@ -3,8 +3,13 @@ import { classifyAgentAction } from './classify.js';
 import { cleanText } from '../core/utils.js';
 
 function sendMacosNotification(title, body) {
+  if (process.platform !== 'darwin') return; // 仅 macOS 支持 osascript
   const script = `display notification "${body.replace(/"/g, '\\"')}" with title "${title.replace(/"/g, '\\"')}" sound name "Glass"`;
-  spawn('osascript', ['-e', script], { stdio: 'ignore' });
+  try {
+    spawn('osascript', ['-e', script], { stdio: 'ignore' });
+  } catch (err) {
+    // osascript 不可用时静默忽略（Linux/Windows 环境）
+  }
 }
 
 export function createAgentAuthorizer({


### PR DESCRIPTION
## Fix: osascript platform guard

**问题：** 在非 macOS 环境（如 Linux）运行 sagent 时， 命令不存在导致进程崩溃：


**修复：** 在  的  开头加平台判断， 时直接 return，不尝试调用 osascript。

**注意：** macos/ 目录下的其他 osascript 调用（observe.js / execute.js）是 macOS 专用工具的固有依赖，不影响非 macOS 用户（那些工具本来就不会在 Linux 上运行）。