### PR TITLE
fix: 修复新建空会话后历史会话无法点击

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2786,7 +2786,7 @@ export default function App() {
           onDelete={handleDeleteSession}
           onClearAll={handleClearAllSessions}
           onSelect={(id) => { handleSelectSession(id); if (window.innerWidth < 768) setShowSessions(false); }}
-          locked={sessionLocked || (sessions.length > 0 && sessions[0].messages.length === 0)}
+          locked={sessionLocked}
           showMemoryPanel={showMemoryPanel}
           onToggleMemory={() => setShowMemoryPanel(v => !v)}
         />


### PR DESCRIPTION
## Summary
- 移除 SessionList `locked` prop 中多余的条件 `sessions.length > 0 && sessions[0].messages.length === 0`，该条件导致新建空会话后所有历史会话按钮被禁用
- `handleCreateSession` 已有独立逻辑（#160）防止重复创建空会话，无需在 `locked` 中重复

## Test plan
- [ ] 新建会话后，确认历史会话仍可正常点击切换
- [ ] agent 运行中/streaming 时，确认会话列表仍正确锁定
- [ ] 连续新建多个会话，确认不会创建重复空会话