### PR TITLE
fix: expand DANGEROUS_PATTERNS to block /home/ /Users/ /root/ (#80)

### DIFF
--- a/agent/tools/fs/execute.js
+++ b/agent/tools/fs/execute.js
@@ -37,6 +37,11 @@ const DANGEROUS_PATTERNS = [
   / id_rsa/,
   / id_dsa/,
   / authorized_keys/,
+  /^\/home\//i,           // 禁止访问其他用户的 HOME 目录
+  /^\/Users\//i,          // 禁止访问 macOS 系统目录
+  /^\/root\//i,           // 禁止访问 root HOME
+  /\/\.ssh\//i,           // 禁止访问任意 .ssh 子目录
+  /\/\.gnupg\//i,         // 禁止访问 GPG 密钥目录
 ];
 
 function assertSafePath(targetPath) {


### PR DESCRIPTION
## fix: 扩展 DANGEROUS_PATTERNS 阻止敏感路径访问 (#80)

**问题:** OpenClaw #51429 报告硬编码路径安全隐患。sagent 的  已有基础防护，但缺少 HOME 目录保护。

**修复:** 在  中增加：
-  — 阻止访问所有 Linux HOME
-  — 阻止访问 macOS 系统目录
-  — 阻止访问 root 目录
-  — 阻止访问任意 .ssh 子目录
-  — 阻止访问 GPG 密钥目录

**改动量:** 1 个文件，5 行