### PR TITLE
Fix agent placeholder stuck on backend crash or SSE disconnect

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2240,16 +2240,33 @@ export default function App() {
         });
       }
     } finally {
-      // SSE 可能断连导致 done 事件丢失，检查占位消息是否未被替换
+      // SSE 可能断连导致 done/error 事件丢失，检查占位消息是否未被替换
       setAgentTrace(prev => {
         const doneEvent = prev.find(e => e.type === 'done');
-        if (doneEvent) {
+        const errorEvent = prev.find(e => e.type === 'error');
+        if (doneEvent || errorEvent) {
           updateSession(sessionId, session => {
             const msgs = session.messages;
             const lastIdx = msgs.length - 1;
             if (lastIdx >= 0 && msgs[lastIdx].role === 'assistant' && msgs[lastIdx].content.includes('正在执行任务')) {
               const next = [...msgs];
-              next[lastIdx] = { role: 'assistant', content: doneEvent.answer || 'Agent 已完成任务。' };
+              if (doneEvent) {
+                next[lastIdx] = { role: 'assistant', content: doneEvent.answer || 'Agent 已完成任务。' };
+              } else {
+                next[lastIdx] = { role: 'assistant', content: `⚠️ Desktop Agent 失败：${errorEvent.error || '连接中断'}` };
+              }
+              return touchSession(session, { messages: next, agentTrace: prev });
+            }
+            return touchSession(session, { agentTrace: prev });
+          });
+        } else if (prev.length === 0 || !prev.some(e => e.type === 'done' || e.type === 'error')) {
+          // No events received at all or SSE disconnected without done/error
+          updateSession(sessionId, session => {
+            const msgs = session.messages;
+            const lastIdx = msgs.length - 1;
+            if (lastIdx >= 0 && msgs[lastIdx].role === 'assistant' && msgs[lastIdx].content.includes('正在执行任务')) {
+              const next = [...msgs];
+              next[lastIdx] = { role: 'assistant', content: '⚠️ Desktop Agent 连接中断，未收到执行结果。' };
               return touchSession(session, { messages: next, agentTrace: prev });
             }
             return touchSession(session, { agentTrace: prev });


### PR DESCRIPTION
## Summary

- 修复后端崩溃或 SSE 连接中断时，前端聊天区一直卡在"Desktop Agent 正在执行任务，请稍候…"不更新的问题
- `finally` 块新增三种兜底：收到 `error` 事件时替换为错误提示；无 `done`/`error` 事件时显示"连接中断"；收到 `done` 的逻辑不变

## 根因

之前 `finally` 只检查了 `done` 事件来替换占位消息，后端崩溃或 SSE 断连导致既没收到 `done` 也没收到 `error` 时，占位消息永远不会被替换。