### PR TITLE
Show full agent answer in trace panel and model result card

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1602,6 +1602,33 @@ textarea {
   word-break: break-word;
 }
 
+.model-card-result-toggle {
+  display: inline-block;
+  margin-top: 2px;
+  font-size: 10px;
+  color: var(--c-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+.model-card-result-toggle:hover { text-decoration: underline; }
+
+.agent-done-answer {
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: var(--r-sm);
+  font-size: var(--f-xs);
+  line-height: 1.6;
+  max-height: 300px;
+  overflow-y: auto;
+  word-break: break-word;
+}
+.agent-done-answer :first-child { margin-top: 0; }
+.agent-done-answer :last-child { margin-bottom: 0; }
+
 /* ── Strategy Toggle ── */
 
 .model-tags-wrap {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1057,6 +1057,7 @@ function ModelPlanCard({ event, isWinner, modelList, strategy, result }) {
   const label = getModelLabel(event.model, modelList);
   const stage = event.stage;
   const [showReasoning, setShowReasoning] = useState(false);
+  const [showFullResult, setShowFullResult] = useState(false);
 
   if (stage === 'start') return null;
 
@@ -1106,7 +1107,12 @@ function ModelPlanCard({ event, isWinner, modelList, strategy, result }) {
           {isWinner && result && (
             <div className="model-card-result">
               <span className="model-card-result-label">执行结果</span>
-              <p>{result.length > 300 ? result.slice(0, 300) + '…' : result}</p>
+              <p>{showFullResult || result.length <= 50 ? result : result.slice(0, 50) + '…'}</p>
+              {result.length > 50 && (
+                <button className="model-card-result-toggle" onClick={() => setShowFullResult(v => !v)}>
+                  {showFullResult ? '收起' : '展开全部'}
+                </button>
+              )}
             </div>
           )}
         </div>
@@ -1509,6 +1515,11 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
                           const short = m.split('/').pop();
                           return <span key={m} className="agent-model-chip">{short}</span>;
                         })}
+                      </div>
+                    )}
+                    {event.answer && (
+                      <div className="agent-done-answer">
+                        <MarkdownBlock content={event.answer} />
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- Trace 面板 "完成" 区域新增完整 answer 展示，用绿色背景卡片渲染 markdown 内容
- ModelPlanCard 执行结果从 300 字硬截断改为 50 字预览 + "展开全部/收起" 按钮

## Test plan
- [ ] 运行 Agent 任务完成后，确认 trace 面板"完成"区域显示完整答案内容
- [ ] 竞速模式下确认采纳模型的执行结果默认显示 50 字，点击"展开全部"可查看完整内容
- [ ] 短结果（≤50 字）不显示展开按钮