### PR TITLE
fix: 空会话时禁止新建会话

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2294,6 +2294,10 @@ export default function App() {
       return;
     }
 
+    if (sessions.length > 0 && sessions[0].messages.length === 0) {
+      return;
+    }
+
     const nextSession = createSession();
 
     setChatState(prev =>
@@ -2782,7 +2786,7 @@ export default function App() {
           onDelete={handleDeleteSession}
           onClearAll={handleClearAllSessions}
           onSelect={(id) => { handleSelectSession(id); if (window.innerWidth < 768) setShowSessions(false); }}
-          locked={sessionLocked}
+          locked={sessionLocked || (sessions.length > 0 && sessions[0].messages.length === 0)}
           showMemoryPanel={showMemoryPanel}
           onToggleMemory={() => setShowMemoryPanel(v => !v)}
         />


### PR DESCRIPTION
## Summary
- 如果最新会话为空（没有消息），禁止创建新会话
- 新建按钮也会被禁用（locked 状态），防止用户点击无效

## Test plan
- [ ] 打开应用，默认有一个空会话，此时新建按钮应为禁用状态
- [ ] 发送一条消息后，新建按钮恢复可用
- [ ] 新建会话后，新会话为空，再次新建按钮应为禁用状态