### PR TITLE
fix: guard osascript with platform check to prevent crash on Linux

### DIFF
--- a/agent/policy/approvals.js
+++ b/agent/policy/approvals.js
@@ -3,8 +3,13 @@ import { classifyAgentAction } from './classify.js';
 import { cleanText } from '../core/utils.js';
 
 function sendMacosNotification(title, body) {
+  if (process.platform !== 'darwin') return; // 仅 macOS 支持 osascript
   const script = `display notification "${body.replace(/"/g, '\\"')}" with title "${title.replace(/"/g, '\\"')}" sound name "Glass"`;
-  spawn('osascript', ['-e', script], { stdio: 'ignore' });
+  try {
+    spawn('osascript', ['-e', script], { stdio: 'ignore' });
+  } catch (err) {
+    // osascript 不可用时静默忽略（Linux/Windows 环境）
+  }
 }
 
 export function createAgentAuthorizer({

--- a/agent/policy/approvals.js
+++ b/agent/policy/approvals.js
@@ -78,16 +78,6 @@ export function createAgentAuthorizer({
     });
 
     const isQuestion = action.type === 'ask_user';
-    const eventType = isQuestion ? 'question_required' : 'approval_required';
-
-    onEvent?.({
-      type: eventType,
-      runId,
-      approvalId,
-      step: context.step,
-      action,
-      message: isQuestion ? action.question : policy.reason,
-    });
 
     if (isQuestion) {
       const nativeAnswer = macosAsk('Desktop Agent 提问', cleanText(action.question, 200));
@@ -106,7 +96,6 @@ export function createAgentAuthorizer({
         }
         return { status: 'approved', response: nativeAnswer };
       }
-      sendMacosNotification('Desktop Agent 提问', cleanText(action.question, 120));
     } else {
       const nativeDecision = macosConfirm('Desktop Agent 需要审批', `${cleanText(policy.reason, 200)}\n\n${JSON.stringify(action)}`);
       if (nativeDecision) {
@@ -125,6 +114,22 @@ export function createAgentAuthorizer({
         }
         return { status: 'approved' };
       }
+    }
+
+    // Native dialog unavailable or timed out — fall back to web UI
+    const eventType = isQuestion ? 'question_required' : 'approval_required';
+    onEvent?.({
+      type: eventType,
+      runId,
+      approvalId,
+      step: context.step,
+      action,
+      message: isQuestion ? action.question : policy.reason,
+    });
+
+    if (isQuestion) {
+      sendMacosNotification('Desktop Agent 提问', cleanText(action.question, 120));
+    } else {
       sendMacosNotification('Desktop Agent 需要审批', `${cleanText(policy.reason, 120)}\n\nrunId: ${runId}`);
     }
 

--- a/agent/policy/approvals.js
+++ b/agent/policy/approvals.js
@@ -1,14 +1,18 @@
 import { spawn } from 'node:child_process';
 import { classifyAgentAction } from './classify.js';
 import { cleanText } from '../core/utils.js';
+import { log } from '../../helpers/logger.js';
 
 function sendMacosNotification(title, body) {
-  if (process.platform !== 'darwin') return; // 仅 macOS 支持 osascript
+  if (process.platform !== 'darwin') {
+    log.warn(`[Notification] macOS 通知不可用，当前平台: ${process.platform}`);
+    return;
+  }
   const script = `display notification "${body.replace(/"/g, '\\"')}" with title "${title.replace(/"/g, '\\"')}" sound name "Glass"`;
   try {
     spawn('osascript', ['-e', script], { stdio: 'ignore' });
   } catch (err) {
-    // osascript 不可用时静默忽略（Linux/Windows 环境）
+    log.warn(`[Notification] osascript 调用失败: ${err.message}`);
   }
 }
 

--- a/agent/policy/approvals.js
+++ b/agent/policy/approvals.js
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, execSync } from 'node:child_process';
 import { classifyAgentAction } from './classify.js';
 import { cleanText } from '../core/utils.js';
 import { log } from '../../helpers/logger.js';
@@ -13,6 +13,36 @@ function sendMacosNotification(title, body) {
     spawn('osascript', ['-e', script], { stdio: 'ignore' });
   } catch (err) {
     log.warn(`[Notification] osascript 调用失败: ${err.message}`);
+  }
+}
+
+function macosConfirm(title, message) {
+  if (process.platform !== 'darwin') return null;
+  const escapedTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const escapedMsg = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const script = `display dialog "${escapedMsg}" with title "${escapedTitle}" buttons {"拒绝", "批准"} default button "批准" with icon note`;
+  try {
+    const result = execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, { encoding: 'utf-8', timeout: 30000 });
+    return result.includes('批准') ? 'approve' : 'reject';
+  } catch (err) {
+    if (err.status === 1) return 'reject';
+    return null;
+  }
+}
+
+function macosAsk(title, message) {
+  if (process.platform !== 'darwin') return null;
+  const escapedTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const escapedMsg = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const script = `display dialog "${escapedMsg}" with title "${escapedTitle}" default answer "" buttons {"跳过", "回答"} default button "回答" with icon note`;
+  try {
+    const result = execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, { encoding: 'utf-8', timeout: 60000 });
+    if (result.includes('跳过')) return '';
+    const match = result.match(/text returned:(.*?)(?:, button returned:|$)/s);
+    return match ? match[1].trim() : '';
+  } catch (err) {
+    if (err.status === 1) return '';
+    return null;
   }
 }
 
@@ -60,15 +90,42 @@ export function createAgentAuthorizer({
     });
 
     if (isQuestion) {
-      sendMacosNotification(
-        'Desktop Agent 提问',
-        `${cleanText(action.question, 120)}`
-      );
+      const nativeAnswer = macosAsk('Desktop Agent 提问', cleanText(action.question, 200));
+      if (nativeAnswer !== null) {
+        onEvent?.({
+          type: 'user_response',
+          runId,
+          approvalId,
+          step: context.step,
+          question: action.question,
+          response: nativeAnswer,
+        });
+        approvalStore.resolve(approvalId, nativeAnswer);
+        if (!nativeAnswer) {
+          return { status: 'rejected', message: '用户跳过了问题', response: '' };
+        }
+        return { status: 'approved', response: nativeAnswer };
+      }
+      sendMacosNotification('Desktop Agent 提问', cleanText(action.question, 120));
     } else {
-      sendMacosNotification(
-        'Desktop Agent 需要审批',
-        `${cleanText(policy.reason, 120)}\n\nrunId: ${runId}`
-      );
+      const nativeDecision = macosConfirm('Desktop Agent 需要审批', `${cleanText(policy.reason, 200)}\n\n${JSON.stringify(action)}`);
+      if (nativeDecision) {
+        onEvent?.({
+          type: 'approval_result',
+          runId,
+          approvalId,
+          step: context.step,
+          decision: nativeDecision,
+          action,
+          message: nativeDecision === 'approve' ? '用户已批准操作' : '用户拒绝了操作',
+        });
+        approvalStore.resolve(approvalId, nativeDecision);
+        if (nativeDecision === 'reject') {
+          return { status: 'rejected', message: '用户拒绝批准该操作，Agent 将尝试其他方案。' };
+        }
+        return { status: 'approved' };
+      }
+      sendMacosNotification('Desktop Agent 需要审批', `${cleanText(policy.reason, 120)}\n\nrunId: ${runId}`);
     }
 
     const decision = await promise;

--- a/agent/policy/approvals.js
+++ b/agent/policy/approvals.js
@@ -1,4 +1,4 @@
-import { spawn, execSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { classifyAgentAction } from './classify.js';
 import { cleanText } from '../core/utils.js';
 import { log } from '../../helpers/logger.js';
@@ -13,36 +13,6 @@ function sendMacosNotification(title, body) {
     spawn('osascript', ['-e', script], { stdio: 'ignore' });
   } catch (err) {
     log.warn(`[Notification] osascript 调用失败: ${err.message}`);
-  }
-}
-
-function macosConfirm(title, message) {
-  if (process.platform !== 'darwin') return null;
-  const escapedTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  const escapedMsg = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  const script = `display dialog "${escapedMsg}" with title "${escapedTitle}" buttons {"拒绝", "批准"} default button "批准" with icon note`;
-  try {
-    const result = execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, { encoding: 'utf-8', timeout: 30000 });
-    return result.includes('批准') ? 'approve' : 'reject';
-  } catch (err) {
-    if (err.status === 1) return 'reject';
-    return null;
-  }
-}
-
-function macosAsk(title, message) {
-  if (process.platform !== 'darwin') return null;
-  const escapedTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  const escapedMsg = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  const script = `display dialog "${escapedMsg}" with title "${escapedTitle}" default answer "" buttons {"跳过", "回答"} default button "回答" with icon note`;
-  try {
-    const result = execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, { encoding: 'utf-8', timeout: 60000 });
-    if (result.includes('跳过')) return '';
-    const match = result.match(/text returned:(.*?)(?:, button returned:|$)/s);
-    return match ? match[1].trim() : '';
-  } catch (err) {
-    if (err.status === 1) return '';
-    return null;
   }
 }
 
@@ -90,42 +60,15 @@ export function createAgentAuthorizer({
     });
 
     if (isQuestion) {
-      const nativeAnswer = macosAsk('Desktop Agent 提问', cleanText(action.question, 200));
-      if (nativeAnswer !== null) {
-        onEvent?.({
-          type: 'user_response',
-          runId,
-          approvalId,
-          step: context.step,
-          question: action.question,
-          response: nativeAnswer,
-        });
-        approvalStore.resolve(approvalId, nativeAnswer);
-        if (!nativeAnswer) {
-          return { status: 'rejected', message: '用户跳过了问题', response: '' };
-        }
-        return { status: 'approved', response: nativeAnswer };
-      }
-      sendMacosNotification('Desktop Agent 提问', cleanText(action.question, 120));
+      sendMacosNotification(
+        'Desktop Agent 提问',
+        `${cleanText(action.question, 120)}`
+      );
     } else {
-      const nativeDecision = macosConfirm('Desktop Agent 需要审批', `${cleanText(policy.reason, 200)}\n\n${JSON.stringify(action)}`);
-      if (nativeDecision) {
-        onEvent?.({
-          type: 'approval_result',
-          runId,
-          approvalId,
-          step: context.step,
-          decision: nativeDecision,
-          action,
-          message: nativeDecision === 'approve' ? '用户已批准操作' : '用户拒绝了操作',
-        });
-        approvalStore.resolve(approvalId, nativeDecision);
-        if (nativeDecision === 'reject') {
-          return { status: 'rejected', message: '用户拒绝批准该操作，Agent 将尝试其他方案。' };
-        }
-        return { status: 'approved' };
-      }
-      sendMacosNotification('Desktop Agent 需要审批', `${cleanText(policy.reason, 120)}\n\nrunId: ${runId}`);
+      sendMacosNotification(
+        'Desktop Agent 需要审批',
+        `${cleanText(policy.reason, 120)}\n\nrunId: ${runId}`
+      );
     }
 
     const decision = await promise;

--- a/agent/policy/approvals.js
+++ b/agent/policy/approvals.js
@@ -78,6 +78,16 @@ export function createAgentAuthorizer({
     });
 
     const isQuestion = action.type === 'ask_user';
+    const eventType = isQuestion ? 'question_required' : 'approval_required';
+
+    onEvent?.({
+      type: eventType,
+      runId,
+      approvalId,
+      step: context.step,
+      action,
+      message: isQuestion ? action.question : policy.reason,
+    });
 
     if (isQuestion) {
       const nativeAnswer = macosAsk('Desktop Agent 提问', cleanText(action.question, 200));
@@ -96,6 +106,7 @@ export function createAgentAuthorizer({
         }
         return { status: 'approved', response: nativeAnswer };
       }
+      sendMacosNotification('Desktop Agent 提问', cleanText(action.question, 120));
     } else {
       const nativeDecision = macosConfirm('Desktop Agent 需要审批', `${cleanText(policy.reason, 200)}\n\n${JSON.stringify(action)}`);
       if (nativeDecision) {
@@ -114,22 +125,6 @@ export function createAgentAuthorizer({
         }
         return { status: 'approved' };
       }
-    }
-
-    // Native dialog unavailable or timed out — fall back to web UI
-    const eventType = isQuestion ? 'question_required' : 'approval_required';
-    onEvent?.({
-      type: eventType,
-      runId,
-      approvalId,
-      step: context.step,
-      action,
-      message: isQuestion ? action.question : policy.reason,
-    });
-
-    if (isQuestion) {
-      sendMacosNotification('Desktop Agent 提问', cleanText(action.question, 120));
-    } else {
       sendMacosNotification('Desktop Agent 需要审批', `${cleanText(policy.reason, 120)}\n\nrunId: ${runId}`);
     }
 


### PR DESCRIPTION
## Fix: osascript platform guard

**问题：** 在非 macOS 环境（如 Linux）运行 sagent 时，`osascript` 命令不存在导致进程崩溃：



**修复：** 在 `approvals.js` 的 `sendMacosNotification()` 开头加平台判断，`process.platform !== 'darwin'` 时直接 return，不尝试调用 osascript。

**注意：** macos/ 目录下的其他 osascript 调用（observe.js / execute.js）是 macOS 专用工具的固有依赖，不影响非 macOS 用户。