### PR TITLE
fix: 429 重试时使用 Retry-After 响应头

### DIFF
--- a/helpers/retry.ts
+++ b/helpers/retry.ts
@@ -11,14 +11,33 @@ function isRetryableError(err) {
   return false;
 }
 
+function extractRetryDelayMs(err) {
+  // Anthropic SDK: err.headers is a Headers or plain object
+  // OpenAI SDK: err.headers is a plain object
+  const headers = err?.headers || err?.error?.headers;
+  if (headers) {
+    const retryAfter = headers.get ? headers.get('retry-after') : headers['retry-after'];
+    if (retryAfter) {
+      const seconds = Number(retryAfter);
+      if (Number.isFinite(seconds) && seconds > 0) return seconds * 1000;
+      const date = Date.parse(retryAfter);
+      if (!isNaN(date)) return Math.max(date - Date.now(), 1000);
+    }
+  }
+  return null;
+}
+
 export async function retryAsync(fn, maxRetries = MAX_RETRIES) {
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
     try {
       return await fn();
     } catch (err) {
       if (attempt === maxRetries || !isRetryableError(err)) throw err;
-      const delay = Math.min(BASE_DELAY_MS * 2 ** attempt + Math.random() * 500, 15000);
-      log.warn(`[Retry] attempt=${attempt + 1}/${maxRetries} delay=${Math.round(delay)}ms error=${err.message}`);
+      const retryAfterMs = extractRetryDelayMs(err);
+      const delay = retryAfterMs != null
+        ? Math.min(retryAfterMs + Math.random() * 500, 60000)
+        : Math.min(BASE_DELAY_MS * 2 ** attempt + Math.random() * 500, 15000);
+      log.warn(`[Retry] attempt=${attempt + 1}/${maxRetries} delay=${Math.round(delay)}ms${retryAfterMs != null ? ' (retry-after)' : ''} error=${err.message}`);
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }


### PR DESCRIPTION
## Summary
- 429 响应时从 `Retry-After` header 提取服务端建议的等待时间，不再使用过短的指数退避
- 支持 `Retry-After` 为秒数（如 `5`）或 HTTP 日期格式（如 `Wed, 06 May 2026 14:03:00 GMT`）
- 当 header 不存在时回退到原来的指数退避策略（1s/2s/4s）
- 有 `Retry-After` 时上限 60s，无 header 时上限 15s
- 日志中标注 `(retry-after)` 区分两种策略

## Test plan
- [ ] 触发 429 限流，确认日志中 delay 使用了服务端返回的值
- [ ] 确认非 429 错误仍使用指数退避