### PR TITLE
fix: 已完成的任务不应被恢复执行

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -183,6 +183,9 @@ app.listen(Number(PORT), HOST, async () => {
       if (needsNvidia && !openai_client) {
         console.log(`[Resume] 跳过: ${cp.runId} 需要 NVIDIA_API_KEY 但未配置，清理 checkpoint`);
         await clearCheckpoints(CHECKPOINT_DIR);
+      } else if (cp.history?.some(h => h.action?.type === 'finish')) {
+        console.log(`[Resume] ${cp.runId} 已完成（含 finish 动作），跳过恢复，清理 checkpoint`);
+        await clearCheckpoints(CHECKPOINT_DIR);
       } else {
         console.log(`[Resume] 发现 ${checkpoints.length} 个未完成任务，恢复最后一个: ${cp.runId}`);
         agentRunStore.createRun({ model: cp.model, task: cp.task }, cp.startedAt, cp.runId);


### PR DESCRIPTION
## Summary
- 恢复逻辑增加检查：如果 checkpoint 的 history 中已包含 `finish` 动作，说明任务已完成，直接清理 checkpoint 跳过恢复
- 根本原因：agent 完成任务后 checkpoint 在循环退出前已保存，如果服务在 cleanup 删除 checkpoint 前崩溃/重启，残留的 checkpoint 会被误判为未完成任务

## Test plan
- [ ] 执行一个 agent 任务直到完成，然后重启服务，确认日志显示 `跳过恢复，清理 checkpoint` 而不是尝试恢复执行
- [ ] 模拟中断（在中间步骤 kill 进程），确认重启后正确恢复未完成的任务