### PR TITLE
feat: 会话级健康检查点与中断恢复机制（#99）

### DIFF
--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -16,23 +16,19 @@
  *   - agent/desktop/agent.js 的 runDesktopAgent() 是唯一的调用方，
  *     注入所有具体实现后调用 runAgentRuntime({ ... })
  *
- * v2 增强（2026-04-30）：
+ * v2 增强：
  *   - 会话级健康检查点（session-checkpoint.js 集成）
- *   - decide 连续失败自动回滚到上一个健康快照
  *   - 前端可触发手动回滚
  */
 
 import { log } from "../../helpers/logger.js";
 import {
   saveHealthySnapshot,
-  saveFailedSnapshot,
   loadLatestHealthySnapshot,
   HEALTH_CHECKPOINT_INTERVAL,
 } from "./session-checkpoint.js";
 
 const MAX_HISTORY_STEPS = 64;
-const MAX_DECIDE_ERRORS = 3; // 连续 decide 失败多少次后自动回滚
-const MAX_ROLLBACKS = 2;    // 最大自动回滚次数，防止无限循环
 
 function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
   if (history.length <= maxSteps) {
@@ -78,15 +74,13 @@ export async function runAgentRuntime({
   initialStep = 1,
   initialHistory = [],
   onCheckpoint = null,
-  // v2: 会话检查点 & 自动回滚
+  // v2: 会话检查点 & 手动回滚
   sessionCheckpointDir = null,
   runRecord = null,
 }) {
   const history = initialHistory;
   let finalAnswer = "";
   const state = await initialize?.({ task, onEvent });
-  let decideErrorCount = 0;
-  let rollbackCount = 0;
 
   const cancelled = () => cancelSignal?.aborted;
 
@@ -102,13 +96,11 @@ export async function runAgentRuntime({
         log.info(`[Runtime] 执行回滚到第 ${targetStep} 步`);
         const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, targetStep);
         if (snapshot) {
-          // 清空 history 到目标步数
           history.length = 0;
           for (const h of snapshot.history) {
             history.push({ ...h });
           }
           step = targetStep;
-          decideErrorCount = 0;
           runRecord.pendingRollback = null;
           runRecord.rolledBack = true;
 
@@ -147,58 +139,14 @@ export async function runAgentRuntime({
 
       const compactHistory = compressHistory(history, MAX_HISTORY_STEPS);
 
-      // ---- 决策（带自动回滚保护） ----
-      let decision;
-      try {
-        decision = await decide({
-          task,
-          step,
-          history: compactHistory,
-          observation,
-          state,
-        });
-        decideErrorCount = 0; // 成功则重置错误计数
-      } catch (decErr) {
-        decideErrorCount++;
-        log.error(`[Runtime] step ${step} decide 失败 (${decideErrorCount}/${MAX_DECIDE_ERRORS}): ${decErr.message}`);
-
-        if (decideErrorCount >= MAX_DECIDE_ERRORS && sessionCheckpointDir && runRecord) {
-          if (rollbackCount >= MAX_ROLLBACKS) {
-            log.warn(`[Runtime] 已达到最大回滚次数 ${MAX_ROLLBACKS}，不再回滚`);
-            throw decErr;
-          }
-          // 自动回滚到上一个健康快照
-          const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, step - 1);
-          if (snapshot) {
-            log.info(`[Runtime] 连续 ${MAX_DECIDE_ERRORS} 次 decide 失败，自动回滚到第 ${snapshot.step} 步`);
-            history.length = 0;
-            for (const h of snapshot.history) {
-              history.push({ ...h });
-            }
-            step = snapshot.step;
-            decideErrorCount = 0;
-            rollbackCount++;
-
-            await saveFailedSnapshot({
-              dir: sessionCheckpointDir,
-              runId: runRecord.runId,
-              step,
-              history,
-              error: new Error(`连续 ${MAX_DECIDE_ERRORS} 次 decide 失败，自动回滚`),
-              state,
-            });
-
-            onEvent?.({
-              type: "rollback",
-              targetStep: snapshot.step,
-              message: `连续 ${MAX_DECIDE_ERRORS} 次决策失败，自动回滚到第 ${snapshot.step} 步`,
-              auto: true,
-            });
-            continue;
-          }
-        }
-        throw decErr; // 未达到阈值或无快照，继续抛异常
-      }
+      // ---- 决策 ----
+      const decision = await decide({
+        task,
+        step,
+        history: compactHistory,
+        observation,
+        state,
+      });
 
       if (cancelled()) {
         throw new Error("Agent 已取消");

--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -15,11 +15,23 @@
  * 调用场景：
  *   - agent/desktop/agent.js 的 runDesktopAgent() 是唯一的调用方，
  *     注入所有具体实现后调用 runAgentRuntime({ ... })
+ *
+ * v2 增强（2026-04-30）：
+ *   - 会话级健康检查点（session-checkpoint.js 集成）
+ *   - decide 连续失败自动回滚到上一个健康快照
+ *   - 前端可触发手动回滚
  */
 
 import { log } from "../../helpers/logger.js";
+import {
+  saveHealthySnapshot,
+  saveFailedSnapshot,
+  loadLatestHealthySnapshot,
+  HEALTH_CHECKPOINT_INTERVAL,
+} from "./session-checkpoint.js";
 
 const MAX_HISTORY_STEPS = 64;
+const MAX_DECIDE_ERRORS = 3; // 连续 decide 失败多少次后自动回滚
 
 function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
   if (history.length <= maxSteps) {
@@ -43,6 +55,13 @@ function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
   ];
 }
 
+/**
+ * 检查外部回滚请求（由前端通过 /api/agent/rollback 设置）
+ */
+function shouldRollback(runRecord) {
+  return runRecord?.pendingRollback != null;
+}
+
 export async function runAgentRuntime({
   task,
   maxSteps = 8,
@@ -58,10 +77,14 @@ export async function runAgentRuntime({
   initialStep = 1,
   initialHistory = [],
   onCheckpoint = null,
+  // v2: 会话检查点 & 自动回滚
+  sessionCheckpointDir = null,
+  runRecord = null,
 }) {
   const history = initialHistory;
   let finalAnswer = "";
   const state = await initialize?.({ task, onEvent });
+  let decideErrorCount = 0;
 
   try {
     for (let step = initialStep; step <= maxSteps; step += 1) {
@@ -69,6 +92,35 @@ export async function runAgentRuntime({
         throw new Error("Agent 已取消");
       }
 
+      // ---- 检查外部回滚请求 ----
+      if (runRecord && shouldRollback(runRecord)) {
+        const targetStep = runRecord.pendingRollback;
+        log.info(`[Runtime] 执行回滚到第 ${targetStep} 步`);
+        const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, targetStep);
+        if (snapshot) {
+          // 清空 history 到目标步数
+          history.length = 0;
+          for (const h of snapshot.history) {
+            history.push({ ...h });
+          }
+          step = targetStep;
+          decideErrorCount = 0;
+          runRecord.pendingRollback = null;
+          runRecord.rolledBack = true;
+
+          onEvent?.({
+            type: "rollback",
+            targetStep,
+            message: `已回滚到第 ${targetStep} 步`,
+          });
+          continue;
+        } else {
+          log.warn(`[Runtime] 回滚失败: 未找到第 ${targetStep} 步的健康快照`);
+          runRecord.pendingRollback = null;
+        }
+      }
+
+      // ---- 观察 ----
       const lastAction =
         history.length > 0 ? history[history.length - 1].action : null;
       const skipObservation = shouldObserve
@@ -91,18 +143,59 @@ export async function runAgentRuntime({
 
       const compactHistory = compressHistory(history, MAX_HISTORY_STEPS);
 
-      const decision = await decide({
-        task,
-        step,
-        history: compactHistory,
-        observation,
-        state,
-      });
+      // ---- 决策（带自动回滚保护） ----
+      let decision;
+      try {
+        decision = await decide({
+          task,
+          step,
+          history: compactHistory,
+          observation,
+          state,
+        });
+        decideErrorCount = 0; // 成功则重置错误计数
+      } catch (decErr) {
+        decideErrorCount++;
+        log.error(`[Runtime] step ${step} decide 失败 (${decideErrorCount}/${MAX_DECIDE_ERRORS}): ${decErr.message}`);
+
+        if (decideErrorCount >= MAX_DECIDE_ERRORS && sessionCheckpointDir && runRecord) {
+          // 自动回滚到上一个健康快照
+          const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, step - 1);
+          if (snapshot) {
+            log.info(`[Runtime] 连续 ${MAX_DECIDE_ERRORS} 次 decide 失败，自动回滚到第 ${snapshot.step} 步`);
+            history.length = 0;
+            for (const h of snapshot.history) {
+              history.push({ ...h });
+            }
+            step = snapshot.step;
+            decideErrorCount = 0;
+
+            await saveFailedSnapshot({
+              dir: sessionCheckpointDir,
+              runId: runRecord.runId,
+              step,
+              history,
+              error: new Error(`连续 ${MAX_DECIDE_ERRORS} 次 decide 失败，自动回滚`),
+              state,
+            });
+
+            onEvent?.({
+              type: "rollback",
+              targetStep: snapshot.step,
+              message: `连续 ${MAX_DECIDE_ERRORS} 次决策失败，自动回滚到第 ${snapshot.step} 步`,
+              auto: true,
+            });
+            continue;
+          }
+        }
+        throw decErr; // 未达到阈值或无快照，继续抛异常
+      }
 
       if (isCancelled?.()) {
         throw new Error("Agent 已取消");
       }
 
+      // ---- 授权 ----
       const authorization = await authorize?.(state, decision.action, {
         task,
         step,
@@ -140,6 +233,7 @@ export async function runAgentRuntime({
         usage: decision.usage || null,
       });
 
+      // ---- 执行 ----
       let result;
       try {
         result = await execute(state, decision.action, {
@@ -176,7 +270,27 @@ export async function runAgentRuntime({
         });
       }
 
+      // ---- 原有 checkpoint（step 级） ----
       onCheckpoint?.(history, step);
+
+      // ---- 会话级健康快照 ----
+      if (sessionCheckpointDir && runRecord && step % HEALTH_CHECKPOINT_INTERVAL === 0) {
+        const runId = runRecord.runId;
+        saveHealthySnapshot({
+          dir: sessionCheckpointDir,
+          runId,
+          step,
+          history,
+          state,
+          result,
+          usage: decision.usage,
+        }).catch(err => log.error(`[Runtime] 健康快照保存失败: ${err.message}`));
+        onEvent?.({
+          type: "session_checkpoint",
+          step,
+          message: `已创建第 ${step} 步健康快照`,
+        });
+      }
 
       if (decision.action.type === "finish") {
         finalAnswer = decision.action.answer || result;

--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -91,9 +91,13 @@ export async function runAgentRuntime({
       }
 
       // ---- 检查外部回滚请求 ----
+      if (runRecord && shouldRollback(runRecord) && !sessionCheckpointDir) {
+        log.warn(`[Runtime] 回滚请求存在但 sessionCheckpointDir 未设置，跳过`);
+        runRecord.pendingRollback = null;
+      }
       if (sessionCheckpointDir && runRecord && shouldRollback(runRecord)) {
         const targetStep = runRecord.pendingRollback;
-        log.info(`[Runtime] 执行回滚到第 ${targetStep} 步`);
+        log.info(`[Runtime] 执行回滚到第 ${targetStep} 步, dir=${sessionCheckpointDir}, runId=${runRecord.runId}`);
         const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, targetStep);
         if (snapshot) {
           history.length = 0;
@@ -233,15 +237,19 @@ export async function runAgentRuntime({
       // ---- 会话级健康快照 ----
       if (sessionCheckpointDir && runRecord && step % HEALTH_CHECKPOINT_INTERVAL === 0) {
         const runId = runRecord.runId;
-        saveHealthySnapshot({
-          dir: sessionCheckpointDir,
-          runId,
-          step,
-          history,
-          state,
-          result,
-          usage: decision.usage,
-        }).catch(err => log.error(`[Runtime] 健康快照保存失败: ${err.message}`));
+        try {
+          await saveHealthySnapshot({
+            dir: sessionCheckpointDir,
+            runId,
+            step,
+            history,
+            state,
+            result,
+            usage: decision.usage,
+          });
+        } catch (err) {
+          log.error(`[Runtime] 健康快照保存失败: ${err.message}`);
+        }
         onEvent?.({
           type: "session_checkpoint",
           step,

--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -234,22 +234,21 @@ export async function runAgentRuntime({
       // ---- 原有 checkpoint（step 级） ----
       onCheckpoint?.(history, step);
 
-      // ---- 会话级健康快照 ----
+      // ---- 会话级健康快照（后台写入，不阻塞） ----
       if (sessionCheckpointDir && runRecord && step % HEALTH_CHECKPOINT_INTERVAL === 0) {
         const runId = runRecord.runId;
-        try {
-          await saveHealthySnapshot({
-            dir: sessionCheckpointDir,
-            runId,
-            step,
-            history,
-            state,
-            result,
-            usage: decision.usage,
-          });
-        } catch (err) {
+        const snapData = {
+          dir: sessionCheckpointDir,
+          runId,
+          step,
+          history: history.map(h => ({ ...h })),
+          state: { ...state },
+          result,
+          usage: decision.usage,
+        };
+        saveHealthySnapshot(snapData).catch(err => {
           log.error(`[Runtime] 健康快照保存失败: ${err.message}`);
-        }
+        });
         onEvent?.({
           type: "session_checkpoint",
           step,

--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -32,6 +32,7 @@ import {
 
 const MAX_HISTORY_STEPS = 64;
 const MAX_DECIDE_ERRORS = 3; // 连续 decide 失败多少次后自动回滚
+const MAX_ROLLBACKS = 2;    // 最大自动回滚次数，防止无限循环
 
 function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
   if (history.length <= maxSteps) {
@@ -85,6 +86,7 @@ export async function runAgentRuntime({
   let finalAnswer = "";
   const state = await initialize?.({ task, onEvent });
   let decideErrorCount = 0;
+  let rollbackCount = 0;
 
   const cancelled = () => cancelSignal?.aborted;
 
@@ -95,7 +97,7 @@ export async function runAgentRuntime({
       }
 
       // ---- 检查外部回滚请求 ----
-      if (runRecord && shouldRollback(runRecord)) {
+      if (sessionCheckpointDir && runRecord && shouldRollback(runRecord)) {
         const targetStep = runRecord.pendingRollback;
         log.info(`[Runtime] 执行回滚到第 ${targetStep} 步`);
         const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, targetStep);
@@ -161,6 +163,10 @@ export async function runAgentRuntime({
         log.error(`[Runtime] step ${step} decide 失败 (${decideErrorCount}/${MAX_DECIDE_ERRORS}): ${decErr.message}`);
 
         if (decideErrorCount >= MAX_DECIDE_ERRORS && sessionCheckpointDir && runRecord) {
+          if (rollbackCount >= MAX_ROLLBACKS) {
+            log.warn(`[Runtime] 已达到最大回滚次数 ${MAX_ROLLBACKS}，不再回滚`);
+            throw decErr;
+          }
           // 自动回滚到上一个健康快照
           const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, step - 1);
           if (snapshot) {
@@ -171,6 +177,7 @@ export async function runAgentRuntime({
             }
             step = snapshot.step;
             decideErrorCount = 0;
+            rollbackCount++;
 
             await saveFailedSnapshot({
               dir: sessionCheckpointDir,

--- a/agent/core/session-checkpoint.js
+++ b/agent/core/session-checkpoint.js
@@ -16,7 +16,6 @@
 
 import { mkdir, writeFile, readFile, unlink, readdir, rename } from 'node:fs/promises';
 import { join } from 'node:path';
-import { log } from '../../helpers/logger.js';
 
 const HEALTH_CHECKPOINT_INTERVAL = 5;  // 每 5 步打一次健康快照
 const KEEP_HEALTHY = 3;
@@ -86,9 +85,9 @@ export async function saveHealthySnapshot({ dir, runId, step, history, state, re
   };
 
   const filePath = healthyPath(dir, runId, step);
-  const tmpPath = filePath + '.tmp';
-  await writeFile(tmpPath, JSON.stringify(snapshot), 'utf8');
-  await rename(tmpPath, filePath);
+  const tmpFile = filePath + '.tmp';
+  await writeFile(tmpFile, JSON.stringify(snapshot), 'utf8');
+  await rename(tmpFile, filePath);
 
   // 修剪旧快照
   await pruneSnapshots(dir, runId, 'healthy', KEEP_HEALTHY);
@@ -116,9 +115,9 @@ export async function saveFailedSnapshot({ dir, runId, step, history, error, sta
   };
 
   const filePath = failedPath(dir, runId, step);
-  const tmpPath = filePath + '.tmp';
-  await writeFile(tmpPath, JSON.stringify(snapshot), 'utf8');
-  await rename(tmpPath, filePath);
+  const tmpFile = filePath + '.tmp';
+  await writeFile(tmpFile, JSON.stringify(snapshot), 'utf8');
+  await rename(tmpFile, filePath);
 
   await pruneSnapshots(dir, runId, 'failed', KEEP_FAILED);
 }

--- a/agent/core/session-checkpoint.js
+++ b/agent/core/session-checkpoint.js
@@ -17,7 +17,7 @@
 import { mkdir, writeFile, readFile, unlink, readdir, rename, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
-const HEALTH_CHECKPOINT_INTERVAL = 5;  // 每 5 步打一次健康快照
+const HEALTH_CHECKPOINT_INTERVAL = 2;  // 每 2 步打一次健康快照
 const KEEP_HEALTHY = 3;
 const KEEP_FAILED = 1;
 

--- a/agent/core/session-checkpoint.js
+++ b/agent/core/session-checkpoint.js
@@ -14,7 +14,7 @@
  *   - desktop/agent.js: 异常检测后自动触发回滚
  */
 
-import { mkdir, writeFile, readFile, unlink, readdir, rename } from 'node:fs/promises';
+import { mkdir, writeFile, readFile, unlink, readdir, rename, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const HEALTH_CHECKPOINT_INTERVAL = 5;  // 每 5 步打一次健康快照
@@ -50,10 +50,12 @@ function assessHealth(result) {
 function sanitizeState(state) {
   if (!state) return null;
   const safe = { ...state };
-  // 移除敏感字段
+  // 移除不可序列化/敏感字段
   delete safe.chromium;
   delete safe.browserCandidatePaths;
   delete safe.onEvent;
+  delete safe.browserSession;
+  delete safe.observeDesktop;
   // 标记 browser session 存在，但不存储引用
   safe.browserSessionActive = Boolean(state.browserSession);
   return safe;
@@ -77,6 +79,7 @@ export async function saveHealthySnapshot({ dir, runId, step, history, state, re
       result: typeof h.result === 'string' ? h.result.slice(0, 2000) : '',
       url: h.url,
       title: h.title,
+      observation: h.observation ? { url: h.observation.url, title: h.observation.title, text: typeof h.observation.text === 'string' ? h.observation.text.slice(0, 500) : undefined } : undefined,
     })),
     state: sanitizeState(state),
     usage: usage || {},
@@ -182,11 +185,7 @@ export async function listSessionCheckpoints(dir, runId) {
 export async function clearSessionCheckpoints(dir, runId) {
   const cpDir = sessionDir(dir, runId);
   try {
-    const files = await readdir(cpDir);
-    for (const f of files) {
-      await unlink(join(cpDir, f)).catch(() => {});
-    }
-    await unlink(cpDir).catch(() => {});
+    await rm(cpDir, { recursive: true, force: true });
   } catch { /* ignore */ }
 }
 
@@ -197,6 +196,12 @@ async function pruneSnapshots(dir, runId, type, keepCount) {
   const cpDir = sessionDir(dir, runId);
   try {
     const files = await readdir(cpDir);
+    // 清理残留的 .tmp 文件
+    for (const f of files) {
+      if (f.endsWith('.tmp')) {
+        await unlink(join(cpDir, f)).catch(() => {});
+      }
+    }
     const snapshots = files
       .filter(f => f.startsWith(`session-${type}-`) && f.endsWith('.json'))
       .map(f => {

--- a/agent/core/session-checkpoint.js
+++ b/agent/core/session-checkpoint.js
@@ -17,9 +17,9 @@
 import { mkdir, writeFile, readFile, unlink, readdir, rename, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
-const HEALTH_CHECKPOINT_INTERVAL = 2;  // 每 2 步打一次健康快照
-const KEEP_HEALTHY = 3;
-const KEEP_FAILED = 1;
+const HEALTH_CHECKPOINT_INTERVAL = 1;  // 每步都保存快照，支持回滚到任意步
+const KEEP_HEALTHY = 30;  // 保留最近 30 个快照（覆盖 128 步运行）
+const KEEP_FAILED = 3;
 
 function sessionDir(dir, runId) {
   return join(dir, 'session-checkpoints', runId);

--- a/agent/core/session-checkpoint.js
+++ b/agent/core/session-checkpoint.js
@@ -1,0 +1,215 @@
+/**
+ * Session Checkpoint — 会话级健康检查点与中断恢复机制
+ *
+ * 与 agent/core/checkpoint.js（step 级原子写入，用于重启后继续任务）不同，
+ * 本模块提供：
+ *   1. 健康快照 — 每 N 步保存完整 history + state 到独立文件
+ *   2. 回滚 API — 恢复到任意历史检查点
+ *   3. 自动恢复 — decide 连续失败时自动回退到上一个健康快照
+ *   4. 快照修剪 — 只保留最近 3 个健康快照 + 1 个失败快照
+ *
+ * 调用场景：
+ *   - runtime.js: 每步成功后自动打健康快照
+ *   - routes/agent.js: 提供 /api/agent/checkpoints 和 /api/agent/rollback 端点
+ *   - desktop/agent.js: 异常检测后自动触发回滚
+ */
+
+import { mkdir, writeFile, readFile, unlink, readdir, rename } from 'node:fs/promises';
+import { join } from 'node:path';
+import { log } from '../../helpers/logger.js';
+
+const HEALTH_CHECKPOINT_INTERVAL = 5;  // 每 5 步打一次健康快照
+const KEEP_HEALTHY = 3;
+const KEEP_FAILED = 1;
+
+function sessionDir(dir, runId) {
+  return join(dir, 'session-checkpoints', runId);
+}
+
+function healthyPath(dir, runId, step) {
+  return join(sessionDir(dir, runId), `session-healthy-${step}.json`);
+}
+
+function failedPath(dir, runId, step) {
+  return join(sessionDir(dir, runId), `session-failed-${step}.json`);
+}
+
+/**
+ * 评估一次执行结果的健康度
+ * 简单规则：result 不是错误信息且不为空，判断为健康
+ */
+function assessHealth(result) {
+  if (!result || typeof result !== 'string') return 'unknown';
+  if (result.startsWith('执行失败')) return 'unhealthy';
+  if (result.startsWith('操作未获批准')) return 'degraded';
+  return 'healthy';
+}
+
+/**
+ * 对 state 做去敏处理，避免存储敏感信息
+ */
+function sanitizeState(state) {
+  if (!state) return null;
+  const safe = { ...state };
+  // 移除敏感字段
+  delete safe.chromium;
+  delete safe.browserCandidatePaths;
+  delete safe.onEvent;
+  // 标记 browser session 存在，但不存储引用
+  safe.browserSessionActive = Boolean(state.browserSession);
+  return safe;
+}
+
+/**
+ * 写入健康快照（只保留最近 KEEP_HEALTHY 个）
+ */
+export async function saveHealthySnapshot({ dir, runId, step, history, state, result, usage }) {
+  const cpDir = sessionDir(dir, runId);
+  await mkdir(cpDir, { recursive: true });
+
+  const snapshot = {
+    type: 'healthy',
+    runId,
+    step,
+    history: history.map(h => ({
+      step: h.step,
+      rationale: h.rationale,
+      action: h.action,
+      result: typeof h.result === 'string' ? h.result.slice(0, 2000) : '',
+      url: h.url,
+      title: h.title,
+    })),
+    state: sanitizeState(state),
+    usage: usage || {},
+    health: assessHealth(result),
+    timestamp: Date.now(),
+  };
+
+  const filePath = healthyPath(dir, runId, step);
+  const tmpPath = filePath + '.tmp';
+  await writeFile(tmpPath, JSON.stringify(snapshot), 'utf8');
+  await rename(tmpPath, filePath);
+
+  // 修剪旧快照
+  await pruneSnapshots(dir, runId, 'healthy', KEEP_HEALTHY);
+}
+
+/**
+ * 写入失败快照（只保留最近 KEEP_FAILED 个）
+ */
+export async function saveFailedSnapshot({ dir, runId, step, history, error, state }) {
+  const cpDir = sessionDir(dir, runId);
+  await mkdir(cpDir, { recursive: true });
+
+  const snapshot = {
+    type: 'failed',
+    runId,
+    step,
+    error: error?.message || String(error || ''),
+    history: (history || []).slice(-5).map(h => ({
+      step: h.step,
+      action: h.action,
+      result: typeof h.result === 'string' ? h.result.slice(0, 500) : '',
+    })),
+    state: sanitizeState(state),
+    timestamp: Date.now(),
+  };
+
+  const filePath = failedPath(dir, runId, step);
+  const tmpPath = filePath + '.tmp';
+  await writeFile(tmpPath, JSON.stringify(snapshot), 'utf8');
+  await rename(tmpPath, filePath);
+
+  await pruneSnapshots(dir, runId, 'failed', KEEP_FAILED);
+}
+
+/**
+ * 加载最新的健康快照（step 小于等于 targetStep）
+ */
+export async function loadLatestHealthySnapshot(dir, runId, upToStep) {
+  const cpDir = sessionDir(dir, runId);
+  try {
+    const files = await readdir(cpDir);
+    const healthyFiles = files
+      .filter(f => f.startsWith('session-healthy-') && f.endsWith('.json'))
+      .map(f => {
+        const match = f.match(/session-healthy-(\d+)\.json$/);
+        return { file: f, step: match ? parseInt(match[1], 10) : 0 };
+      })
+      .filter(f => f.step <= upToStep)
+      .sort((a, b) => b.step - a.step); // 最新的在前
+
+    if (healthyFiles.length === 0) return null;
+
+    const raw = await readFile(join(cpDir, healthyFiles[0].file), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 列出所有检查点
+ */
+export async function listSessionCheckpoints(dir, runId) {
+  const cpDir = sessionDir(dir, runId);
+  try {
+    const files = await readdir(cpDir);
+    const result = [];
+    for (const f of files) {
+      if (!f.endsWith('.json')) continue;
+      try {
+        const raw = await readFile(join(cpDir, f), 'utf8');
+        const parsed = JSON.parse(raw);
+        result.push({
+          step: parsed.step,
+          type: parsed.type,
+          health: parsed.health,
+          timestamp: parsed.timestamp,
+          error: parsed.error || null,
+          file: f,
+        });
+      } catch { /* skip corrupt files */ }
+    }
+    return result.sort((a, b) => a.step - b.step);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 清理指定 runId 的所有会话检查点
+ */
+export async function clearSessionCheckpoints(dir, runId) {
+  const cpDir = sessionDir(dir, runId);
+  try {
+    const files = await readdir(cpDir);
+    for (const f of files) {
+      await unlink(join(cpDir, f)).catch(() => {});
+    }
+    await unlink(cpDir).catch(() => {});
+  } catch { /* ignore */ }
+}
+
+/**
+ * 修剪太旧的快照
+ */
+async function pruneSnapshots(dir, runId, type, keepCount) {
+  const cpDir = sessionDir(dir, runId);
+  try {
+    const files = await readdir(cpDir);
+    const snapshots = files
+      .filter(f => f.startsWith(`session-${type}-`) && f.endsWith('.json'))
+      .map(f => {
+        const match = f.match(new RegExp(`session-${type}-(\\d+)\\.json$`));
+        return { file: f, step: match ? parseInt(match[1], 10) : 0 };
+      })
+      .sort((a, b) => b.step - a.step); // 最新的在前
+
+    for (let i = keepCount; i < snapshots.length; i++) {
+      await unlink(join(cpDir, snapshots[i].file)).catch(() => {});
+    }
+  } catch { /* ignore */ }
+}
+
+export { HEALTH_CHECKPOINT_INTERVAL, KEEP_HEALTHY, KEEP_FAILED };

--- a/agent/desktop/agent.js
+++ b/agent/desktop/agent.js
@@ -595,6 +595,7 @@ export function createDesktopAgentRunner({
     onEvent,
     isCancelled,
     runId,
+    runRecord = null,
     startedAt = Date.now(),
     initialStep = 1,
     initialHistory = [],
@@ -617,6 +618,9 @@ export function createDesktopAgentRunner({
       isCancelled,
       initialStep,
       initialHistory,
+      // v2: 会话级健康检查点支持
+      sessionCheckpointDir: checkpointDir,
+      runRecord,
       onCheckpoint: checkpointDir
         ? (history, step) => saveCheckpoint(checkpointDir, {
             runId, task, model, systemPrompt, headless,

--- a/agent/desktop/agent.js
+++ b/agent/desktop/agent.js
@@ -662,7 +662,7 @@ export function createDesktopAgentRunner({
         }),
       authorize,
       shouldObserve: (lastAction) => {
-        if (!lastAction) return true;
+        if (!lastAction) return false;
         const tool = lastAction.tool || '';
         return tool !== 'fs' && tool !== 'terminal';
       },

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1380,6 +1380,59 @@ textarea {
   cursor: not-allowed;
 }
 
+.rollback-suggestion {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: var(--r-md);
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+}
+
+.rollback-suggestion-info {
+  font-size: var(--f-sm);
+  font-weight: 600;
+  color: #9a3412;
+  margin-bottom: 4px;
+}
+
+.rollback-suggestion-detail {
+  color: var(--c-text-secondary);
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.rollback-suggestion-ctx {
+  font-size: var(--f-xs);
+  color: var(--c-text-secondary);
+  margin: 2px 0;
+  line-height: 1.4;
+}
+
+.rollback-suggestion-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  padding: 4px 12px;
+  border-radius: var(--r-pill);
+  border: 1px solid #f97316;
+  background: #fff;
+  color: #c2410c;
+  font-size: var(--f-xs);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--ease);
+}
+
+.rollback-suggestion-btn:hover:not(:disabled) {
+  background: #ffedd5;
+}
+
+.rollback-suggestion-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .agent-trace-content { min-width: 0; flex: 1; }
 .agent-trace-content strong { display: block; font-size: var(--f-sm); color: var(--c-text); }
 .agent-trace-content p { margin-top: 2px; font-size: var(--f-xs); line-height: 1.5; color: var(--c-text-secondary); word-break: break-word; }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1177,6 +1177,140 @@ textarea {
   cursor: not-allowed;
 }
 
+.agent-rollback-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: var(--r-pill);
+  border: 1px solid #fed7aa;
+  background: #fff7ed;
+  color: #c2410c;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--ease);
+  flex-shrink: 0;
+}
+
+.agent-rollback-btn:hover:not(:disabled) {
+  background: #ffedd5;
+  border-color: #fdba74;
+}
+
+.agent-rollback-btn.active {
+  background: #ffedd5;
+  border-color: #f97316;
+}
+
+.agent-rollback-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.checkpoint-panel {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--c-border);
+  background: var(--c-surface);
+}
+
+.checkpoint-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  font-size: var(--f-sm);
+}
+
+.checkpoint-panel-close {
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--c-text-secondary);
+  border-radius: var(--r-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.checkpoint-panel-close:hover { background: #f3f4f6; }
+
+.checkpoint-panel-note {
+  font-size: var(--f-xs);
+  color: var(--c-text-secondary);
+  margin-bottom: 10px;
+}
+
+.checkpoint-empty {
+  font-size: var(--f-xs);
+  color: var(--c-text-secondary);
+  text-align: center;
+  padding: 12px 0;
+}
+
+.checkpoint-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.checkpoint-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--c-border);
+  background: var(--c-bg);
+}
+
+.checkpoint-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--f-xs);
+}
+
+.checkpoint-step { font-weight: 600; color: var(--c-text); }
+
+.checkpoint-health {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: var(--r-pill);
+  font-weight: 600;
+}
+
+.checkpoint-health.healthy { background: #dcfce7; color: #166534; }
+.checkpoint-health.degraded { background: #fef3c7; color: #92400e; }
+.checkpoint-health.unknown { background: #e5e7eb; color: #4b5563; }
+
+.checkpoint-rollback-btn {
+  height: 22px;
+  padding: 0 10px;
+  border-radius: var(--r-pill);
+  border: 1px solid #fed7aa;
+  background: #fff7ed;
+  color: #c2410c;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--ease);
+}
+
+.checkpoint-rollback-btn:hover:not(:disabled) {
+  background: #ffedd5;
+  border-color: #fdba74;
+}
+
+.checkpoint-rollback-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .agent-headless-toggle {
   display: none;
   align-items: center;
@@ -1339,6 +1473,7 @@ textarea {
 .agent-trace-badge.error { background: #fee2e2; color: #991b1b; }
 .agent-trace-badge.plan { background: #ede9fe; color: #6d28d9; }
 .agent-trace-badge.consensus { background: #dcfce7; color: #166534; }
+.agent-trace-badge.rollback { background: #ffedd5; color: #9a3412; }
 
 .agent-trace-content { min-width: 0; flex: 1; }
 .agent-trace-content strong { display: block; font-size: var(--f-sm); color: var(--c-text); }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1083,7 +1083,6 @@ textarea {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  overflow-y: auto;
 }
 
 .agent-panel {
@@ -1093,6 +1092,10 @@ textarea {
   background: var(--c-surface);
   max-width: 860px;
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
 }
 
 @media (min-width: 1100px) {
@@ -1113,6 +1116,13 @@ textarea {
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--c-surface);
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--c-border);
+  margin-bottom: 4px;
 }
 
 .agent-panel-eyebrow {
@@ -1433,6 +1443,9 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 @media (min-width: 640px) and (max-width: 1099px) {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1187,140 +1187,6 @@ textarea {
   cursor: not-allowed;
 }
 
-.agent-rollback-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  height: 22px;
-  padding: 0 8px;
-  border-radius: var(--r-pill);
-  border: 1px solid #fed7aa;
-  background: #fff7ed;
-  color: #c2410c;
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all var(--ease);
-  flex-shrink: 0;
-}
-
-.agent-rollback-btn:hover:not(:disabled) {
-  background: #ffedd5;
-  border-color: #fdba74;
-}
-
-.agent-rollback-btn.active {
-  background: #ffedd5;
-  border-color: #f97316;
-}
-
-.agent-rollback-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.checkpoint-panel {
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--c-border);
-  background: var(--c-surface);
-}
-
-.checkpoint-panel-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 6px;
-  font-size: var(--f-sm);
-}
-
-.checkpoint-panel-close {
-  width: 22px;
-  height: 22px;
-  border: none;
-  background: none;
-  cursor: pointer;
-  font-size: 14px;
-  color: var(--c-text-secondary);
-  border-radius: var(--r-sm);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.checkpoint-panel-close:hover { background: #f3f4f6; }
-
-.checkpoint-panel-note {
-  font-size: var(--f-xs);
-  color: var(--c-text-secondary);
-  margin-bottom: 10px;
-}
-
-.checkpoint-empty {
-  font-size: var(--f-xs);
-  color: var(--c-text-secondary);
-  text-align: center;
-  padding: 12px 0;
-}
-
-.checkpoint-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.checkpoint-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 10px;
-  border-radius: var(--r-sm);
-  border: 1px solid var(--c-border);
-  background: var(--c-bg);
-}
-
-.checkpoint-info {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: var(--f-xs);
-}
-
-.checkpoint-step { font-weight: 600; color: var(--c-text); }
-
-.checkpoint-health {
-  font-size: 10px;
-  padding: 1px 5px;
-  border-radius: var(--r-pill);
-  font-weight: 600;
-}
-
-.checkpoint-health.healthy { background: #dcfce7; color: #166534; }
-.checkpoint-health.degraded { background: #fef3c7; color: #92400e; }
-.checkpoint-health.unknown { background: #e5e7eb; color: #4b5563; }
-
-.checkpoint-rollback-btn {
-  height: 22px;
-  padding: 0 10px;
-  border-radius: var(--r-pill);
-  border: 1px solid #fed7aa;
-  background: #fff7ed;
-  color: #c2410c;
-  font-size: 10px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all var(--ease);
-}
-
-.checkpoint-rollback-btn:hover:not(:disabled) {
-  background: #ffedd5;
-  border-color: #fdba74;
-}
-
-.checkpoint-rollback-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .agent-headless-toggle {
   display: none;
   align-items: center;
@@ -1487,6 +1353,32 @@ textarea {
 .agent-trace-badge.plan { background: #ede9fe; color: #6d28d9; }
 .agent-trace-badge.consensus { background: #dcfce7; color: #166534; }
 .agent-trace-badge.rollback { background: #ffedd5; color: #9a3412; }
+
+.trace-rollback-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  color: var(--c-text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all var(--ease);
+}
+
+.trace-rollback-btn:hover:not(:disabled) {
+  background: #ffedd5;
+  border-color: #fdba74;
+  color: #c2410c;
+}
+
+.trace-rollback-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 .agent-trace-content { min-width: 0; flex: 1; }
 .agent-trace-content strong { display: block; font-size: var(--f-sm); color: var(--c-text); }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1419,7 +1419,7 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
             <Square size={10} /> {agentStopping ? '停止中…' : pendingApproval ? '停止并拒绝' : '停止'}
           </button>
         )}
-        {running && checkpoints.length > 0 && (
+        {running && (
           <button className={`agent-rollback-btn ${showCheckpointPanel ? 'active' : ''}`} onClick={onToggleCheckpointPanel} title="回滚到历史快照">
             <RotateCcw size={10} /> 回滚
           </button>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2122,17 +2122,6 @@ export default function App() {
     setTimeout(() => agentAbortRef.current?.abort(), 1500);
   };
 
-  const fetchCheckpoints = async () => {
-    try {
-      const rid = agentRunIdRef.current;
-      const url = rid ? `/api/agent/checkpoints?runId=${rid}` : '/api/agent/checkpoints';
-      const res = await fetch(url);
-      if (res.ok) {
-        const data = await res.json();
-      }
-    } catch { /* ignore fetch errors */ }
-  };
-
   const handleRollback = async targetStep => {
     const rid = agentRunIdRef.current;
     console.log('[Rollback] targetStep:', targetStep, 'runId:', rid, 'running:', agentRunning);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1671,6 +1671,22 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
                   <div className="agent-trace-content">
                     <strong>Agent 失败</strong>
                     <p>{event.error}</p>
+                    {event.rollbackSuggestion && (() => {
+                      const rs = event.rollbackSuggestion;
+                      return (
+                        <div className="rollback-suggestion">
+                          <p className="rollback-suggestion-info">
+                            建议回滚到 Step {rs.step} 重新执行
+                            {rs.lastAction && <span className="rollback-suggestion-detail">（上一步: {rs.lastAction.tool}.{rs.lastAction.type}）</span>}
+                          </p>
+                          {rs.lastRationale && <p className="rollback-suggestion-ctx">决策: {rs.lastRationale}</p>}
+                          {rs.lastResult && <p className="rollback-suggestion-ctx">结果: {rs.lastResult}</p>}
+                          <button className="rollback-suggestion-btn" onClick={() => onRollback(rs.step)} disabled={rollbackLoading}>
+                            <RotateCcw size={12} /> 回滚到 Step {rs.step}
+                          </button>
+                        </div>
+                      );
+                    })()}
                   </div>
                 </>
               )}
@@ -2003,7 +2019,20 @@ export default function App() {
     // 普通切换会话时，Agent trace 跟着 active session 走；
     // 但如果当前正处在“刷新后重连中的运行态”，不要被旧 session 覆盖掉。
     if (agentRunning) return;
-    setAgentTrace(activeSession.agentTrace || []);
+    const savedTrace = activeSession.agentTrace || [];
+    setAgentTrace(savedTrace);
+    // Recover runId from saved trace (survives page refresh / backend restart)
+    const runEvent = savedTrace.find(e => e.runId);
+    if (runEvent) {
+      agentRunIdRef.current = runEvent.runId;
+      setAgentRunId(runEvent.runId);
+    } else {
+      agentRunIdRef.current = null;
+      setAgentRunId(null);
+    }
+    // Recover last agent task text from session messages for rollback retry
+    const lastUserMsg = [...(activeSession.messages || [])].reverse().find(m => m.role === 'user');
+    lastAgentTaskRef.current = lastUserMsg?.content || null;
     setAgentStartedAt(null);
     setPendingApproval(null);
     approvalRequestRef.current = null;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1419,7 +1419,7 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
             <Square size={10} /> {agentStopping ? '停止中…' : pendingApproval ? '停止并拒绝' : '停止'}
           </button>
         )}
-        {running && (
+        {(running || trace.length > 0) && (
           <button className={`agent-rollback-btn ${showCheckpointPanel ? 'active' : ''}`} onClick={onToggleCheckpointPanel} title="回滚到历史快照">
             <RotateCcw size={10} /> 回滚
           </button>
@@ -1808,6 +1808,7 @@ export default function App() {
   const bottomRef = useRef(null);
   const textareaRef = useRef(null);
   const reconnectTaskRef = useRef(null);
+  const lastAgentTaskRef = useRef(null);
 
   // 拉取后端可用模型。这里除了更新下拉/模型标签，
   // 还要顺手修正那些引用了已下线模型的历史聊天会话。
@@ -2128,7 +2129,9 @@ export default function App() {
 
   const fetchCheckpoints = async () => {
     try {
-      const res = await fetch('/api/agent/checkpoints');
+      const rid = agentRunIdRef.current;
+      const url = rid ? `/api/agent/checkpoints?runId=${rid}` : '/api/agent/checkpoints';
+      const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
         setAgentCheckpoints(data.checkpoints || []);
@@ -2148,16 +2151,26 @@ export default function App() {
     if (!rid) return;
     setRollbackLoading(true);
     try {
-      const res = await fetch('/api/agent/rollback', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ targetStep }),
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        alert(data.error || '回滚失败');
+      if (agentRunning) {
+        // Running task — use pendingRollback for in-place rollback
+        const res = await fetch('/api/agent/rollback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ targetStep }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          alert(data.error || '回滚失败');
+        } else {
+          setShowCheckpointPanel(false);
+        }
       } else {
+        // Finished task — restart from checkpoint
         setShowCheckpointPanel(false);
+        setAgentTrace(prev => prev.filter(e => e.step == null || e.step <= targetStep));
+        await sendAgentTask(lastAgentTaskRef.current || '继续任务', {
+          fromCheckpoint: { runId: rid, step: targetStep },
+        });
       }
     } catch {
       alert('回滚请求失败');
@@ -2346,18 +2359,21 @@ export default function App() {
 
   // Agent 流程和普通对话不一样：聊天区只保留“任务 + 最终回答”，
   // 详细的中间步骤全部写进 agentTrace，再由 AgentPanel 单独展示。
-  const sendAgentTask = async text => {
+  const sendAgentTask = async (text, extraBody) => {
     const sessionId = activeSession.id;
-    const userMsg = { role: 'user', content: text, ts: Date.now() };
-    const history = [...messages, userMsg];
+    const isRetry = !!extraBody?.fromCheckpoint;
+    lastAgentTaskRef.current = text;
+    const history = isRetry ? messages : [...messages, { role: 'user', content: text, ts: Date.now() }];
 
-    updateSession(sessionId, session =>
-      touchSession(session, {
-        messages: [...history, { role: 'assistant', content: 'Desktop Agent 正在执行任务，请稍候…', ts: Date.now() }],
-      })
-    );
-    setInput('');
-    setAgentTrace([]);
+    if (!isRetry) {
+      updateSession(sessionId, session =>
+        touchSession(session, {
+          messages: [...history, { role: 'assistant', content: 'Desktop Agent 正在执行任务，请稍候…', ts: Date.now() }],
+        })
+      );
+      setInput('');
+      setAgentTrace([]);
+    }
     setAgentStartedAt(Date.now());
     setAgentRunning(true);
     setPendingApproval(null);
@@ -2379,6 +2395,7 @@ export default function App() {
         memory: agentMemory,
         signal: controller.signal,
         messages: history.slice(-10),
+        ...extraBody,
         async onEvent(event) {
           if (event.type === 'model_plan') {
             console.log(`[AgentUI] model_plan step=${event.step} stage=${event.stage} model=${event.model || '-'} models=${event.models?.join(',') || '-'}`);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -409,7 +409,7 @@ async function streamChatCompletion({
 // Agent 的首个 POST 既负责发起任务，也承载最初的一段 SSE。
 // 如果这段连接中途断开，但服务端 run 已经创建成功，就退化为
 // 通过 runId 继续订阅 /stream/:runId，而不是直接把整次任务判失败。
-async function streamAgentRun({ task, model, models, strategy, headless, memory, signal, onEvent, messages }) {
+async function streamAgentRun({ task, model, models, strategy, headless, memory, signal, onEvent, messages, ...extra }) {
   let runId = null;
   let gotDone = false;
 
@@ -422,7 +422,7 @@ async function streamAgentRun({ task, model, models, strategy, headless, memory,
   try {
     await streamSseJson({
       url: AGENT_API_URL,
-      body: { task, model, models, strategy, headless, memory, messages },
+      body: { task, model, models, strategy, headless, memory, messages, ...extra },
       signal,
       onEvent: wrappedEvent,
     });
@@ -2017,8 +2017,6 @@ export default function App() {
       } catch (err) {
         if (err.name === 'AbortError') {
           setAgentRunning(false);
-          agentRunIdRef.current = null;
-          setAgentRunId(null);
         }
       }
     })();
@@ -2512,8 +2510,7 @@ export default function App() {
       });
 
       agentAbortRef.current = null;
-      agentRunIdRef.current = null;
-      setAgentRunId(null);
+      // Keep agentRunIdRef for post-task checkpoint queries
       setAgentRunning(false);
       setAgentStopping(false);
       setReconnectedRun(false);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1321,7 +1321,7 @@ function MemoryPanel({ onClose }) {
 // - 负责展示 trace
 // - 负责显示暂停/审批/用时/token 等运行态指标
 // - 在移动端和桌面端之间复用同一套事件展示逻辑
-function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedAt, modelList, collapsed, onToggleCollapse, onStop, agentStopping, pendingApproval, onToggleMemory, showMemoryPanel, checkpoints, onRollback, rollbackLoading, showCheckpointPanel, onToggleCheckpointPanel }) {
+function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedAt, modelList, collapsed, onToggleCollapse, onStop, agentStopping, pendingApproval, onToggleMemory, showMemoryPanel, onRollback, rollbackLoading }) {
   const traceBottomRef = useRef(null);
   const startTimeRef = useRef(null);
   const isMobile = typeof window !== 'undefined' && window.innerWidth < PHONE_BREAKPOINT;
@@ -1372,10 +1372,7 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
   }, [hasPendingQuestion]);
 
   useEffect(() => {
-    // Only auto-scroll trace on small screens where it has a max-height
-    if (window.innerWidth < DOCKED_LAYOUT_BREAKPOINT) {
-      traceBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
+    traceBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [trace]);
 
   if (mode !== 'agent') {
@@ -1419,11 +1416,6 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
             <Square size={10} /> {agentStopping ? '停止中…' : pendingApproval ? '停止并拒绝' : '停止'}
           </button>
         )}
-        {(running || trace.length > 0) && (
-          <button className={`agent-rollback-btn ${showCheckpointPanel ? 'active' : ''}`} onClick={onToggleCheckpointPanel} title="回滚到历史快照">
-            <RotateCcw size={10} /> 回滚
-          </button>
-        )}
         <label className="agent-headless-toggle" title={headless ? '浏览器在后台运行' : '浏览器窗口可见'}>
           <input
             type="checkbox"
@@ -1447,31 +1439,6 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
         <>
           {showMemoryPanel ? (
             <MemoryPanel onClose={() => onToggleMemory()} />
-          ) : showCheckpointPanel ? (
-            <div className="checkpoint-panel">
-              <div className="checkpoint-panel-head">
-                <strong>健康快照</strong>
-                <button className="checkpoint-panel-close" onClick={onToggleCheckpointPanel}>✕</button>
-              </div>
-              <p className="checkpoint-panel-note">选择一个快照回滚，Agent 将从该步重新执行。</p>
-              {checkpoints.length === 0 ? (
-                <p className="checkpoint-empty">暂无快照（每 5 步自动保存）</p>
-              ) : (
-                <div className="checkpoint-list">
-                  {checkpoints.map(cp => (
-                    <div key={cp.step} className="checkpoint-item">
-                      <div className="checkpoint-info">
-                        <span className="checkpoint-step">Step {cp.step}</span>
-                        <span className={`checkpoint-health ${cp.health || 'unknown'}`}>{cp.health || 'unknown'}</span>
-                      </div>
-                      <button className="checkpoint-rollback-btn" onClick={() => onRollback(cp.step)} disabled={rollbackLoading}>
-                        {rollbackLoading ? '回滚中…' : '回滚'}
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
           ) : (
             <>
               <p className="agent-panel-note">
@@ -1724,6 +1691,9 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
                   <div className="agent-trace-content">
                     <strong>Step {event.step} 健康快照已保存</strong>
                   </div>
+                  <button className="trace-rollback-btn" onClick={() => onRollback(event.step)} disabled={rollbackLoading || running} title={`回滚到 Step ${event.step}`}>
+                    <RotateCcw size={10} />
+                  </button>
                 </>
               )}
             </div>
@@ -1765,8 +1735,6 @@ export default function App() {
   const [approvalSubmitting, setApprovalSubmitting] = useState(false);
   const [agentCollapsed, setAgentCollapsed] = useState(false);
   const [showMemoryPanel, setShowMemoryPanel] = useState(false);
-  const [showCheckpointPanel, setShowCheckpointPanel] = useState(false);
-  const [agentCheckpoints, setAgentCheckpoints] = useState([]);
   const [rollbackLoading, setRollbackLoading] = useState(false);
   const [agentMobileTab, setAgentMobileTab] = useState('agent');
   const [pendingQuestion, setPendingQuestion] = useState(null);
@@ -1988,7 +1956,7 @@ export default function App() {
               if (event.type === 'rollback') {
                 setAgentTrace(prev => {
                   const target = event.targetStep;
-                  return prev.filter(e => e.step == null || e.step <= target);
+                  return prev.filter(e => (e.step == null && e.type !== 'done' && e.type !== 'error') || e.step <= target);
                 });
               }
 
@@ -2132,21 +2100,17 @@ export default function App() {
       const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
-        setAgentCheckpoints(data.checkpoints || []);
       }
     } catch { /* ignore fetch errors */ }
   };
 
-  const toggleCheckpointPanel = () => {
-    if (!showCheckpointPanel) {
-      fetchCheckpoints();
-    }
-    setShowCheckpointPanel(v => !v);
-  };
-
   const handleRollback = async targetStep => {
     const rid = agentRunIdRef.current;
-    if (!rid) return;
+    console.log('[Rollback] targetStep:', targetStep, 'runId:', rid, 'running:', agentRunning);
+    if (!rid) {
+      console.warn('[Rollback] no runId, cannot rollback');
+      return;
+    }
     setRollbackLoading(true);
     try {
       if (agentRunning) {
@@ -2159,13 +2123,10 @@ export default function App() {
         const data = await res.json();
         if (!res.ok) {
           alert(data.error || '回滚失败');
-        } else {
-          setShowCheckpointPanel(false);
         }
       } else {
         // Finished task — restart from checkpoint
-        setShowCheckpointPanel(false);
-        setAgentTrace(prev => prev.filter(e => e.step == null || e.step <= targetStep));
+        setAgentTrace(prev => prev.filter(e => (e.step == null && e.type !== 'done' && e.type !== 'error') || e.step <= targetStep));
         await sendAgentTask(lastAgentTaskRef.current || '继续任务', {
           fromCheckpoint: { runId: rid, step: targetStep },
         });
@@ -2371,6 +2332,13 @@ export default function App() {
       );
       setInput('');
       setAgentTrace([]);
+    } else {
+      // Retry from checkpoint — update chat placeholder to show re-executing
+      updateSession(sessionId, session => {
+        const msgs = [...session.messages];
+        msgs.push({ role: 'assistant', content: 'Desktop Agent 正在从检查点重新执行任务…', ts: Date.now() });
+        return touchSession(session, { messages: msgs });
+      });
     }
     setAgentStartedAt(Date.now());
     setAgentRunning(true);
@@ -2395,10 +2363,16 @@ export default function App() {
         messages: history.slice(-10),
         ...extraBody,
         async onEvent(event) {
-          if (event.type === 'model_plan') {
-            console.log(`[AgentUI] model_plan step=${event.step} stage=${event.stage} model=${event.model || '-'} models=${event.models?.join(',') || '-'}`);
-          }
-          setAgentTrace(prev => [...prev, event]);
+          console.log(`[AgentUI] event type=${event.type} step=${event.step ?? '-'} stage=${event.stage ?? '-'} model=${event.model || '-'}`);
+          setAgentTrace(prev => {
+            // Deduplicate: same type+step+stage+model already exists
+            const key = `${event.type}:${event.step ?? ''}:${event.stage ?? ''}:${event.model ?? ''}`;
+            if (prev.some(e => `${e.type}:${e.step ?? ''}:${e.stage ?? ''}:${e.model ?? ''}` === key)) {
+              console.log(`[AgentUI] DEDUP skipped: ${key}`);
+              return prev;
+            }
+            return [...prev, event];
+          });
 
           if (event.runId && !agentRunIdRef.current) {
             agentRunIdRef.current = event.runId;
@@ -2421,7 +2395,7 @@ export default function App() {
           if (event.type === 'rollback') {
             setAgentTrace(prev => {
               const target = event.targetStep;
-              return prev.filter(e => e.step == null || e.step <= target);
+              return prev.filter(e => (e.step == null && e.type !== 'done' && e.type !== 'error') || e.step <= target);
             });
             return;
           }
@@ -2788,11 +2762,8 @@ export default function App() {
                   pendingApproval={pendingApproval}
                   onToggleMemory={() => setShowMemoryPanel(v => !v)}
                   showMemoryPanel={showMemoryPanel}
-                  checkpoints={agentCheckpoints}
                   onRollback={handleRollback}
                   rollbackLoading={rollbackLoading}
-                  showCheckpointPanel={showCheckpointPanel}
-                  onToggleCheckpointPanel={toggleCheckpointPanel}
                 />
               </div>
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, Component, useMemo } from 'react';
 import {
   Menu, Timer, Trash2, Square, Brain, ChevronDown, ChevronUp,
-  Copy, Check, Send,
+  Copy, Check, Send, RotateCcw,
 } from 'lucide-react';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
@@ -1321,7 +1321,7 @@ function MemoryPanel({ onClose }) {
 // - 负责展示 trace
 // - 负责显示暂停/审批/用时/token 等运行态指标
 // - 在移动端和桌面端之间复用同一套事件展示逻辑
-function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedAt, modelList, collapsed, onToggleCollapse, onStop, agentStopping, pendingApproval, onToggleMemory, showMemoryPanel }) {
+function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedAt, modelList, collapsed, onToggleCollapse, onStop, agentStopping, pendingApproval, onToggleMemory, showMemoryPanel, checkpoints, onRollback, rollbackLoading, showCheckpointPanel, onToggleCheckpointPanel }) {
   const traceBottomRef = useRef(null);
   const startTimeRef = useRef(null);
   const isMobile = typeof window !== 'undefined' && window.innerWidth < PHONE_BREAKPOINT;
@@ -1419,6 +1419,11 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
             <Square size={10} /> {agentStopping ? '停止中…' : pendingApproval ? '停止并拒绝' : '停止'}
           </button>
         )}
+        {running && checkpoints.length > 0 && (
+          <button className={`agent-rollback-btn ${showCheckpointPanel ? 'active' : ''}`} onClick={onToggleCheckpointPanel} title="回滚到历史快照">
+            <RotateCcw size={10} /> 回滚
+          </button>
+        )}
         <label className="agent-headless-toggle" title={headless ? '浏览器在后台运行' : '浏览器窗口可见'}>
           <input
             type="checkbox"
@@ -1442,6 +1447,31 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
         <>
           {showMemoryPanel ? (
             <MemoryPanel onClose={() => onToggleMemory()} />
+          ) : showCheckpointPanel ? (
+            <div className="checkpoint-panel">
+              <div className="checkpoint-panel-head">
+                <strong>健康快照</strong>
+                <button className="checkpoint-panel-close" onClick={onToggleCheckpointPanel}>✕</button>
+              </div>
+              <p className="checkpoint-panel-note">选择一个快照回滚，Agent 将从该步重新执行。</p>
+              {checkpoints.length === 0 ? (
+                <p className="checkpoint-empty">暂无快照（每 5 步自动保存）</p>
+              ) : (
+                <div className="checkpoint-list">
+                  {checkpoints.map(cp => (
+                    <div key={cp.step} className="checkpoint-item">
+                      <div className="checkpoint-info">
+                        <span className="checkpoint-step">Step {cp.step}</span>
+                        <span className={`checkpoint-health ${cp.health || 'unknown'}`}>{cp.health || 'unknown'}</span>
+                      </div>
+                      <button className="checkpoint-rollback-btn" onClick={() => onRollback(cp.step)} disabled={rollbackLoading}>
+                        {rollbackLoading ? '回滚中…' : '回滚'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           ) : (
             <>
               <p className="agent-panel-note">
@@ -1677,6 +1707,25 @@ function AgentPanel({ mode, running, trace, headless, onHeadlessChange, startedA
                   </div>
                 </>
               )}
+
+              {event.type === 'rollback' && (
+                <>
+                  <span className="agent-trace-badge rollback">回滚</span>
+                  <div className="agent-trace-content">
+                    <strong>已回滚到 Step {event.targetStep}</strong>
+                    <p>{event.message}</p>
+                  </div>
+                </>
+              )}
+
+              {event.type === 'session_checkpoint' && (
+                <>
+                  <span className="agent-trace-badge plan">快照</span>
+                  <div className="agent-trace-content">
+                    <strong>Step {event.step} 健康快照已保存</strong>
+                  </div>
+                </>
+              )}
             </div>
             );
           })})()}
@@ -1716,6 +1765,9 @@ export default function App() {
   const [approvalSubmitting, setApprovalSubmitting] = useState(false);
   const [agentCollapsed, setAgentCollapsed] = useState(false);
   const [showMemoryPanel, setShowMemoryPanel] = useState(false);
+  const [showCheckpointPanel, setShowCheckpointPanel] = useState(false);
+  const [agentCheckpoints, setAgentCheckpoints] = useState([]);
+  const [rollbackLoading, setRollbackLoading] = useState(false);
   const [agentMobileTab, setAgentMobileTab] = useState('agent');
   const [pendingQuestion, setPendingQuestion] = useState(null);
   const [questionSubmitting, setQuestionSubmitting] = useState(false);
@@ -2065,6 +2117,46 @@ export default function App() {
     }
     // Abort SSE after a short grace period for in-flight results
     setTimeout(() => agentAbortRef.current?.abort(), 1500);
+  };
+
+  const fetchCheckpoints = async () => {
+    try {
+      const res = await fetch('/api/agent/checkpoints');
+      if (res.ok) {
+        const data = await res.json();
+        setAgentCheckpoints(data.checkpoints || []);
+      }
+    } catch {}
+  };
+
+  const toggleCheckpointPanel = () => {
+    if (!showCheckpointPanel) {
+      fetchCheckpoints();
+    }
+    setShowCheckpointPanel(v => !v);
+  };
+
+  const handleRollback = async targetStep => {
+    const rid = agentRunIdRef.current;
+    if (!rid) return;
+    setRollbackLoading(true);
+    try {
+      const res = await fetch('/api/agent/rollback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetStep }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || '回滚失败');
+      } else {
+        setShowCheckpointPanel(false);
+      }
+    } catch {
+      alert('回滚请求失败');
+    } finally {
+      setRollbackLoading(false);
+    }
   };
   const requestAgentApproval = event =>
     new Promise(resolve => {
@@ -2667,6 +2759,11 @@ export default function App() {
                   pendingApproval={pendingApproval}
                   onToggleMemory={() => setShowMemoryPanel(v => !v)}
                   showMemoryPanel={showMemoryPanel}
+                  checkpoints={agentCheckpoints}
+                  onRollback={handleRollback}
+                  rollbackLoading={rollbackLoading}
+                  showCheckpointPanel={showCheckpointPanel}
+                  onToggleCheckpointPanel={toggleCheckpointPanel}
                 />
               </div>
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1984,6 +1984,13 @@ export default function App() {
                 approvalRequestRef.current = null;
               }
 
+              if (event.type === 'rollback') {
+                setAgentTrace(prev => {
+                  const target = event.targetStep;
+                  return prev.filter(e => e.step == null || e.step <= target);
+                });
+              }
+
               if (event.type === 'done') {
                 setAgentRunning(false);
                 updateActiveSession(session => {
@@ -2392,6 +2399,14 @@ export default function App() {
             await new Promise(resolve => {
               questionRequestRef.current = { ...event, resolve };
               setPendingQuestion(event);
+            });
+            return;
+          }
+
+          if (event.type === 'rollback') {
+            setAgentTrace(prev => {
+              const target = event.targetStep;
+              return prev.filter(e => e.step == null || e.step <= target);
             });
             return;
           }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2134,7 +2134,7 @@ export default function App() {
         const data = await res.json();
         setAgentCheckpoints(data.checkpoints || []);
       }
-    } catch {}
+    } catch { /* ignore fetch errors */ }
   };
 
   const toggleCheckpointPanel = () => {

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -483,9 +483,15 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
     if (typeof targetStep !== 'number' || !Number.isInteger(targetStep) || targetStep < 1) {
       return res.status(400).json({ error: 'targetStep 必须是正整数' });
     }
+    if (!checkpointDir) {
+      return res.status(400).json({ error: '会话检查点未启用' });
+    }
     const activeRun = agentRunStore.getActiveRun();
     if (!activeRun) {
       return res.status(404).json({ error: '没有活跃的运行' });
+    }
+    if (activeRun.rolledBack) {
+      return res.status(409).json({ error: '已有回滚请求处理中' });
     }
     activeRun.pendingRollback = targetStep;
     log.info(`[API] 设置回滚请求: runId=${activeRun.runId} targetStep=${targetStep}`);

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -44,7 +44,6 @@ import {
 import { removeCheckpoint } from '../agent/core/checkpoint.js';
 import {
   listSessionCheckpoints,
-  clearSessionCheckpoints,
 } from '../agent/core/session-checkpoint.js';
 import { summarizeText } from '../agent/core/ai-client.js';
 import { log } from '../helpers/logger.js';

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -42,6 +42,10 @@ import {
   compactConversationMemory,
 } from '../agent/core/memory.js';
 import { removeCheckpoint } from '../agent/core/checkpoint.js';
+import {
+  listSessionCheckpoints,
+  clearSessionCheckpoints,
+} from '../agent/core/session-checkpoint.js';
 import { summarizeText } from '../agent/core/ai-client.js';
 import { log } from '../helpers/logger.js';
 
@@ -155,6 +159,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
         systemPrompt,
         headless: agentHeadless,
         runId,
+        runRecord,
         onEvent: sendEvent,
         isCancelled: () => runRecord.cancelled,
         conversationHistory: Array.isArray(conversationHistory) ? conversationHistory : [],
@@ -446,6 +451,46 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
     }
+  });
+
+  // ---- v2: 会话检查点 API ----
+
+  /**
+   * GET /api/agent/checkpoints — 列出当前运行的所有会话检查点
+   */
+  router.get('/api/agent/checkpoints', async (_req, res) => {
+    if (!checkpointDir) {
+      return res.json({ checkpoints: [] });
+    }
+    const activeRun = agentRunStore.getActiveRun();
+    if (!activeRun) {
+      return res.json({ checkpoints: [] });
+    }
+    try {
+      const checkpoints = await listSessionCheckpoints(checkpointDir, activeRun.runId);
+      res.json({ runId: activeRun.runId, checkpoints });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  /**
+   * POST /api/agent/rollback — 回滚到指定步数
+   * Body: { targetStep: number }
+   * 设置 pendingRollback 标记，runtime 会在下一轮循环中执行回滚
+   */
+  router.post('/api/agent/rollback', (req, res) => {
+    const { targetStep } = req.body ?? {};
+    if (typeof targetStep !== 'number' || !Number.isInteger(targetStep) || targetStep < 1) {
+      return res.status(400).json({ error: 'targetStep 必须是正整数' });
+    }
+    const activeRun = agentRunStore.getActiveRun();
+    if (!activeRun) {
+      return res.status(404).json({ error: '没有活跃的运行' });
+    }
+    activeRun.pendingRollback = targetStep;
+    log.info(`[API] 设置回滚请求: runId=${activeRun.runId} targetStep=${targetStep}`);
+    res.json({ ok: true, runId: activeRun.runId, targetStep });
   });
 
   return router;

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -44,6 +44,7 @@ import {
 import { removeCheckpoint } from '../agent/core/checkpoint.js';
 import {
   listSessionCheckpoints,
+  loadLatestHealthySnapshot,
 } from '../agent/core/session-checkpoint.js';
 import { summarizeText } from '../agent/core/ai-client.js';
 import { log } from '../helpers/logger.js';
@@ -53,7 +54,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
   const defaultModel = modelConfig?.[0]?.id || 'minimaxai/minimax-m2.7';
 
   router.post('/api/agent', async (req, res) => {
-    const { task, model = defaultModel, models: reqModels, strategy = 'race', headless, memory: useMemory = true, messages: conversationHistory } = req.body ?? {};
+    const { task, model = defaultModel, models: reqModels, strategy = 'race', headless, memory: useMemory = true, messages: conversationHistory, fromCheckpoint } = req.body ?? {};
     const agentModels = Array.isArray(reqModels) && reqModels.length > 0 ? reqModels : [model];
 
     if (typeof task !== 'string' || !task.trim()) {
@@ -64,6 +65,21 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
     const activeRun = agentRunStore.getActiveRun();
     if (activeRun) {
       return res.status(409).json({ error: '已有 Agent 在运行中，请等待完成或取消', runId: activeRun.runId });
+    }
+
+    // Load checkpoint history if retrying from a checkpoint
+    let checkpointInitialStep;
+    let checkpointInitialHistory;
+    if (fromCheckpoint && checkpointDir) {
+      const cpRunId = fromCheckpoint.runId;
+      const cpStep = fromCheckpoint.step;
+      if (typeof cpRunId === 'string' && typeof cpStep === 'number') {
+        const snapshot = await loadLatestHealthySnapshot(checkpointDir, cpRunId, cpStep);
+        if (snapshot) {
+          checkpointInitialStep = snapshot.step + 1;
+          checkpointInitialHistory = snapshot.history || [];
+        }
+      }
     }
 
     const normalizedTask = task.trim();
@@ -163,6 +179,8 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
         cancelSignal: runRecord.cancelAc.signal,
         conversationHistory: Array.isArray(conversationHistory) ? conversationHistory : [],
         memory: useMemory,
+        initialStep: checkpointInitialStep,
+        initialHistory: checkpointInitialHistory,
       });
 
       finalAnswer = agentResult.answer;
@@ -457,17 +475,19 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
   /**
    * GET /api/agent/checkpoints — 列出当前运行的所有会话检查点
    */
-  router.get('/api/agent/checkpoints', async (_req, res) => {
+  router.get('/api/agent/checkpoints', async (req, res) => {
     if (!checkpointDir) {
       return res.json({ checkpoints: [] });
     }
+    const queryRunId = req.query.runId;
     const activeRun = agentRunStore.getActiveRun();
-    if (!activeRun) {
+    const runId = queryRunId || activeRun?.runId;
+    if (!runId) {
       return res.json({ checkpoints: [] });
     }
     try {
-      const checkpoints = await listSessionCheckpoints(checkpointDir, activeRun.runId);
-      res.json({ runId: activeRun.runId, checkpoints });
+      const checkpoints = await listSessionCheckpoints(checkpointDir, runId);
+      res.json({ runId, checkpoints });
     } catch (err) {
       res.status(500).json({ error: err.message });
     }

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -108,6 +108,11 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
     res.flushHeaders();
+    res.socket?.setNoDelay(true);
+    // Heartbeat: detect half-open connections between steps
+    const heartbeat = setInterval(() => {
+      if (!res.writableEnded) res.write(': heartbeat\n\n');
+    }, 15000);
 
     log.info(
       `[${formatLogTime()}] POST /api/agent model=${model} headless=${agentHeadless} task=${safeJson(normalizedTask)} ` +
@@ -132,6 +137,9 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
       }
       logAgentEvent(payload);
       agentRunStore.addEvent(runId, payload);
+      if (payload.type === 'model_plan' || payload.type === 'session_checkpoint') {
+        log.debug(`[SSE] write type=${payload.type} step=${payload.step} stage=${payload.stage ?? '-'} model=${payload.model ?? '-'} writableEnded=${res.writableEnded} writableFinished=${res.writableFinished}`);
+      }
       rawSendEvent(payload);
       // Forward to any reconnected clients
       const run = agentRunStore.getRun(runId);
@@ -148,6 +156,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
       runId,
       message: '准备启动桌面 Agent',
     });
+    log.debug(`[SSE] stream started, writableEnded=${res.writableEnded} writableFinished=${res.writableFinished}`);
 
     // Load memory
     let memory = null;
@@ -234,6 +243,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
         `  ╚${bRow.slice(2)}╝`,
       ].join('\n');
       log.info(`\n${box}`);
+      clearInterval(heartbeat);
       agentRunStore.closeRun(runId);
       approvalStore.rejectAll();
       res.end();
@@ -353,8 +363,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
     res.flushHeaders();
-
-    // Send run metadata first so frontend can restore timer and model
+    res.socket?.setNoDelay(true);
     res.write(`data: ${JSON.stringify({
       type: 'run_meta',
       runId: run.runId,

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -208,10 +208,28 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
     } catch (err) {
       agentError = err;
       log.error('Desktop agent error:', err?.message || err);
+      // Suggest rollback to latest healthy snapshot
+      let rollbackSuggestion = null;
+      if (checkpointDir) {
+        try {
+          const latestStep = Math.max(completedStepCount, observedStepCount) - 1;
+          const snapshot = await loadLatestHealthySnapshot(checkpointDir, runId, latestStep);
+          if (snapshot) {
+            const lastStep = snapshot.history.length > 0 ? snapshot.history[snapshot.history.length - 1] : null;
+            rollbackSuggestion = {
+              step: snapshot.step,
+              lastAction: lastStep ? { type: lastStep.action?.type, tool: lastStep.action?.tool } : null,
+              lastRationale: lastStep?.rationale?.slice(0, 200) || null,
+              lastResult: lastStep?.result?.slice(0, 200) || null,
+            };
+          }
+        } catch { /* ignore snapshot load failure */ }
+      }
       sendEvent({
         type: 'error',
         runId,
         error: err.message,
+        rollbackSuggestion,
       });
     } finally {
       if (checkpointDir) {

--- a/server.js
+++ b/server.js
@@ -153,6 +153,7 @@ async function resumeFromCheckpoint(cp) {
       systemPrompt,
       headless,
       runId,
+      runRecord: agentRunStore.getRun(runId),
       startedAt,
       initialStep: step + 1,
       initialHistory: history,

--- a/test/session-checkpoint.test.js
+++ b/test/session-checkpoint.test.js
@@ -187,6 +187,8 @@ describe('runtime: session checkpoint integration', () => {
     const cpEvents = evtLog.filter(e => e.type === 'session_checkpoint');
     expect(cpEvents.map(e => e.step)).toEqual([1, 2, 3, 4, 5, 6, 7]);
 
+    // Snapshot save is fire-and-forget — wait for disk writes to complete
+    await new Promise(r => setTimeout(r, 200));
     const cp = await loadLatestHealthySnapshot(tmpDir, runId, 6);
     expect(cp).not.toBeNull();
     expect(cp.history.length).toBeGreaterThanOrEqual(5);
@@ -218,6 +220,9 @@ describe('runtime: session checkpoint integration', () => {
       execute: () => 'executed',
       cleanup: noop,
     });
+
+    // Snapshot save is fire-and-forget — wait for disk writes to complete
+    await new Promise(r => setTimeout(r, 200));
 
     // Verify step 2 snapshot exists
     const snap2 = await loadLatestHealthySnapshot(tmpDir, runId, 2);

--- a/test/session-checkpoint.test.js
+++ b/test/session-checkpoint.test.js
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  saveHealthySnapshot,
+  saveFailedSnapshot,
+  loadLatestHealthySnapshot,
+  listSessionCheckpoints,
+  clearSessionCheckpoints,
+  KEEP_HEALTHY,
+} from '../agent/core/session-checkpoint.js';
+import { runAgentRuntime } from '../agent/core/runtime.js';
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-checkpoint-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function makeHistory(steps) {
+  return steps.map(s => ({
+    step: s,
+    rationale: `step ${s} rationale`,
+    action: { type: 'click', elementId: `el-${s}` },
+    result: `step ${s} result`,
+  }));
+}
+
+// ─── session-checkpoint module tests ───
+
+describe('saveHealthySnapshot + loadLatestHealthySnapshot', () => {
+  it('writes snapshot to disk and loads it back', async () => {
+    const runId = 'run_test1';
+    const history = makeHistory([1, 2]);
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 2, history, state: null, result: 'ok' });
+
+    const cp = await loadLatestHealthySnapshot(tmpDir, runId, 2);
+    expect(cp).not.toBeNull();
+    expect(cp.step).toBe(2);
+    expect(cp.type).toBe('healthy');
+    expect(cp.history).toHaveLength(2);
+    expect(cp.history[0].step).toBe(1);
+    expect(cp.history[1].step).toBe(2);
+  });
+
+  it('loads the latest snapshot <= upToStep', async () => {
+    const runId = 'run_test2';
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 2, history: makeHistory([1, 2]), state: null, result: 'ok' });
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 4, history: makeHistory([1, 2, 3, 4]), state: null, result: 'ok' });
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 6, history: makeHistory([1, 2, 3, 4, 5, 6]), state: null, result: 'ok' });
+
+    const cp = await loadLatestHealthySnapshot(tmpDir, runId, 5);
+    expect(cp).not.toBeNull();
+    expect(cp.step).toBe(4);
+
+    const cp6 = await loadLatestHealthySnapshot(tmpDir, runId, 6);
+    expect(cp6.step).toBe(6);
+  });
+
+  it('returns null when no snapshot exists', async () => {
+    const cp = await loadLatestHealthySnapshot(tmpDir, 'run_nonexist', 5);
+    expect(cp).toBeNull();
+  });
+});
+
+describe('snapshot pruning', () => {
+  it('keeps only KEEP_HEALTHY most recent snapshots', async () => {
+    const runId = 'run_prune';
+    for (let s = 2; s <= 10; s += 2) {
+      await saveHealthySnapshot({ dir: tmpDir, runId, step: s, history: makeHistory([s]), state: null, result: 'ok' });
+    }
+
+    const cpDir = path.join(tmpDir, 'session-checkpoints', runId);
+    const files = await fs.readdir(cpDir);
+    const healthyFiles = files.filter(f => f.startsWith('session-healthy-') && f.endsWith('.json'));
+    expect(healthyFiles).toHaveLength(KEEP_HEALTHY);
+
+    const steps = healthyFiles.map(f => {
+      const m = f.match(/session-healthy-(\d+)\.json$/);
+      return m ? parseInt(m[1]) : 0;
+    }).sort((a, b) => a - b);
+    expect(steps).toEqual([6, 8, 10]);
+  });
+});
+
+describe('sanitizeState', () => {
+  it('removes sensitive fields from snapshot state', async () => {
+    const runId = 'run_sanitize';
+    const state = {
+      chromium: '/path/to/chrome',
+      browserCandidatePaths: ['/a', '/b'],
+      onEvent: () => {},
+      browserSession: { page: {} },
+      observeDesktop: true,
+      customField: 'keep this',
+    };
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 2, history: [], state, result: 'ok' });
+
+    const cp = await loadLatestHealthySnapshot(tmpDir, runId, 2);
+    expect(cp.state.chromium).toBeUndefined();
+    expect(cp.state.browserCandidatePaths).toBeUndefined();
+    expect(cp.state.onEvent).toBeUndefined();
+    expect(cp.state.browserSession).toBeUndefined();
+    expect(cp.state.observeDesktop).toBeUndefined();
+    expect(cp.state.browserSessionActive).toBe(true);
+    expect(cp.state.customField).toBe('keep this');
+  });
+});
+
+describe('listSessionCheckpoints', () => {
+  it('lists both healthy and failed checkpoints sorted by step', async () => {
+    const runId = 'run_list';
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 2, history: [], state: null, result: 'ok' });
+    await saveFailedSnapshot({ dir: tmpDir, runId, step: 5, history: [], error: new Error('boom'), state: null });
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 4, history: [], state: null, result: 'ok' });
+
+    const list = await listSessionCheckpoints(tmpDir, runId);
+    expect(list).toHaveLength(3);
+    expect(list[0].step).toBe(2);
+    expect(list[0].type).toBe('healthy');
+    expect(list[1].step).toBe(4);
+    expect(list[2].step).toBe(5);
+    expect(list[2].type).toBe('failed');
+    expect(list[2].error).toBe('boom');
+  });
+});
+
+describe('clearSessionCheckpoints', () => {
+  it('removes the entire checkpoint directory', async () => {
+    const runId = 'run_clear';
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 2, history: [], state: null, result: 'ok' });
+
+    const cpDir = path.join(tmpDir, 'session-checkpoints', runId);
+    await fs.access(cpDir);
+
+    await clearSessionCheckpoints(tmpDir, runId);
+    await expect(fs.access(cpDir)).rejects.toThrow();
+  });
+});
+
+// ─── runtime integration tests ───
+
+function noop() {}
+const events = () => {
+  const log = [];
+  return { log, onEvent: e => log.push(e) };
+};
+
+describe('runtime: session checkpoint integration', () => {
+  it('saves snapshots at interval steps', async () => {
+    const runId = 'run_rt2';
+    const runRecord = { runId, pendingRollback: null };
+    const { log: evtLog, onEvent } = events();
+    const cancelSignal = new AbortController().signal;
+
+    let stepCount = 0;
+    await runAgentRuntime({
+      task: 'test',
+      maxSteps: 7,
+      onEvent,
+      cancelSignal,
+      sessionCheckpointDir: tmpDir,
+      runRecord,
+      initialize: noop,
+      observe: noop,
+      decide: () => {
+        stepCount++;
+        if (stepCount >= 7) {
+          return { action: { type: 'finish', answer: 'all done' }, rationale: 'enough' };
+        }
+        return { action: { type: 'click', elementId: 'btn' }, rationale: 'go' };
+      },
+      authorize: noop,
+      execute: () => 'executed',
+      cleanup: noop,
+    });
+
+    // HEALTH_CHECKPOINT_INTERVAL = 2, steps 2,4,6 should have snapshots
+    const cpEvents = evtLog.filter(e => e.type === 'session_checkpoint');
+    expect(cpEvents.map(e => e.step)).toEqual([2, 4, 6]);
+
+    const cp = await loadLatestHealthySnapshot(tmpDir, runId, 6);
+    expect(cp).not.toBeNull();
+    expect(cp.history.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('manual rollback restores snapshot history and continues', async () => {
+    const runId = 'run_rt3';
+    const cancelSignal = new AbortController().signal;
+
+    // First run: create checkpoints up to step 6
+    let stepCount = 0;
+    await runAgentRuntime({
+      task: 'test',
+      maxSteps: 7,
+      onEvent: noop,
+      cancelSignal,
+      sessionCheckpointDir: tmpDir,
+      runRecord: { runId, pendingRollback: null },
+      initialize: noop,
+      observe: noop,
+      decide: () => {
+        stepCount++;
+        if (stepCount >= 7) {
+          return { action: { type: 'finish', answer: 'done' }, rationale: 'enough' };
+        }
+        return { action: { type: 'click', elementId: 'btn' }, rationale: 'go' };
+      },
+      authorize: noop,
+      execute: () => 'executed',
+      cleanup: noop,
+    });
+
+    // Verify step 2 snapshot exists
+    const snap2 = await loadLatestHealthySnapshot(tmpDir, runId, 2);
+    expect(snap2).not.toBeNull();
+    expect(snap2.step).toBe(2);
+
+    // Second run: rollback to step 2
+    const runRecord2 = { runId, pendingRollback: 2 };
+    const { log: evtLog2, onEvent: onEvent2 } = events();
+    stepCount = 0;
+
+    const result = await runAgentRuntime({
+      task: 'test',
+      maxSteps: 8,
+      onEvent: onEvent2,
+      cancelSignal,
+      sessionCheckpointDir: tmpDir,
+      runRecord: runRecord2,
+      initialStep: 1,
+      initialHistory: makeHistory([1, 2, 3, 4]),
+      initialize: noop,
+      observe: noop,
+      decide: () => {
+        stepCount++;
+        if (stepCount >= 3) {
+          return { action: { type: 'finish', answer: 'rolled back' }, rationale: 'done' };
+        }
+        return { action: { type: 'click', elementId: 'btn' }, rationale: 'retry' };
+      },
+      authorize: noop,
+      execute: () => 'executed',
+      cleanup: noop,
+    });
+
+    const rollbackEvent = evtLog2.find(e => e.type === 'rollback');
+    expect(rollbackEvent).toBeDefined();
+    expect(rollbackEvent.targetStep).toBe(2);
+    expect(runRecord2.pendingRollback).toBeNull();
+    expect(runRecord2.rolledBack).toBe(true);
+    expect(result.answer).toBe('rolled back');
+  });
+
+  it('rollback to nonexistent snapshot clears pendingRollback and continues', async () => {
+    const runId = 'run_rt4';
+    const runRecord = { runId, pendingRollback: 99 };
+    const { log: evtLog, onEvent } = events();
+    const cancelSignal = new AbortController().signal;
+
+    const result = await runAgentRuntime({
+      task: 'test',
+      maxSteps: 3,
+      onEvent,
+      cancelSignal,
+      sessionCheckpointDir: tmpDir,
+      runRecord,
+      initialize: noop,
+      observe: noop,
+      decide: () => ({ action: { type: 'finish', answer: 'done' }, rationale: 'ok' }),
+      authorize: noop,
+      execute: noop,
+      cleanup: noop,
+    });
+
+    expect(runRecord.pendingRollback).toBeNull();
+    expect(evtLog.some(e => e.type === 'rollback')).toBe(false);
+    // Runtime returns result, it doesn't emit 'done' event itself
+    expect(result.answer).toBe('done');
+  });
+});

--- a/test/session-checkpoint.test.js
+++ b/test/session-checkpoint.test.js
@@ -71,7 +71,8 @@ describe('saveHealthySnapshot + loadLatestHealthySnapshot', () => {
 describe('snapshot pruning', () => {
   it('keeps only KEEP_HEALTHY most recent snapshots', async () => {
     const runId = 'run_prune';
-    for (let s = 2; s <= 10; s += 2) {
+    // Save more than KEEP_HEALTHY snapshots
+    for (let s = 1; s <= 40; s++) {
       await saveHealthySnapshot({ dir: tmpDir, runId, step: s, history: makeHistory([s]), state: null, result: 'ok' });
     }
 
@@ -84,7 +85,9 @@ describe('snapshot pruning', () => {
       const m = f.match(/session-healthy-(\d+)\.json$/);
       return m ? parseInt(m[1]) : 0;
     }).sort((a, b) => a - b);
-    expect(steps).toEqual([6, 8, 10]);
+    // Should keep the latest KEEP_HEALTHY steps
+    expect(steps[0]).toBe(40 - KEEP_HEALTHY + 1);
+    expect(steps[steps.length - 1]).toBe(40);
   });
 });
 
@@ -180,9 +183,9 @@ describe('runtime: session checkpoint integration', () => {
       cleanup: noop,
     });
 
-    // HEALTH_CHECKPOINT_INTERVAL = 2, steps 2,4,6 should have snapshots
+    // HEALTH_CHECKPOINT_INTERVAL = 1, every step gets a snapshot (including the finish step)
     const cpEvents = evtLog.filter(e => e.type === 'session_checkpoint');
-    expect(cpEvents.map(e => e.step)).toEqual([2, 4, 6]);
+    expect(cpEvents.map(e => e.step)).toEqual([1, 2, 3, 4, 5, 6, 7]);
 
     const cp = await loadLatestHealthySnapshot(tmpDir, runId, 6);
     expect(cp).not.toBeNull();


### PR DESCRIPTION
## Summary

- 会话级健康快照：每步自动保存完整 history + state，支持回滚到任意步
- 内联回滚按钮：trace 中每个快照事件旁有 rewind 按钮，运行中/完成后均可回滚
- 失败自动推荐回滚：模型全部失败时自动建议回滚到最近健康快照，显示步骤上下文
- SSE 事件去重：防止重连后重复渲染步骤
- 运行后 runId 恢复：页面刷新/后端重启后仍可回滚
- 非阻塞快照写入：后台写磁盘不卡主流程
- 第一步跳过观察：直接让 LLM 处理用户任务

Closes #99
Related #134 (Agent 快照与回滚)
Related #117 (自愈 Agent — 错误后自动恢复)