### PR TITLE
feat: improve browser visual capture for Claude Opus 4.7 visual reasoning level

### DIFF
--- a/agent/tools/browser/observe.js
+++ b/agent/tools/browser/observe.js
@@ -49,7 +49,7 @@ export async function captureBrowserObservation(page) {
       )
     )
       .filter(isVisible)
-      .slice(0, 30)
+      .slice(0, 50)
       .map((element, index) => {
         const elementId = String(index + 1);
         element.setAttribute('data-agent-node-id', elementId);
@@ -63,7 +63,7 @@ export async function captureBrowserObservation(page) {
         };
       });
 
-    const bodyText = (document.body?.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 5000);
+    const bodyText = (document.body?.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 15000);
 
     return {
       title: document.title,

--- a/agent/tools/browser/session.js
+++ b/agent/tools/browser/session.js
@@ -23,6 +23,7 @@ export async function createBrowserSession({
 
   const context = await browser.newContext({
     viewport: { width: 1440, height: 960 },
+  deviceScaleFactor: 3, // 3x for Claude Opus 4.7 visual reasoning level
   });
 
   // Block heavy resources for speed


### PR DESCRIPTION
## feat: 提升浏览器视觉捕获能力

**背景:**
Claude Opus 4.7 (2026-04-16) 在视觉推理上有重大突破（CharXiv: 82.1%→91.0%，3x 分辨率支持），sagent 需要跟上这个能力。

**改动:**
1. :  — 3x 分辨率截图，让 Claude 能看清更细微的 UI 元素
2. :  捕获从 5000 → 15000 字符，保留更多上下文
3. :  捕获从 30 → 50 个，Agent 有更多可交互元素可选

**对齐 Claude Opus 4.7 能力:**
- 视觉理解提升 ≈ 对标 3x 分辨率带来的 UI 识别改进
- 视觉基准从 82.1% → 91.0% 的关键之一就是更高分辨率输入