### PR TITLE
fix: replace hardcoded paths with env-based configuration (#80)

### DIFF
--- a/agent/core/llm-logger.js
+++ b/agent/core/llm-logger.js
@@ -13,16 +13,20 @@ import { mkdir, appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { log } from '../../helpers/logger.js';
 
-let logDir = 'data/llm-logs';
+let logDir = process.env.LLM_LOG_DIR || '';
 
 export function initLlmLogger(baseDir) {
   logDir = join(baseDir, 'llm-logs');
 }
 
+function getLogDir() {
+  return logDir || process.env.LLM_LOG_DIR || join(process.cwd(), 'data/llm-logs');
+}
+
 function todayDir() {
   const d = new Date();
   const date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-  return join(logDir, date);
+  return join(getLogDir(), date);
 }
 
 function modelFileName(model) {

--- a/agent/tools/macos/helper-client.js
+++ b/agent/tools/macos/helper-client.js
@@ -2,9 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 
+const PROJECT_DIR = process.env.PROJECT_DIR || process.cwd();
 const DEFAULT_HELPER_CANDIDATES = [
   process.env.AGENT_MACOS_HELPER_PATH,
-  path.resolve(process.cwd(), 'agent/tools/macos/helper/bin/macos-agent-helper'),
+  path.resolve(PROJECT_DIR, 'agent/tools/macos/helper/bin/macos-agent-helper'),
 ].filter(Boolean);
 
 function execFileJson(file, args, payload = {}) {

--- a/agent/tools/macos/observe.js
+++ b/agent/tools/macos/observe.js
@@ -6,7 +6,7 @@ import { getMacOSCapabilityReport } from './permissions.js';
 import { invokeMacOSHelper, resolveMacOSBackend } from './helper-client.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SCREENSHOT_DIR = path.resolve(__dirname, '../../../data/screenshots');
+const SCREENSHOT_DIR = process.env.SCREENSHOT_DIR || path.resolve(__dirname, '../../../data/screenshots');
 
 function execFileText(file, args) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## 修复内容

修复 #80 — 硬编码路径导致安全隐患

### 问题
代码中存在多处硬编码路径：
1. `agent/core/llm-logger.js` — `logDir = 'data/llm-logs'`
2. `agent/tools/macos/observe.js` — `SCREENSHOT_DIR` 相对路径
3. `agent/tools/macos/helper-client.js` — helper 路径依赖 `process.cwd()`

### 修复方案
| 文件 | 修改前 | 修改后 |
|------|--------|--------|
| llm-logger.js | `logDir = 'data/llm-logs'` | 优先 `process.env.LLM_LOG_DIR`，无配置时回退 |
| observe.js | `path.resolve(__dirname, '../../../data/screenshots')` | 优先 `process.env.SCREENSHOT_DIR`，无配置时回退 |
| helper-client.js | `process.cwd() + 'agent/...'` | 优先 `process.env.PROJECT_DIR`，无配置时回退 |

Closes #80