### PR TITLE
fix: race-mode abort losing models, replace cancel polling with AbortSignal

### DIFF
--- a/agent/core/planner.js
+++ b/agent/core/planner.js
@@ -38,9 +38,9 @@ export function createJsonPlanner({
       max_tokens: maxTokens,
       messages,
     };
-    if (signal) createOpts.signal = signal;
+    const reqOpts = signal ? { signal } : undefined;
 
-    const response = await retryAsync(() => client.chat.completions.create(createOpts));
+    const response = await retryAsync(() => client.chat.completions.create(createOpts, reqOpts));
 
     logLlmResponse(model, response);
 
@@ -72,9 +72,8 @@ export function createJsonPlanner({
         max_tokens: maxTokens,
         messages: retryMessages,
       };
-      if (signal) retryOpts.signal = signal;
 
-      const retryResponse = await retryAsync(() => client.chat.completions.create(retryOpts));
+      const retryResponse = await retryAsync(() => client.chat.completions.create(retryOpts, reqOpts));
       const retryParsed = parser(retryResponse);
 
       if (!retryParsed.parseFailed) {

--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -47,7 +47,7 @@ export async function runAgentRuntime({
   task,
   maxSteps = 8,
   onEvent,
-  isCancelled,
+  cancelSignal,
   initialize,
   observe,
   decide,
@@ -63,9 +63,11 @@ export async function runAgentRuntime({
   let finalAnswer = "";
   const state = await initialize?.({ task, onEvent });
 
+  const cancelled = () => cancelSignal?.aborted;
+
   try {
     for (let step = initialStep; step <= maxSteps; step += 1) {
-      if (isCancelled?.()) {
+      if (cancelled()) {
         throw new Error("Agent 已取消");
       }
 
@@ -99,7 +101,7 @@ export async function runAgentRuntime({
         state,
       });
 
-      if (isCancelled?.()) {
+      if (cancelled()) {
         throw new Error("Agent 已取消");
       }
 
@@ -154,7 +156,7 @@ export async function runAgentRuntime({
         log.error(`[Runtime] step ${step} execute error: ${execErr.message}`);
       }
 
-      if (isCancelled?.()) {
+      if (cancelled()) {
         throw new Error("Agent 已取消");
       }
 

--- a/agent/desktop/agent.js
+++ b/agent/desktop/agent.js
@@ -131,19 +131,18 @@ function toolUseToNormalizedDecision(toolUse) {
   return normalizeDesktopAgentDecision({ action });
 }
 
-async function singleModelPlan({ model, openai_client, anthropic_client, modelConfig, isCancelled, ...context }) {
-  if (isCancelled?.()) throw new Error('Agent 已取消');
+async function singleModelPlan({ model, openai_client, anthropic_client, modelConfig, cancelSignal, raceSignal, ...context }) {
+  if (cancelSignal?.aborted) throw new Error('Agent 已取消');
 
-  // Create an AbortController that fires when isCancelled becomes true
+  // Create an AbortController that fires on user cancel OR race winner
   const ac = new AbortController();
-  let cancelTimer = null;
-  if (isCancelled) {
-    cancelTimer = setInterval(() => {
-      if (isCancelled()) {
-        ac.abort();
-        clearInterval(cancelTimer);
-      }
-    }, 200);
+  const onUserCancel = () => ac.abort();
+  const onRaceAbort = () => ac.abort();
+  if (cancelSignal) {
+    if (cancelSignal.aborted) { ac.abort(); } else { cancelSignal.addEventListener('abort', onUserCancel); }
+  }
+  if (raceSignal) {
+    if (raceSignal.aborted) { ac.abort(); } else { raceSignal.addEventListener('abort', onRaceAbort); }
   }
 
   try {
@@ -179,7 +178,8 @@ async function singleModelPlan({ model, openai_client, anthropic_client, modelCo
       return { ...result, model };
     }
   } finally {
-    if (cancelTimer) clearInterval(cancelTimer);
+    if (cancelSignal) cancelSignal.removeEventListener('abort', onUserCancel);
+    if (raceSignal) raceSignal.removeEventListener('abort', onRaceAbort);
   }
 }
 
@@ -251,7 +251,7 @@ function aggregateResults(modelResults) {
 const DEFAULT_MODEL_TIMEOUT_MS = 10_000;
 
 function buildDesktopPlanner({ openai_client, anthropic_client, modelConfig, blacklistedModels, modelTimeoutMs = DEFAULT_MODEL_TIMEOUT_MS, staggerDelayMs = 0, batchSize = 1 }) {
-  function planWithTimeout(model, context, isCancelled) {
+  function planWithTimeout(model, context, cancelSignal, raceSignal) {
     const timeoutMs = typeof modelTimeoutMs === 'number' && modelTimeoutMs > 0 ? modelTimeoutMs : DEFAULT_MODEL_TIMEOUT_MS;
     const shortModel = model.split('/').pop();
     const startTime = Date.now();
@@ -263,7 +263,7 @@ function buildDesktopPlanner({ openai_client, anthropic_client, modelConfig, bla
       timer = setTimeout(() => reject(new Error(`模型超时 (${Math.round(timeoutMs / 1000)}s)`)), timeoutMs);
     });
     return Promise.race([
-      singleModelPlan({ model, openai_client, anthropic_client, modelConfig, isCancelled, ...context }),
+      singleModelPlan({ model, openai_client, anthropic_client, modelConfig, cancelSignal, raceSignal, ...context }),
       timeout,
     ])
       .then(result => {
@@ -276,15 +276,21 @@ function buildDesktopPlanner({ openai_client, anthropic_client, modelConfig, bla
       })
       .catch(err => {
         const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-        const errLine = `  !!! LLM FAILED   ${shortModel}  ${elapsed}s  ${err.message.slice(0, 60)}`;
-        const ew = Math.max(displayWidth(errLine) + 4, 52);
-        log.warn(`\n  ${'╔' + '═'.repeat(ew) + '╗'}\n  ║${padEndW(errLine, ew)}║\n  ${'╚' + '═'.repeat(ew) + '╝'}`);
+        if (err.name === 'AbortError' || err.message?.includes('aborted')) {
+          const line = `  ··· RACE_ABORT  ${shortModel}  ${elapsed}s`;
+          const w = Math.max(displayWidth(line) + 4, 52);
+          log.info(`\n  ${'╔' + '═'.repeat(w) + '╗'}\n  ║${padEndW(line, w)}║\n  ${'╚' + '═'.repeat(w) + '╝'}`);
+        } else {
+          const errLine = `  !!! LLM FAILED   ${shortModel}  ${elapsed}s  ${err.message.slice(0, 60)}`;
+          const ew = Math.max(displayWidth(errLine) + 4, 52);
+          log.warn(`\n  ${'╔' + '═'.repeat(ew) + '╗'}\n  ║${padEndW(errLine, ew)}║\n  ${'╚' + '═'.repeat(ew) + '╝'}`);
+        }
         throw err;
       })
       .finally(() => clearTimeout(timer));
   }
 
-  return async ({ model, agentModels, strategy = 'race', onEvent, isCancelled, step, ...context }) => {
+  return async ({ model, agentModels, strategy = 'race', onEvent, cancelSignal, step, ...context }) => {
     const extraModels = Array.isArray(agentModels) && agentModels.length > 1
       ? agentModels.filter(m => m !== model)
       : [];
@@ -299,7 +305,7 @@ function buildDesktopPlanner({ openai_client, anthropic_client, modelConfig, bla
       }
       onEvent?.({ type: 'model_plan', stage: 'thinking', model, step });
       try {
-        const result = await planWithTimeout(model, planCtx, isCancelled);
+        const result = await planWithTimeout(model, planCtx, cancelSignal, undefined);
         onEvent?.({ type: 'model_plan', stage: 'success', model, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
         return result;
       } catch (err) {
@@ -340,7 +346,7 @@ function buildDesktopPlanner({ openai_client, anthropic_client, modelConfig, bla
 
       const settled = await Promise.allSettled(
         activeModels.map(m =>
-	          planWithTimeout(m, planCtx, isCancelled)
+	          planWithTimeout(m, planCtx, cancelSignal, undefined)
             .then(result => {
               log.debug(`[MultiModel] step=${step} model=${m} succeeded: ${result.action?.tool}.${result.action?.type}`);
               onEvent?.({ type: 'model_plan', stage: 'success', model: m, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
@@ -396,18 +402,20 @@ function buildDesktopPlanner({ openai_client, anthropic_client, modelConfig, bla
       let launched = 0;
       const failures = [];
       const timers = [];
+      const raceAc = new AbortController();
 
       function launchModel(m) {
-        if (settled || isCancelled()) return;
+        if (settled || cancelSignal.aborted) return;
         launched++;
         onEvent?.({ type: 'model_plan', stage: 'thinking', model: m, step });
-        planWithTimeout(m, planCtx, isCancelled)
+        planWithTimeout(m, planCtx, cancelSignal, raceAc.signal)
           .then(result => {
             if (settled) {
               onEvent?.({ type: 'model_plan', stage: 'cancelled', model: m, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
               return;
             }
             settled = true;
+            raceAc.abort();
             timers.forEach(t => clearTimeout(t));
             log.info(`[MultiModel] 使用 ${m} 的结果（${activeModels.join(', ')}）`);
             onEvent?.({ type: 'model_plan', stage: 'winner', model: m, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
@@ -437,7 +445,7 @@ function buildDesktopPlanner({ openai_client, anthropic_client, modelConfig, bla
 
       let nextIndex = 0;
       function tryLaunchBatch(skipDelay = false) {
-        if (settled || isCancelled() || nextIndex >= activeModels.length) return;
+        if (settled || cancelSignal.aborted || nextIndex >= activeModels.length) return;
 
         const isFirstBatch = nextIndex === 0;
         const batch = activeModels.slice(nextIndex, nextIndex + batchSize);
@@ -593,7 +601,7 @@ export function createDesktopAgentRunner({
     systemPrompt = null,
     headless = defaultHeadless,
     onEvent,
-    isCancelled,
+    cancelSignal,
     runId,
     startedAt = Date.now(),
     initialStep = 1,
@@ -614,7 +622,7 @@ export function createDesktopAgentRunner({
       task,
       maxSteps,
       onEvent,
-      isCancelled,
+      cancelSignal,
       initialStep,
       initialHistory,
       onCheckpoint: checkpointDir
@@ -640,7 +648,7 @@ export function createDesktopAgentRunner({
           agentModels,
           strategy,
           onEvent,
-          isCancelled,
+          cancelSignal,
           task: currentTask,
           systemPrompt,
           step,

--- a/helpers/agent-logging.js
+++ b/helpers/agent-logging.js
@@ -16,7 +16,9 @@ export function buildAgentMetrics(startedAt, { stepCount = 0, status = 'done' } 
 
 export function buildSseWriter(res) {
   return payload => {
-    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    if (!res.writableEnded) {
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    }
   };
 }
 

--- a/helpers/run-store.js
+++ b/helpers/run-store.js
@@ -42,7 +42,7 @@ export function createAgentRunStore() {
       const record = {
         runId,
         startedAt,
-        cancelled: false,
+        cancelAc: new AbortController(),
         events: [],
         status: 'running',
         meta,
@@ -59,7 +59,7 @@ export function createAgentRunStore() {
      */
     getActiveRun() {
       for (const run of runs.values()) {
-        if (run.status === 'running' && !run.cancelled) {
+        if (run.status === 'running' && !run.cancelAc.signal.aborted) {
           return run;
         }
       }
@@ -85,7 +85,7 @@ export function createAgentRunStore() {
     cancelRun(runId) {
       const run = getRun(runId);
       if (!run) return;
-      run.cancelled = true;
+      run.cancelAc.abort();
     },
 
     /**

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -156,7 +156,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
         headless: agentHeadless,
         runId,
         onEvent: sendEvent,
-        isCancelled: () => runRecord.cancelled,
+        cancelSignal: runRecord.cancelAc.signal,
         conversationHistory: Array.isArray(conversationHistory) ? conversationHistory : [],
         memory: useMemory,
       });
@@ -343,7 +343,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
 
     // Register writer BEFORE snapshotting to avoid event gap
     let writer = null;
-    if (run.status === 'running' && !run.cancelled) {
+    if (run.status === 'running' && !run.cancelAc.signal.aborted) {
       writer = payload => {
         if (!res.writableEnded) {
           res.write(`data: ${JSON.stringify(payload)}\n\n`);
@@ -365,7 +365,7 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
       res.write(`data: ${JSON.stringify(run.events[i])}\n\n`);
     }
 
-    if (run.status !== 'running' || run.cancelled) {
+    if (run.status !== 'running' || run.cancelAc.signal.aborted) {
       res.end();
     }
   });


### PR DESCRIPTION
## Summary

- **Race 模式胜出后 abort 其他模型**：winner 决出后 `raceAc.abort()` 取消仍在运行的模型 HTTP 请求，节省 API 配额和响应时间
- **取消轮询改为事件驱动**：`isCancelled` 函数 → `cancelSignal` (AbortSignal)，`singleModelPlan` 通过 `addEventListener` 监听，不再 `setInterval` 每 200ms 轮询
- **修复 NVIDIA API 400 错误**：`planner.js` 中 `signal` 从请求 body 移到 RequestOptions 第二参数
- **修复 ERR_STREAM_WRITE_AFTER_END 崩溃**：abort 事件可能晚于 `res.end()`，`buildSseWriter` 加 `writableEnded` 检查
- **Race abort 日志优化**：abort 显示 `··· RACE_ABORT` (info)，不再误报 `!!! LLM FAILED` (warn)

## Test plan

- [ ] `npm test` 通过
- [ ] 后端 `npx eslint .` 0 errors
- [ ] Race 模式下 winner 后其他模型立即取消，日志显示 RACE_ABORT
- [ ] 用户取消 Agent 正常工作
- [ ] NVIDIA 模型不再报 400 signal 错误