### PR TITLE
fix: context truncation, memory cleanup API, bot detection

### DIFF
--- a/agent/core/memory.js
+++ b/agent/core/memory.js
@@ -282,3 +282,16 @@ export async function compactConversationMemory(memory, { maxEntries = MAX_CONVE
   memory.conversation = conv.slice(-maxEntries);
   memory.lastCompactedAt = new Date().toISOString();
 }
+
+export async function clearMemory(dir) {
+  const fresh = emptyMemory();
+  await saveMemory(dir, fresh);
+  return fresh;
+}
+
+export async function clearProjectKnowledge(dir) {
+  const memory = await loadMemory(dir);
+  memory.projectKnowledge = emptyMemory().projectKnowledge;
+  await saveMemory(dir, memory);
+  return memory;
+}

--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -28,11 +28,23 @@ import {
   HEALTH_CHECKPOINT_INTERVAL,
 } from "./session-checkpoint.js";
 
-const MAX_HISTORY_STEPS = 64;
+const MAX_HISTORY_STEPS = 20;
+const MAX_RESULT_CHARS = 1000;
 
 function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
+  // Always truncate result fields to limit context size
+  const truncateEntry = (h) => {
+    if (h.result && typeof h.result === 'string' && h.result.length > MAX_RESULT_CHARS) {
+      return { ...h, result: h.result.slice(0, MAX_RESULT_CHARS) + '…[truncated]' };
+    }
+    if (h.result != null && typeof h.result !== 'string' && String(h.result).length > MAX_RESULT_CHARS) {
+      return { ...h, result: String(h.result).slice(0, MAX_RESULT_CHARS) + '…[truncated]' };
+    }
+    return h;
+  };
+
   if (history.length <= maxSteps) {
-    return history;
+    return history.map(truncateEntry);
   }
   const recent = history.slice(-maxSteps);
   const dropped = history.slice(0, -maxSteps);
@@ -48,7 +60,7 @@ function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
       type: "summary",
       text: `历史摘要（共${dropped.length}步）: ${summary}`,
     },
-    ...recent,
+    ...recent.map(truncateEntry),
   ];
 }
 

--- a/agent/core/runtime.js
+++ b/agent/core/runtime.js
@@ -12,6 +12,13 @@
  *   5. execute()     — 执行动作（路由到 browser/fs/terminal/macos 工具）
  *   6. 回到步骤 2，直到 decide 返回 finish 或达到 maxSteps
  *
+ * 历史截断 / Progressive history truncation：
+ *   compressHistory() 发给 LLM 前截断历史，防止上下文超限：
+ *   - 保留最近 AGENT_MAX_HISTORY_STEPS（默认 20）步
+ *   - 渐进截断 result：最近 3 步保留最多 1000 字符，4-10 步 500 字符，11+ 步 200 字符
+ *   - 超出步数压缩为一行摘要
+ *   - 可通过 .env 的 AGENT_MAX_HISTORY_STEPS / AGENT_MAX_RESULT_CHARS 配置
+ *
  * 调用场景：
  *   - agent/desktop/agent.js 的 runDesktopAgent() 是唯一的调用方，
  *     注入所有具体实现后调用 runAgentRuntime({ ... })
@@ -28,30 +35,30 @@ import {
   HEALTH_CHECKPOINT_INTERVAL,
 } from "./session-checkpoint.js";
 
-const MAX_HISTORY_STEPS = 20;
-const MAX_RESULT_CHARS = 1000;
+const MAX_HISTORY_STEPS = Number(process.env.AGENT_MAX_HISTORY_STEPS || 20);
+const MAX_RESULT_CHARS = Number(process.env.AGENT_MAX_RESULT_CHARS || 1000);
 
 function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
-  // Always truncate result fields to limit context size
-  const truncateEntry = (h) => {
-    if (h.result && typeof h.result === 'string' && h.result.length > MAX_RESULT_CHARS) {
-      return { ...h, result: h.result.slice(0, MAX_RESULT_CHARS) + '…[truncated]' };
-    }
-    if (h.result != null && typeof h.result !== 'string' && String(h.result).length > MAX_RESULT_CHARS) {
-      return { ...h, result: String(h.result).slice(0, MAX_RESULT_CHARS) + '…[truncated]' };
-    }
-    return h;
+  // Progressive truncation: recent steps keep more context, old steps get shorter results
+  const truncateEntry = (h, remaining) => {
+    // Last 3 steps: full (up to MAX_RESULT_CHARS)
+    // Steps 4-10: 500 chars
+    // Steps 11+: 200 chars
+    const limit = remaining <= 3 ? MAX_RESULT_CHARS : remaining <= 10 ? 500 : 200;
+    const str = h.result == null ? '' : String(h.result);
+    if (str.length <= limit) return h;
+    return { ...h, result: str.slice(0, limit) + '…[truncated]' };
   };
 
   if (history.length <= maxSteps) {
-    return history.map(truncateEntry);
+    return history.map((h, i) => truncateEntry(h, history.length - i));
   }
   const recent = history.slice(-maxSteps);
   const dropped = history.slice(0, -maxSteps);
   const summary = dropped
     .map(
       (h) =>
-        `step ${h.step}: [${h.action?.type ?? "?"}] ${h.result ? `→ ${String(h.result).slice(0, 1000)}` : ""}`,
+        `step ${h.step}: [${h.action?.type ?? "?"}] ${h.result ? `→ ${String(h.result).slice(0, 200)}` : ""}`,
     )
     .join(" | ");
   return [
@@ -60,7 +67,7 @@ function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
       type: "summary",
       text: `历史摘要（共${dropped.length}步）: ${summary}`,
     },
-    ...recent.map(truncateEntry),
+    ...recent.map((h, i) => truncateEntry(h, recent.length - i)),
   ];
 }
 

--- a/agent/tools/fetch/execute.js
+++ b/agent/tools/fetch/execute.js
@@ -1,3 +1,20 @@
+/**
+ * Fetch — HTTP 抓取工具，支持 curl 轻量抓取和 Playwright 浏览器渲染两种模式
+ *
+ * 执行策略：
+ *   1. 已知需要浏览器的域名（domain-rules.js）→ 直接走 fetchWithBrowser
+ *   2. 其余域名 → 先 curl，检测反爬响应 → fallback 到浏览器
+ *   3. 浏览器也触发反爬 → 返回明确错误，提示 agent 换方式
+ *   4. parallel_fetch：多个 URL 并发抓取，结果用 --- 分隔
+ *
+ * 反爬检测（domain-rules.js BOT_SIGNALS）：
+ *   curl 和浏览器返回的内容都经 detectBotResponse 检测，
+ *   匹配到验证页关键词时不再静默返回，而是报错让 agent 采取替代方案。
+ *
+ * 调用场景：
+ *   - agent/desktop/agent.js routeAction → executeFetchAction()
+ */
+
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createBrowserSession, closeBrowserSession } from '../browser/webview-session.js';
@@ -156,7 +173,12 @@ async function executeSingleFetch(action, browserSession, domainRules) {
 
   if (useBrowser) {
     try {
-      return await fetchWithBrowser(browserSession, action);
+      const result = await fetchWithBrowser(browserSession, action);
+      if (domainRules && await domainRules.detectBotResponse(result)) {
+        log.info(`[Fetch] 浏览器也触发反爬: ${action.url}`);
+        return `http_fetch ${action.url}: 页面要求人机验证（反爬机制），无法获取内容。请尝试其他方式获取信息。`;
+      }
+      return result;
     } catch (err) {
       log.warn(`[Fetch] WebView 访问失败: ${(err.message || '').slice(0, 80)}`);
       return `http_fetch ${action.url}: 浏览器访问失败 (${(err.message || '').slice(0, 100)})。`;
@@ -170,10 +192,16 @@ async function executeSingleFetch(action, browserSession, domainRules) {
       if (isBot) {
         log.info(`[Fetch] 检测到反爬机制: ${action.url}`);
         await domainRules.markBrowserDomain(action.url);
-        try {
-          return await fetchWithBrowser(browserSession, action);
-        } catch {
-          /* fall through to curl result */
+        if (browserSession) {
+          try {
+            const browserResult = await fetchWithBrowser(browserSession, action);
+            if (await domainRules.detectBotResponse(browserResult)) {
+              return `http_fetch ${action.url}: 页面要求人机验证（反爬机制），无法获取内容。请尝试其他方式获取信息。`;
+            }
+            return browserResult;
+          } catch {
+            /* fall through to curl result */
+          }
         }
       }
     }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1518,6 +1518,7 @@ textarea {
 
 .model-plan-group {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   gap: 6px;
   width: 100%;
@@ -1528,7 +1529,18 @@ textarea {
   min-width: 0;
   display: flex;
   gap: 6px;
-  flex-wrap: wrap;
+}
+
+.model-plan-collapsed {
+  flex-basis: 100%;
+  font-size: var(--f-xs);
+  color: var(--c-text-tertiary);
+}
+
+.model-plan-collapsed .collapsed-summary {
+  cursor: pointer;
+  padding: 2px 0;
+  color: var(--c-text-secondary);
 }
 
 .model-card {
@@ -2713,11 +2725,34 @@ textarea:disabled {
   padding: 8px 0;
   border-top: 1px solid var(--c-border);
   margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
+.memory-clear-group {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.memory-clear-btn {
+  padding: 4px 8px;
+  font-size: 10px;
+  color: #6b7280;
+  background: #f3f4f6;
+  border: 1px solid #d1d5db;
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.memory-clear-btn:hover { background: #e5e7eb; }
+.memory-clear-btn.danger { color: #dc2626; border-color: #fca5a5; }
+.memory-clear-btn.danger:hover { background: #fef2f2; }
+
 .memory-compact-btn {
-  width: 100%;
-  padding: 6px;
+  padding: 6px 12px;
   font-size: 11px;
   font-weight: 500;
   color: #6d28d9;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1180,13 +1180,16 @@ function ModelPlanGroup({ trace, step, models, modelList, running }) {
     return ev;
   };
 
+  const visibleModels = models.filter(m => { const s = getEvent(m).stage; return s !== 'cancelled' && s !== 'failed'; });
+  const collapsedModels = models.filter(m => { const s = getEvent(m).stage; return s === 'cancelled' || s === 'failed'; });
+
   return (
     <div className="model-plan-group">
       <span className="agent-trace-badge plan">
         {strategyMode === 'vote' ? '投票' : '决策'}
       </span>
       <div className="model-plan-cards">
-        {models.map(m => (
+        {visibleModels.map(m => (
           <ModelPlanCard
             key={m}
             event={getEvent(m)}
@@ -1197,6 +1200,23 @@ function ModelPlanGroup({ trace, step, models, modelList, running }) {
           />
         ))}
       </div>
+      {collapsedModels.length > 0 && (
+        <details className="model-plan-collapsed">
+          <summary className="collapsed-summary">{collapsedModels.length} 个模型已取消/失败</summary>
+          <div className="model-plan-cards">
+            {collapsedModels.map(m => (
+              <ModelPlanCard
+                key={m}
+                event={getEvent(m)}
+                isWinner={false}
+                modelList={modelList}
+                strategy={strategyMode}
+                result={null}
+              />
+            ))}
+          </div>
+        </details>
+      )}
     </div>
   );
 }
@@ -1228,6 +1248,18 @@ function MemoryPanel({ onClose }) {
     } finally {
       setCompacting(false);
     }
+  };
+
+  const handleClear = async (url) => {
+    if (!confirm('确定要清空吗？此操作不可撤销。')) return;
+    try {
+      const r = await fetch(url, { method: 'DELETE' });
+      const result = await r.json();
+      if (result.ok) {
+        const r2 = await fetch('/api/agent/memory');
+        setData(await r2.json());
+      }
+    } catch { /* ignore */ }
   };
 
   const pk = data?.projectKnowledge || {};
@@ -1313,6 +1345,14 @@ function MemoryPanel({ onClose }) {
         <button className="memory-compact-btn" onClick={handleCompact} disabled={compacting}>
           {compacting ? '压缩中…' : '压缩历史'}
         </button>
+        <div className="memory-clear-group">
+          <button className="memory-clear-btn" onClick={() => handleClear('/api/agent/memory/knowledge')} title="清空项目知识，保留对话">
+            清空知识
+          </button>
+          <button className="memory-clear-btn danger" onClick={() => handleClear('/api/agent/memory')} title="清空全部记忆">
+            清空全部
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -2351,7 +2391,8 @@ export default function App() {
       setInput('');
       setAgentTrace([]);
     } else {
-      // Retry from checkpoint — update chat placeholder to show re-executing
+      // Retry from checkpoint — clear old trace, update chat placeholder
+      setAgentTrace([]);
       updateSession(sessionId, session => {
         const msgs = [...session.messages];
         msgs.push({ role: 'assistant', content: 'Desktop Agent 正在从检查点重新执行任务…', ts: Date.now() });
@@ -2422,10 +2463,17 @@ export default function App() {
             setAgentTrace(prev => {
               updateSession(sessionId, session => {
                 const nextMessages = [...session.messages];
-                nextMessages[nextMessages.length - 1] = {
-                  role: 'assistant',
-                  content: event.answer || 'Agent 已完成任务。',
-                };
+                const lastMsg = nextMessages[nextMessages.length - 1];
+                // Keep retry placeholder, append result as new message
+                if (lastMsg?.content?.includes('从检查点')) {
+                  nextMessages.push({ role: 'assistant', content: event.answer || 'Agent 已完成任务。', ts: Date.now() });
+                } else {
+                  nextMessages[nextMessages.length - 1] = {
+                    role: 'assistant',
+                    content: event.answer || 'Agent 已完成任务。',
+                    ts: Date.now(),
+                  };
+                }
                 return touchSession(session, { messages: nextMessages, agentTrace: prev });
               });
               return prev;
@@ -2436,10 +2484,16 @@ export default function App() {
             setAgentTrace(prev => {
               updateSession(sessionId, session => {
                 const nextMessages = [...session.messages];
-                nextMessages[nextMessages.length - 1] = {
-                  role: 'assistant',
-                  content: `⚠️ Desktop Agent 失败：${event.error}`,
-                };
+                const lastMsg = nextMessages[nextMessages.length - 1];
+                if (lastMsg?.content?.includes('从检查点')) {
+                  nextMessages.push({ role: 'assistant', content: `⚠️ Desktop Agent 失败：${event.error}`, ts: Date.now() });
+                } else {
+                  nextMessages[nextMessages.length - 1] = {
+                    role: 'assistant',
+                    content: `⚠️ Desktop Agent 失败：${event.error}`,
+                    ts: Date.now(),
+                  };
+                }
                 return touchSession(session, { messages: nextMessages, agentTrace: prev });
               });
               return prev;
@@ -2477,9 +2531,9 @@ export default function App() {
             if (lastIdx >= 0 && msgs[lastIdx].role === 'assistant' && msgs[lastIdx].content.includes('正在执行任务')) {
               const next = [...msgs];
               if (doneEvent) {
-                next[lastIdx] = { role: 'assistant', content: doneEvent.answer || 'Agent 已完成任务。' };
+                next[lastIdx] = { role: 'assistant', content: doneEvent.answer || 'Agent 已完成任务。', ts: Date.now() };
               } else {
-                next[lastIdx] = { role: 'assistant', content: `⚠️ Desktop Agent 失败：${errorEvent.error || '连接中断'}` };
+                next[lastIdx] = { role: 'assistant', content: `⚠️ Desktop Agent 失败：${errorEvent.error || '连接中断'}`, ts: Date.now() };
               }
               return touchSession(session, { messages: next, agentTrace: prev });
             }
@@ -2492,7 +2546,7 @@ export default function App() {
             const lastIdx = msgs.length - 1;
             if (lastIdx >= 0 && msgs[lastIdx].role === 'assistant' && msgs[lastIdx].content.includes('正在执行任务')) {
               const next = [...msgs];
-              next[lastIdx] = { role: 'assistant', content: '⚠️ Desktop Agent 连接中断，未收到执行结果。' };
+              next[lastIdx] = { role: 'assistant', content: '⚠️ Desktop Agent 连接中断，未收到执行结果。', ts: Date.now() };
               return touchSession(session, { messages: next, agentTrace: prev });
             }
             return touchSession(session, { agentTrace: prev });

--- a/routes/agent.js
+++ b/routes/agent.js
@@ -40,6 +40,8 @@ import {
   extractConversationEntry,
   extractProjectKnowledge,
   compactConversationMemory,
+  clearMemory,
+  clearProjectKnowledge,
 } from '../agent/core/memory.js';
 import { removeCheckpoint } from '../agent/core/checkpoint.js';
 import {
@@ -494,6 +496,26 @@ export function createAgentRouter({ runDesktopAgent, agentRunStore, approvalStor
       }
     } catch (err) {
       res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  router.delete('/api/agent/memory', async (_req, res) => {
+    try {
+      await clearMemory(memoryDir);
+      log.info('[Memory] 已清空全部记忆');
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  router.delete('/api/agent/memory/knowledge', async (_req, res) => {
+    try {
+      await clearProjectKnowledge(memoryDir);
+      log.info('[Memory] 已清空项目知识');
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
     }
   });
 

--- a/test/session-checkpoint.test.js
+++ b/test/session-checkpoint.test.js
@@ -221,11 +221,13 @@ describe('runtime: session checkpoint integration', () => {
       cleanup: noop,
     });
 
-    // Snapshot save is fire-and-forget — wait for disk writes to complete
-    await new Promise(r => setTimeout(r, 200));
-
-    // Verify step 2 snapshot exists
-    const snap2 = await loadLatestHealthySnapshot(tmpDir, runId, 2);
+    // Snapshot save is fire-and-forget — poll until step 2 snapshot is written
+    let snap2 = null;
+    for (let i = 0; i < 10; i++) {
+      await new Promise(r => setTimeout(r, 100));
+      snap2 = await loadLatestHealthySnapshot(tmpDir, runId, 2);
+      if (snap2) break;
+    }
     expect(snap2).not.toBeNull();
     expect(snap2.step).toBe(2);
 

--- a/test/session-checkpoint.test.js
+++ b/test/session-checkpoint.test.js
@@ -290,5 +290,7 @@ describe('runtime: session checkpoint integration', () => {
     expect(evtLog.some(e => e.type === 'rollback')).toBe(false);
     // Runtime returns result, it doesn't emit 'done' event itself
     expect(result.answer).toBe('done');
+    // Wait for fire-and-forget snapshot writes to complete
+    await new Promise(r => setTimeout(r, 200));
   });
 });


### PR DESCRIPTION
## Summary
- Progressive history truncation: 最近 3 步保留 1000 字符，4-10 步 500，11+ 步 200，防止上下文超限导致所有模型失败
- Memory cleanup API: `DELETE /api/agent/memory` 清空全部记忆，`DELETE /api/agent/memory/knowledge` 只清空 projectKnowledge
- Bot/captcha detection: 浏览器抓取也做反爬检测，返回明确错误而非静默返回验证页内容
- 前端 Memory 面板新增"清空知识"和"清空全部"按钮
- Retry from checkpoint 时清空旧 trace，修复步数不一致
- `AGENT_MAX_HISTORY_STEPS` / `AGENT_MAX_RESULT_CHARS` 可在 `.env` 配置

## Test plan
- [x] `npm test` 32 passed
- [ ] 验证 agent 执行 15+ 步后不再因上下文过大报"所有模型均失败"
- [ ] 前端 Memory 面板清空按钮正常工作，有确认弹窗
- [ ] Google 等反爬站点返回明确错误而非验证页内容