### PR TITLE
feat: add PermissionProfile-based authorization system (OpenAI Codex inspired)

### DIFF
--- a/agent/policy/profiles.js
+++ b/agent/policy/profiles.js
@@ -1,0 +1,56 @@
+/**
+ * Permission Profiles — 基于 Profile 的权限分级系统
+ *
+ * 灵感来源: OpenAI Codex PermissionProfile 权限模型
+ * - trusted: 完全信任，仅 confirm 文件写入和终端确认
+ * - development: 开发模式，允许大部分操作
+ * - restricted: 受限模式，所有写操作需确认
+ * - sandboxed: 沙箱模式，仅读操作 + 白名单命令
+ */
+
+export const PERMISSION_PROFILES = {
+  trusted: {
+    label: '完全信任',
+    description: '仅在写入文件或执行终端命令时请求确认',
+    fs: ['read_file', 'list_dir', 'search_files', 'write_file'],
+    terminal: ['run_safe', 'run_confirmed', 'run_review'],
+    terminal_whitelist: [], // 无限制
+    browser: ['all'],
+    macos: ['all'],
+    spawn: true,
+  },
+  development: {
+    label: '开发模式',
+    description: '允许大部分操作，危险命令需确认',
+    fs: ['read_file', 'list_dir', 'search_files', 'write_file'],
+    terminal: ['run_safe', 'run_confirmed', 'run_review'],
+    terminal_whitelist: ['node', 'python', 'git', 'npm', 'pnpm', 'cargo', 'make'],
+    browser: ['all'],
+    macos: ['all'],
+    spawn: true,
+  },
+  restricted: {
+    label: '受限模式',
+    description: '所有写操作均需确认，终端仅读命令',
+    fs: ['read_file', 'list_dir', 'search_files'],
+    terminal: ['run_safe'],
+    terminal_whitelist: ['ls', 'pwd', 'cat', 'head', 'tail', 'grep', 'find', 'git'],
+    browser: ['all'],
+    macos: ['all'],
+    spawn: false,
+  },
+  sandboxed: {
+    label: '沙箱模式',
+    description: '仅读操作，白名单命令，无 spawn',
+    fs: ['read_file', 'list_dir'],
+    terminal: ['run_safe'],
+    terminal_whitelist: ['ls', 'pwd', 'cat', 'head', 'tail', 'grep', 'find'],
+    browser: ['navigate', 'get_page_content', 'screenshot'],
+    macos: ['list_windows', 'capture_screen'],
+    spawn: false,
+  },
+};
+
+export function getProfile(name) {
+  return PERMISSION_PROFILES[name] || PERMISSION_PROFILES.trusted;
+}


### PR DESCRIPTION
## feat: 添加基于 Profile 的权限分级系统

**灵感来源:** OpenAI Codex  权限模型（社区获 604 👍）

**新增功能:**
- 4 种权限级别：trusted / development / restricted / sandboxed
-  — 定义各级别的工具、命令白名单
-  模式：只读 fs、白名单终端命令、无 spawn
-  模式：允许 npm/cargo/node 等开发命令

**使用场景:**
- 企业部署时选择受限的 sandboxed 模式
- 开发时用 development 模式减少审批打扰
- 完全信任的环境用 trusted 模式

**后续:** classify.js 和 approvals.js 可以集成 getProfile() 根据 profile 调整策略