### PR TITLE
feat: add remember_fact tool for persistent conversation memory (OpenAI Codex inspired)

### DIFF
--- a/agent/core/schemas.js
+++ b/agent/core/schemas.js
@@ -220,6 +220,18 @@ function normalizeMacOsAction(type, action) {
   throw new Error(`不支持的 macOS 动作: ${type}`);
 }
 
+function normalizeRememberFactAction(type, action) {
+  if (type !== 'remember_fact') {
+    throw new Error(`不支持的 remember_fact 动作: ${type}`);
+  }
+  return {
+    tool: 'core',
+    type: 'remember_fact',
+    fact: typeof action.fact === 'string' && action.fact.trim() ? action.fact.trim() : '',
+    category: ['preference', 'structure', 'path', 'learning'].includes(action.category) ? action.category : 'learning',
+  };
+}
+
 function normalizeCoreAction(type, action) {
   if (type === 'finish') {
     return {
@@ -241,6 +253,14 @@ function normalizeCoreAction(type, action) {
       type,
       message: typeof action.message === 'string' ? action.message.trim() : '',
       level: ['info', 'warning', 'discovery'].includes(action.level) ? action.level : 'info',
+    };
+  }
+  if (type === 'remember_fact') {
+    return {
+      tool: 'core',
+      type,
+      fact: typeof action.fact === 'string' && action.fact.trim() ? action.fact.trim() : '',
+      category: ['preference', 'structure', 'path', 'learning'].includes(action.category) ? action.category : 'learning',
     };
   }
   throw new Error(`不支持的核心动作: ${type}`);

--- a/agent/core/tool-definitions.js
+++ b/agent/core/tool-definitions.js
@@ -280,6 +280,18 @@ export function createModelTools() {
       },
     },
     {
+ {
+ name: 'remember_fact',
+ description: '将重要信息持久化到 Agent 记忆（跨任务保持）。保存用户偏好、项目结构、关键路径、经验总结。',
+ input_schema: {
+ type: 'object',
+ properties: {
+ fact: { type: 'string', description: '要记住的信息' },
+ category: { type: 'string', description: '分类: preference/structure/path/learning' },
+ },
+ required: ['fact', 'category'],
+ },
+ },
       name: 'finish',
       description: '完成任务并返回最终结果',
       input_schema: {

--- a/agent/desktop/agent.js
+++ b/agent/desktop/agent.js
@@ -477,6 +477,14 @@ export function createDesktopAgentRunner({
         if (action.type === 'ask_user') {
           return context?.authorization?.response || '用户未回答';
         }
+ if (action.type === 'remember_fact') {
+   state.onEvent?.({
+     type: 'memory_update',
+     category: action.category,
+     fact: action.fact,
+   });
+   return `已记住 [${action.category}]: ${action.fact.slice(0, 50)}${action.fact.length > 50 ? '...' : ''}`;
+ }
         return action.answer || '任务已完成';
       },
       browser: async (state, action) => {


### PR DESCRIPTION
## feat: 添加 remember_fact 工具实现持久化记忆

**灵感来源:**
OpenAI Codex 最新更新中加入了记忆系统，Agent 能够跨任务记住用户偏好和项目信息。

**新增功能:**
-  工具：让 Agent 将重要信息持久化到记忆
- 支持 4 种分类：preference（用户偏好）/ structure（项目结构）/ path（路径）/ learning（经验总结）
- 记忆会通过  事件传递给前端，存储到 
- 后续任务中，Agent 会自动通过  注入历史记忆

**改动文件:**
-  — 新增 remember_fact 工具定义
-  — 新增 remember_fact 动作规范化
-  — core handler 处理 remember_fact，发出 memory_update 事件

**使用示例:**
```json
{"tool": "core", "type": "remember_fact", "fact": "这个项目用 pnpm 管理依赖", "category": "preference"}
```