### PR TITLE
fix: question dialog - skip allows empty, Enter submits

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -958,7 +958,8 @@ function QuestionDialog({ question, submitting, onSubmit, onSkip }) {
           onChange={e => setResponse(e.target.value)}
           placeholder="输入你的回答..."
           rows={3}
-          autoFocus
+ onKeyDown={e => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); onSubmit(response); } }}
+ autoFocus
         />
         <div className="dialog-actions">
           <button className="dialog-btn cancel" onClick={onSkip} disabled={submitting}>
@@ -967,7 +968,7 @@ function QuestionDialog({ question, submitting, onSubmit, onSkip }) {
           <button
             className="dialog-btn confirm approval-confirm"
             onClick={() => onSubmit(response)}
-            disabled={submitting || !response.trim()}
+            disabled={submitting}
           >
             {submitting ? '提交中…' : '回答'}
           </button>

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -218,12 +218,12 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
       return res.status(400).json({ error: 'approvalId 不能为空' });
     }
 
-    if (typeof response !== 'string' || !response.trim()) {
-      return res.status(400).json({ error: 'response 不能为空' });
+    if (typeof response !== 'string') {
+      return res.status(400).json({ error: 'response 必须是字符串' });
     }
 
     try {
-    approvalStore.resolve(approvalId, (response || ).trim());
+      approvalStore.resolve(approvalId, response.trim());
       return res.json({ ok: true });
     } catch (err) {
       return res.status(404).json({ error: err.message });

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -223,7 +223,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
     }
 
     try {
-      approvalStore.resolve(approvalId, response.trim());
+    approvalStore.resolve(approvalId, (response || ).trim());
       return res.json({ ok: true });
     } catch (err) {
       return res.status(404).json({ error: err.message });


### PR DESCRIPTION
## fix: 提问框跳过修复 + 回车提交

**问题:**
1. **跳过无效** — 点击"跳过"后 AI 卡住，因为后端  拒绝空 response
2. **回车无法提交** — textarea 没有处理 Enter 键

**修复:**
1. : 允许空 response，跳过时代替空字符串让 AI 自由发挥
2. : QuestionDialog textarea 加 ，回车提交；同时移除按钮的  限制

**效果:**
- 点击"跳过"或输入空内容回车 → AI 自由决定下一步
- 回车提交回答（Shift+Enter 换行）