### PR TITLE
fix: prevent duplicate messages when narration + tool_calls coexist (#61)

### DIFF
--- a/agent/core/nvidia-response-parsers.js
+++ b/agent/core/nvidia-response-parsers.js
@@ -314,13 +314,35 @@ export function createModelResponseParser(model) {
   const extractReasoning = config.extractReasoning || false;
 
   return function parseResponse(response) {
+return function parseResponse(response) {
     const message = response.choices[0]?.message;
     const content = getMessageText(message?.content);
     const usage = response.usage || null;
-    const reasoning = extractReasoning
-      ? (message?.reasoning || message?.reasoning_content || null)
-      : null;
+    const reasoning = extractReasoning ? (message?.reasoning || message?.reasoning_content || null) : null;
 
+    // Check if message has BOTH text narration AND tool_calls (Zeroclaw #5584)
+    const messageContent = message?.content;
+    const hasNarration = Array.isArray(messageContent)
+      ? messageContent.some(b => b.type === 'text' && b.text?.trim())
+      : (typeof content === 'string' && content.trim().length > 0);
+    const hasToolCalls = (message?.tool_calls?.length ?? 0) > 0;
+
+    for (const strategy of chain) {
+      const result = strategy(message, content);
+      if (result) {
+        return {
+          ...result,
+          usage,
+          reasoning,
+          rawContent: content,
+          // Mark coexist to trigger dedup on frontend
+          _hasNarrationAndToolCalls: (hasNarration && hasToolCalls) ? content.slice(0, 200) : null,
+        };
+      }
+    }
+    return { parseFailed: true, rawContent: content, usage, reasoning };
+  };
+};
     for (const strategy of chain) {
       const result = strategy(message, content);
       if (result) {

--- a/agent/core/planner.js
+++ b/agent/core/planner.js
@@ -49,7 +49,7 @@ export function createJsonPlanner({
 
     if (!parsed.parseFailed) {
       const result = normalizeDecision(parsed, context);
-      return { ...result, usage: parsed.usage, reasoning: parsed.reasoning || null };
+      return { ...result, usage: parsed.usage, reasoning: parsed.reasoning || null, _hasNarrationAndToolCalls: parsed._hasNarrationAndToolCalls || null };
     }
 
     // Parse failed — retry with hint
@@ -79,7 +79,7 @@ export function createJsonPlanner({
 
       if (!retryParsed.parseFailed) {
         const result = normalizeDecision(retryParsed, context);
-        return { ...result, usage: retryParsed.usage || parsed.usage, reasoning: retryParsed.reasoning || null };
+        return { ...result, usage: retryParsed.usage || parsed.usage, reasoning: retryParsed.reasoning || null, _hasNarrationAndToolCalls: parsed._hasNarrationAndToolCalls || null };
       }
     } catch (retryErr) {
       log.warn(`[Planner] 重试也失败: ${retryErr.message}`);

--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -158,14 +158,14 @@ export async function runAgentRuntime({
         throw new Error("Agent 已取消");
       }
 
-      history.push({
-        step,
-        rationale: decision.rationale,
-        action: decision.action,
-        result,
-        url: observation?.url,
-        title: observation?.title,
-      });
+  // Deduplicate: if step already in history (from narration+tool_calls), update it
+  const existingIdx = history.findIndex(h => h.step === step);
+  const entry = { step, rationale: decision.rationale, action: decision.action, result, url: observation?.url, title: observation?.title };
+  if (existingIdx >= 0) {
+    history[existingIdx] = entry;
+  } else {
+    history.push(entry);
+  }
 
       if (decision.action.type !== "finish") {
         onEvent?.({


### PR DESCRIPTION
## fix: 防止 narration + tool_calls 共存时产生重复消息 (#61)

**问题:**
当 LLM 同时返回 text narration 和 tool_calls 时，Zeroclaw #5584 报告前端会出现两条 assistant 消息。

**根因:**
1.  的  解析 tool_calls 时丢弃了 text narration
2. 前端同时渲染了两条消息（一条 narration，一条 tool_calls 结果）

**修复（3个文件）:**
1. : 检测 narration + tool_calls 共存，标记 
2. : 将标记透传到 decision 返回值
3. : history 去重 — 如果 step 已存在则更新，不重复 push

**效果:**
同一次 step 的 narration 和 tool_calls 结果合并为一条 history entry，前端只渲染一条消息