### PR TITLE
feat: add MCP client with sanitize for tool names (#60)

### DIFF
--- a/agent/core/schemas.js
+++ b/agent/core/schemas.js
@@ -322,6 +322,8 @@ export function normalizeDesktopAgentDecision(payload) {
   } else if (tool === 'fetch') {
     normalizedAction = normalizeFetchAction(type, action);
   } else {
+ } else if (tool === 'mcp') {
+ return { tool: 'mcp', server: action.server, tool: action.tool, args: action.args || {} };
     throw new Error(`不支持的工具: ${tool}`);
   }
 

--- a/agent/core/tool-definitions.js
+++ b/agent/core/tool-definitions.js
@@ -290,6 +290,19 @@ export function createModelTools() {
         required: ['answer'],
       },
     },
+  {
+    name: 'mcp',
+    description: '调用外部 MCP (Model Context Protocol) 服务器。工具名经 sanitize 验证防注入。',
+    input_schema: {
+      type: 'object',
+      properties: {
+        server: { type: 'string', description: 'MCP 服务器名称' },
+        tool: { type: 'string', description: '工具名称' },
+        args: { type: 'object', description: '工具参数' },
+      },
+      required: ['server', 'tool'],
+    },
+  },
   ];
 }
 

--- a/agent/desktop/agent.js
+++ b/agent/desktop/agent.js
@@ -11,6 +11,7 @@ import { executeFsAction } from '../tools/fs/execute.js';
 import { executeFetchAction } from '../tools/fetch/execute.js';
 import { createDomainRules } from '../tools/fetch/domain-rules.js';
 import { executeMacOSAction } from '../tools/macos/execute.js';
+import { executeMcpAction } from '../tools/mcp/execute.js';
 import { observeMacOSDesktop } from '../tools/macos/observe.js';
 import { executeTerminalAction } from '../tools/terminal/run.js';
 import { isClaudeModel, buildDesktopAgentSystemPrompt, claudeAgentPlan } from '../core/ai-client.js';
@@ -557,6 +558,7 @@ export function createDesktopAgentRunner({
           runId: state.runId,
         }),
     },
+ mcp: async (_state, action) => executeMcpAction(action),
     { defaultTool: 'core' }
   );
 

--- a/agent/tools/mcp/execute.js
+++ b/agent/tools/mcp/execute.js
@@ -1,0 +1,52 @@
+/**
+ * MCP Client Tool — 调用外部 MCP 服务器
+ */
+import { log } from '../../helpers/logger.js';
+
+const MCP_CLIENT_CONFIG = {
+  'big-model-radar': {
+    url: process.env.MCP_BIG_MODEL_RADAR_URL || '',
+    tools: ['list_reports', 'get_latest', 'get_report', 'search'],
+  },
+};
+
+// Sanitize MCP tool names to prevent injection (NanoBot #3468)
+const SAFE_NAME = /^[a-zA-Z0-9_-]{1,64}$/;
+
+function validateName(name) {
+  if (!name || !SAFE_NAME.test(name)) {
+    throw new Error(`MCP 工具名称包含非法字符: ${name}`);
+  }
+}
+
+export async function executeMcpAction(action) {
+  const { server, tool: toolName, args = {} } = action;
+
+  // Sanitize both server and tool name
+  validateName(server);
+  validateName(toolName);
+
+  const config = MCP_CLIENT_CONFIG[server];
+  if (!config) {
+    throw new Error(`未知的 MCP 服务器: ${server}`);
+  }
+  if (!config.tools.includes(toolName)) {
+    throw new Error(`MCP 服务器 ${server} 不支持工具 ${toolName}`);
+  }
+  if (!config.url) {
+    throw new Error(`MCP 服务器 ${server} 未配置 URL`);
+  }
+
+  const response = await fetch(`${config.url}/tools/${toolName}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(args),
+  });
+
+  if (!response.ok) {
+    throw new Error(`MCP 调用失败: ${response.status}`);
+  }
+
+  const result = await response.json();
+  return typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+}


### PR DESCRIPTION
## feat: MCP 工具名称 sanitize 防注入 (#60)

**问题:** NanoBot #3468 报告 MCP 工具名称未做 sanitize，存在注入风险。

**修复:**
 增加了  — 只允许 ，最大 64 字符，禁止  等危险字符。

同时把 PR #16 中未合并的 MCP 客户端实现补上了（之前 PR #16/24/31 都涉及 MCP 但未合入 main）。

**改动量:** 4 个文件，69 行