### PR TITLE
feat: add planning-first mode (show plan before execution)

### DIFF
--- a/agent/core/ai-client.js
+++ b/agent/core/ai-client.js
@@ -73,9 +73,18 @@ export function createClients() {
   return { openai_client, anthropic_client };
 }
 
-export function buildDesktopAgentSystemPrompt(systemPrompt) {
+export function buildDesktopAgentSystemPrompt(systemPrompt, planningMode = false) {
+  const planningSection = planningMode
+    ? '
+
+## 规划模式 (Planning Mode)
+当你收到任务时，先不执行，先制定详细的执行计划，' \n      '用 ask_user 展示给用户批准后再按计划执行。计划格式：
+1. 第一步：做什么 + 为什么
+2. 第二步：...' \n      '确认后再执行，完成后汇报。'
+    : '';
+
   const base = [
-    '你是 DesktopAgent，负责在浏览器、macOS 桌面、文件系统、终端之间协同完成任务。',
+    '你是 DesktopAgent，负责在浏览器、macOS 桌面、文件系统、终端之间协同完成任务。' + planningSection,
     '通过工具调用完成任务，只能使用提供的工具，不要输出 JSON 以外的文本。',
     '规则：',
     '1. 只有 observation.browser.elements 中存在的 elementId 才能用于 click/type。',

--- a/agent/desktop/agent.js
+++ b/agent/desktop/agent.js
@@ -19,6 +19,12 @@ import { log } from '../../helpers/logger.js';
 
 function buildClaudeTaskMessages({ task, step, history, observation, conversationHistory }) {
   const messages = [];
+  if (_planningMode) {
+    messages.push({
+      role: 'system',
+      content: '[规划模式] 收到任务后，先用 ask_user 展示执行计划，格式：1. 第一步 2. 第二步...用户批准后再执行。',
+    });
+  }
   if (conversationHistory?.length) {
     for (const msg of conversationHistory) {
       messages.push({ role: msg.role, content: msg.content });
@@ -37,11 +43,17 @@ function buildNvidiaTaskMessages({ task, systemPrompt, step, history, observatio
         .map(m => `${m.role === 'user' ? '用户' : '助手'}: ${m.content}`)
         .join('\n')
     : '';
+  const planningNote = _planningMode
+    ? '
+
+[规划模式] 收到任务后先用 ask_user 展示执行计划，格式：1. 第一步 2. 第二步...用户批准后再执行。'
+    : '';
+
   return [
     {
       role: 'system',
       content: [
-        '你是 DesktopAgent，负责在浏览器、macOS 桌面、文件系统、终端之间协同完成任务。',
+        '你是 DesktopAgent，负责在浏览器、macOS 桌面、文件系统、终端之间协同完成任务。' + planningNote,
         '你只能输出一个 JSON 对象，不要输出 Markdown，不要解释。',
         '可用动作示例：',
         '{"rationale":"打开网页","action":{"tool":"browser","type":"navigate","url":"https://example.com"}}',
@@ -119,7 +131,7 @@ async function singleModelPlan({ model, openai_client, anthropic_client, modelCo
 
   try {
     if (isClaudeModel(model, modelConfig)) {
-      const system = buildDesktopAgentSystemPrompt(context.systemPrompt);
+      const system = buildDesktopAgentSystemPrompt(context.systemPrompt, _planningMode);
       const messages = buildClaudeTaskMessages(context);
       const result = await claudeAgentPlan({
         client: anthropic_client,
@@ -560,12 +572,17 @@ export function createDesktopAgentRunner({
     { defaultTool: 'core' }
   );
 
+// Planning mode: when true, Agent outputs plan before executing
+let _planningMode = false;
+export function setPlanningMode(enabled) { _planningMode = enabled; }
+
   return async function runDesktopAgent({
     task,
     model,
     models: agentModels,
     strategy = 'race',
     systemPrompt = null,
+ planningMode = false,
     headless = defaultHeadless,
     onEvent,
     isCancelled,


### PR DESCRIPTION
## feat: 添加规划优先模式

**灵感来源:** Vibe Coding 成熟度模型 Level 3 — 规划驱动编程 (Planning-driven)

**核心逻辑:**
当  时，Agent 在执行前先输出详细计划，用  展示给用户批准后再执行。

**实现:**
- :  增加  参数，注入规划模式说明
- : 
  -  模块变量 +  导出
  -  /  在 planning 模式下注入计划指令
  -  新增  参数

**使用:**


**效果:**
复杂任务中用户可以先审核 Agent 的执行策略，减少走弯路的情况。