### PR TITLE
fix: agent 运行时多项修复

### DIFF
--- a/agent/core/action-types.ts
+++ b/agent/core/action-types.ts
@@ -39,6 +39,8 @@ export const ACTION_TYPE_TO_TOOL = {
   // ide
   ide_list_tools: 'ide',
   ide_call_tool: 'ide',
+  list_tools: 'ide',
+  call_tool: 'ide',
   // core
   finish: 'core',
   ask_user: 'core',

--- a/agent/core/schemas.ts
+++ b/agent/core/schemas.ts
@@ -235,21 +235,21 @@ function normalizeMacOsAction(type, action) {
 }
 
 function normalizeIdeAction(type, action) {
-  if (type === 'ide_list_tools') {
+  if (type === 'ide_list_tools' || type === 'list_tools') {
     return {
       tool: 'ide',
-      type,
+      type: 'ide_list_tools',
       refresh: Boolean(action.refresh),
     };
   }
 
-  if (type === 'ide_call_tool') {
+  if (type === 'ide_call_tool' || type === 'call_tool') {
     const args = action.arguments && typeof action.arguments === 'object' && !Array.isArray(action.arguments)
       ? action.arguments
       : {};
     return {
       tool: 'ide',
-      type,
+      type: 'ide_call_tool',
       toolName: typeof action.toolName === 'string' ? action.toolName.trim() : '',
       arguments: args,
       refreshTools: Boolean(action.refreshTools),

--- a/agent/policy/approvals.ts
+++ b/agent/policy/approvals.ts
@@ -39,7 +39,10 @@ export function createAgentAuthorizer({
         action,
         message: policy.reason,
       });
-      throw new Error(policy.reason);
+      return {
+        status: 'rejected',
+        message: policy.reason,
+      };
     }
 
     const { approvalId, promise } = approvalStore.request({

--- a/agent/policy/classify.ts
+++ b/agent/policy/classify.ts
@@ -5,8 +5,6 @@ function matchesDangerousCommand(command) {
   if (/\|\s*(rm|sudo|dd|mkfs|bash|sh|zsh|python|perl|ruby|node)\b/i.test(command)) return true;
   // Block output redirection to system paths
   if (/>\s*\/(etc|usr|boot|system)/i.test(command)) return true;
-  // Block command chaining with ; (sneaky injection)
-  if (/;/.test(command)) return true;
   // Block process substitution
   if (/[<>]\(/.test(command)) return true;
   return false;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1116,9 +1116,10 @@ function ModelPlanCard({ event, isWinner, modelList, result, forceExpanded, onMa
           )}
         </div>
       )}
-      {stage === 'failed' && event.error && (
+      {stage === 'failed' && (event.error || event.rationale) && (
         <div className="model-card-body">
-          <p className="model-card-error">{event.error}</p>
+          {event.rationale && <p>{event.rationale}</p>}
+          {event.error && <p className="model-card-error">{event.error}</p>}
         </div>
       )}
       {stage === 'discarded' && event.rationale && (


### PR DESCRIPTION
## Summary
- 兼容 `list_tools`/`call_tool` 作为 `ide_list_tools`/`ide_call_tool` 的别名，修复 kimi-k2.6 等模型输出不带前缀的动作类型导致报错
- failed 模型卡片展示 rationale，与 cancelled/discarded 状态保持一致
- 移除过于宽泛的分号拦截规则，避免 `find | awk | sort` 等合法管道命令被误拦
- blocked 命令不再直接终止 agent，改为返回 rejected 让 agent 换方案继续

## Test plan
- [ ] 使用 kimi-k2.6 运行 Agent 任务，验证 `list_tools` 动作正常执行
- [ ] 触发模型失败场景，验证 failed 卡片显示 rationale
- [ ] 让 Agent 执行含 awk 分号的命令，验证不被策略阻止
- [ ] 让 Agent 触发 blocked 策略，验证 agent 不终止而是继续尝试