### PR TITLE
feat: add MCP client tool support (big-model-radar integration)

### DIFF
--- a/agent/core/schemas.js
+++ b/agent/core/schemas.js
@@ -246,6 +246,19 @@ function normalizeCoreAction(type, action) {
   throw new Error(`不支持的核心动作: ${type}`);
 }
 
+function normalizeMcpAction(type, action) {
+  if (type !== 'call_tool') {
+    throw new Error(`不支持的 MCP 动作: ${type}`);
+  }
+  return {
+    tool: 'mcp',
+    type: 'call_tool',
+    server: typeof action.server === 'string' && action.server.trim() ? action.server.trim() : '',
+    mcpTool: action.tool || '',
+    args: typeof action.args === 'object' && action.args !== null ? action.args : {},
+  };
+}
+
 function normalizeFetchAction(type, action) {
   // Fix models that put extractLinks into the URL: "url":"...&extractLinks":true}
   if (typeof action.url === 'string' && /[&?]extractLinks[=:]/i.test(action.url)) {
@@ -321,6 +334,8 @@ export function normalizeDesktopAgentDecision(payload) {
     normalizedAction = normalizeCoreAction(type, action);
   } else if (tool === 'fetch') {
     normalizedAction = normalizeFetchAction(type, action);
+  } else if (tool === 'mcp') {
+    normalizedAction = normalizeMcpAction(type, action);
   } else {
     throw new Error(`不支持的工具: ${tool}`);
   }

--- a/agent/core/tool-definitions.js
+++ b/agent/core/tool-definitions.js
@@ -290,7 +290,20 @@ export function createModelTools() {
         required: ['answer'],
       },
     },
-  ];
+   {
+    name: 'mcp',
+    description: '调用外部 MCP (Model Context Protocol) 服务器。97M+ 月下载量，10k+ 服务器。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        server: { type: 'string', description: 'MCP 服务器名称，如 big-model-radar' },
+        tool: { type: 'string', description: '要调用的工具名，如 get_latest、list_reports、search' },
+        args: { type: 'object', description: '工具参数，如 { type: "ai-agents" }' },
+      },
+      required: ['server', 'tool'],
+    },
+  },
+ ];
 }
 
 export function toolToClaudeTool(tool) {

--- a/agent/desktop/agent.js
+++ b/agent/desktop/agent.js
@@ -11,6 +11,7 @@ import { executeFsAction } from '../tools/fs/execute.js';
 import { executeFetchAction } from '../tools/fetch/execute.js';
 import { createDomainRules } from '../tools/fetch/domain-rules.js';
 import { executeMacOSAction } from '../tools/macos/execute.js';
+import { executeMcpAction } from '../tools/mcp/execute.js';
 import { observeMacOSDesktop } from '../tools/macos/observe.js';
 import { executeTerminalAction } from '../tools/terminal/run.js';
 import { isClaudeModel, buildDesktopAgentSystemPrompt, claudeAgentPlan } from '../core/ai-client.js';
@@ -496,7 +497,8 @@ export function createDesktopAgentRunner({
         executeMacOSAction(action, {
           runId: state.runId,
         }),
-    },
+    mcp: async (_state, action) => executeMcpAction(action),
+  },
     { defaultTool: 'core' }
   );
 

--- a/agent/tools/mcp/execute.js
+++ b/agent/tools/mcp/execute.js
@@ -1,0 +1,50 @@
+/**
+ * MCP Client Tool — 调用外部 MCP 服务器的工具
+ *
+ * MCP (Model Context Protocol) 已达到 10,000+ 服务器、97M 月下载量。
+ * 支持 sagent 调用 Big Model Radar 等 MCP 服务获取 AI 生态情报。
+ *
+ * 使用场景:
+ * { tool: 'mcp', type: 'call_tool', server: 'big-model-radar', tool: 'get_latest', args: { type: 'ai-agents' } }
+ */
+
+const MCP_CLIENT_CONFIG = {
+  'big-model-radar': {
+    url: process.env.MCP_BIG_MODEL_RADAR_URL || 'https://big-model-radar-mcp.example.workers.dev',
+    tools: ['list_reports', 'get_latest', 'get_report', 'search'],
+  },
+};
+
+async function callMcpServer(serverName, toolName, args = {}) {
+  const config = MCP_CLIENT_CONFIG[serverName];
+  if (!config) {
+    throw new Error(`未知的 MCP 服务器: ${serverName}，可用: ${Object.keys(MCP_CLIENT_CONFIG).join(', ')}`);
+  }
+
+  if (!config.tools.includes(toolName)) {
+    throw new Error(`MCP 服务器 ${serverName} 不支持工具 ${toolName}，可用: ${config.tools.join(', ')}`);
+  }
+
+  const response = await fetch(`${config.url}/tools/${toolName}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(args),
+  });
+
+  if (!response.ok) {
+    throw new Error(`MCP 调用失败: ${response.status} ${response.statusText}`);
+  }
+
+  const result = await response.json();
+  return typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+}
+
+export async function executeMcpAction(action) {
+  const { server, tool: toolName, args = {} } = action;
+
+  if (!server) throw new Error('mcp 工具缺少 server');
+  if (!toolName) throw new Error('mcp 工具缺少 tool');
+
+  const result = await callMcpServer(server, toolName, args);
+  return `MCP ${server}.${toolName} 结果:\n${String(result).slice(0, 8000)}`;
+}


### PR DESCRIPTION
## feat: 添加 MCP 客户端工具支持

**背景:**
MCP (Model Context Protocol) 生态快速增长：
- 10,000+ MCP 服务器
- 97M 月下载量
- Anthropic 官方支持

sagent 作为 AI Agent 框架，应该能够调用外部 MCP 服务获取能力扩展。

**新增文件:**
- `agent/tools/mcp/execute.js` — MCP 客户端实现

**改动:**
1. `tool-definitions.js` — 新增 `mcp` 工具定义（server/tool/args 参数）
2. `schemas.js` — 新增 `normalizeMcpAction()` 规范化函数
3. `agent.js` — 路由层新增 `mcp` handler
4. `execute.js` — MCP HTTP 调用实现，预配置 big-model-radar 服务器

**使用示例:**
```json
{"tool": "mcp", "type": "call_tool", "server": "big-model-radar", "tool": "get_latest", "args": {"type": "ai-agents"}}
```

**配置:**
设置环境变量 `MCP_BIG_MODEL_RADAR_URL` 指向你的 MCP 服务器地址。