### PR TITLE
feat: add git workflow awareness tool (Copilot CLI inspired)

### DIFF
--- a/agent/core/schemas.js
+++ b/agent/core/schemas.js
@@ -322,6 +322,8 @@ export function normalizeDesktopAgentDecision(payload) {
   } else if (tool === 'fetch') {
     normalizedAction = normalizeFetchAction(type, action);
   } else {
+ } else if (tool === 'git') {
+ return { tool: 'git', type: action.type || 'status', path: action.path || '.', extra: action.extra || '' };
     throw new Error(`不支持的工具: ${tool}`);
   }
 

--- a/agent/core/tool-definitions.js
+++ b/agent/core/tool-definitions.js
@@ -290,6 +290,19 @@ export function createModelTools() {
         required: ['answer'],
       },
     },
+  {
+    name: 'git',
+    description: '查询 Git 工作区状态、分支、日志、变更等。帮助 Agent 了解当前代码状态，避免在未提交的分支上做危险操作。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: ['status', 'branch', 'log', 'diff', 'stash', 'remote'], description: 'Git 命令类型' },
+        path: { type: 'string', description: '仓库路径，默认 .' },
+        extra: { type: 'string', description: '额外参数，如 log 的数量' },
+      },
+      required: ['type'],
+    },
+  },
   ];
 }
 

--- a/agent/desktop/agent.js
+++ b/agent/desktop/agent.js
@@ -13,6 +13,7 @@ import { createDomainRules } from '../tools/fetch/domain-rules.js';
 import { executeMacOSAction } from '../tools/macos/execute.js';
 import { observeMacOSDesktop } from '../tools/macos/observe.js';
 import { executeTerminalAction } from '../tools/terminal/run.js';
+import { executeGitAction } from '../tools/git/execute.js';
 import { isClaudeModel, buildDesktopAgentSystemPrompt, claudeAgentPlan } from '../core/ai-client.js';
 import { saveCheckpoint } from '../core/checkpoint.js';
 import { log } from '../../helpers/logger.js';
@@ -552,6 +553,7 @@ export function createDesktopAgentRunner({
         return executeFetchAction(action, session.page, domainRules);
       },
       terminal: async (_state, action) => executeTerminalAction(action),
+ git: async (_state, action) => executeGitAction(action),
       macos: async (state, action) =>
         executeMacOSAction(action, {
           runId: state.runId,

--- a/agent/tools/git/execute.js
+++ b/agent/tools/git/execute.js
@@ -1,0 +1,74 @@
+/**
+ * Git Workflow Tool — Git 工作流感知
+ *
+ * 灵感来源: GitHub Copilot CLI 深度绑定 Git 生态（会话命名恢复、Git 工作流集成）
+ * Agent 需要知道当前 Git 状态、分支、变更，才能做出合理的修改决策
+ *
+ * 使用场景:
+ * { tool: 'git', type: 'status' | 'branch' | 'log' | 'diff' | 'stash' }
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { log } from '../../helpers/logger.js';
+
+const execAsync = promisify(exec);
+
+async function execGit(cmd, cwd = '.') {
+  try {
+    const { stdout, stderr } = await execAsync(cmd, { cwd, timeout: 10000 });
+    return { ok: true, stdout: stdout.trim(), stderr: stderr.trim() };
+  } catch (err) {
+    return { ok: false, stdout: err.stdout?.trim() || '', stderr: err.stderr?.trim() || '', code: err.code };
+  }
+}
+
+export async function executeGitAction(action) {
+  const { type, path = '.', extra = '' } = action;
+
+  if (type === 'status') {
+    const r = await execGit('git status --short', path);
+    if (!r.ok && r.code !== 0) return `Git status 失败: ${r.stderr || r.stdout}`;
+    if (!r.stdout) return '工作区干净，无变更';
+    return `[Git Status]\n${r.stdout}`;
+  }
+
+  if (type === 'branch') {
+    const r = await execGit('git branch -v', path);
+    if (!r.ok) return `Git branch 失败: ${r.stderr}`;
+    const current = await execGit('git branch --show-current', path);
+    const currentBranch = current.stdout.trim();
+    const lines = r.stdout.split('\n').map(l => {
+      if (l.trim().startsWith('*')) return l;
+      return '  ' + l;
+    }).join('\n');
+    return `[Git Branch: ${currentBranch}]\n${lines}`;
+  }
+
+  if (type === 'log') {
+    const n = parseInt(extra) || 10;
+    const r = await execGit(`git log --oneline -${n}`, path);
+    if (!r.ok) return `Git log 失败: ${r.stderr}`;
+    return `[Git Log (last ${n})]\n${r.stdout || '(no commits)'}`;
+  }
+
+  if (type === 'diff') {
+    const r = await execGit('git diff --stat', path);
+    if (!r.ok) return `Git diff 失败: ${r.stderr}`;
+    return `[Git Diff]\n${r.stdout || '无变更'}`;
+  }
+
+  if (type === 'stash') {
+    const r = await execGit('git stash list', path);
+    if (!r.ok) return `Git stash 失败: ${r.stderr}`;
+    return `[Git Stash]\n${r.stdout || '(empty)'}`;
+  }
+
+  if (type === 'remote') {
+    const r = await execGit('git remote -v', path);
+    if (!r.ok) return `Git remote 失败: ${r.stderr}`;
+    return `[Git Remote]\n${r.stdout || '(no remote)'}`;
+  }
+
+  throw new Error(`不支持的 git 类型: ${type}`);
+}


### PR DESCRIPTION
## feat: 添加 Git 工作流感知工具

**灵感来源:** GitHub Copilot CLI 深度绑定 Git 生态 — 会话命名恢复、Git 工作流集成

**新增功能:**
- usage: git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           [--super-prefix=<path>] [--config-env=<name>=<envvar>]
           <command> [<args>]

These are common Git commands used in various situations:

start a working area (see also: git help tutorial)
   clone     Clone a repository into a new directory
   init      Create an empty Git repository or reinitialize an existing one

work on the current change (see also: git help everyday)
   add       Add file contents to the index
   mv        Move or rename a file, a directory, or a symlink
   restore   Restore working tree files
   rm        Remove files from the working tree and from the index

examine the history and state (see also: git help revisions)
   bisect    Use binary search to find the commit that introduced a bug
   diff      Show changes between commits, commit and working tree, etc
   grep      Print lines matching a pattern
   log       Show commit logs
   show      Show various types of objects
   status    Show the working tree status

grow, mark and tweak your common history
   branch    List, create, or delete branches
   commit    Record changes to the repository
   merge     Join two or more development histories together
   rebase    Reapply commits on top of another base tip
   reset     Reset current HEAD to the specified state
   switch    Switch branches
   tag       Create, list, delete or verify a tag object signed with GPG

collaborate (see also: git help workflows)
   fetch     Download objects and refs from another repository
   pull      Fetch from and integrate with another repository or a local branch
   push      Update remote refs along with associated objects

'git help -a' and 'git help -g' list available subcommands and some
concept guides. See 'git help <command>' or 'git help <concept>'
to read about a specific subcommand or concept.
See 'git help git' for an overview of the system. 工具：查询 Git 状态、分支、日志、变更、stash、remote
- Agent 在执行危险操作前自动了解当前 Git 状态
- 避免在不干净的分支或 detached HEAD 上做破坏性修改

**使用示例:**
```json
{"tool": "git", "type": "status"}
{"tool": "git", "type": "branch"}
{"tool": "git", "type": "log", "extra": "5"}
```

**实现:**
-  — Git 命令封装
-  — git 工具定义
-  — git 动作规范化
-  — 路由层 git handler