### PR TITLE
feat: Chrome DevTools MCP 集成

### DIFF
--- a/agent/core/action-types.ts
+++ b/agent/core/action-types.ts
@@ -41,6 +41,11 @@ export const ACTION_TYPE_TO_TOOL = {
   ide_call_tool: 'ide',
   list_tools: 'ide',
   call_tool: 'ide',
+  // chrome
+  chrome_list_tools: 'chrome',
+  chrome_call_tool: 'chrome',
+  chrome_list: 'chrome',
+  chrome_call: 'chrome',
   // core
   finish: 'core',
   ask_user: 'core',

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -1,7 +1,9 @@
 import { buildIdePromptLines, isIdeMcpEnabled } from '../tools/ide/mcp-client.ts';
+import { buildChromePromptLines, isChromeMcpEnabled } from '../tools/chrome/mcp-client.ts';
 
 export function buildDesktopAgentSystemPrompt(systemPrompt: string | null) {
   const ideLines = buildIdePromptLines();
+  const chromeLines = buildChromePromptLines();
   return [
     '你是 DesktopAgent，负责在浏览器、macOS 桌面、文件系统、终端之间协同完成任务。',
     '通过工具调用完成任务，只能使用提供的工具，不要输出 JSON 以外的文本。',
@@ -15,6 +17,7 @@ export function buildDesktopAgentSystemPrompt(systemPrompt: string | null) {
     '7. 需要用户输入或确认偏好时使用 ask_user，不要自行假设。',
     '8. 执行中发现重要信息或潜在问题时使用 notify_user 主动告知用户。',
     ...ideLines,
+    ...chromeLines,
     systemPrompt ? `附加约束：${systemPrompt}` : '',
   ]
     .filter(Boolean)
@@ -64,6 +67,8 @@ export function buildNvidiaTaskMessages({
 }) {
   const ideEnabled = isIdeMcpEnabled();
   const ideLines = buildIdePromptLines();
+  const chromeEnabled = isChromeMcpEnabled();
+  const chromeLines = buildChromePromptLines();
   const conversationSummary = conversationHistory?.length
     ? '\n\n之前的对话（供参考）：\n' + conversationHistory
         .map(message => `${message.role === 'user' ? '用户' : '助手'}: ${message.content}`)
@@ -104,6 +109,12 @@ export function buildNvidiaTaskMessages({
               '{"rationale":"调用 IDE 工具获取运行配置","action":{"tool":"ide","type":"ide_call_tool","toolName":"get_run_configurations","arguments":{}}}',
             ]
           : []),
+        ...(chromeEnabled
+          ? [
+              '{"rationale":"查看 Chrome DevTools 可用工具","action":{"tool":"chrome","type":"chrome_list_tools"}}',
+              '{"rationale":"调用 Chrome 工具截图","action":{"tool":"chrome","type":"chrome_call_tool","toolName":"take_screenshot","arguments":{}}}',
+            ]
+          : []),
         '{"rationale":"向用户提问","action":{"tool":"core","type":"ask_user","question":"你希望使用什么命名规范？"}}',
         '{"rationale":"发现重要问题需告知用户","action":{"tool":"core","type":"notify_user","message":"发现 3 个硬编码 API 密钥","level":"warning"}}',
         '{"rationale":"完成任务","action":{"type":"finish","answer":"最终结果"}}',
@@ -120,6 +131,7 @@ export function buildNvidiaTaskMessages({
         '9. 需要用户输入或确认偏好时使用 ask_user。',
         '10. 发现重要信息或问题时使用 notify_user 主动告知用户。',
         ...ideLines,
+        ...chromeLines,
         systemPrompt ? `附加约束：${systemPrompt}` : '',
         conversationSummary,
       ]

--- a/agent/core/schemas.ts
+++ b/agent/core/schemas.ts
@@ -259,6 +259,31 @@ function normalizeIdeAction(type, action) {
   throw new Error(`不支持的 IDE 动作: ${type}`);
 }
 
+function normalizeChromeAction(type, action) {
+  if (type === 'chrome_list_tools' || type === 'chrome_list') {
+    return {
+      tool: 'chrome',
+      type: 'chrome_list_tools',
+      refresh: Boolean(action.refresh),
+    };
+  }
+
+  if (type === 'chrome_call_tool' || type === 'chrome_call') {
+    const args = action.arguments && typeof action.arguments === 'object' && !Array.isArray(action.arguments)
+      ? action.arguments
+      : {};
+    return {
+      tool: 'chrome',
+      type: 'chrome_call_tool',
+      toolName: typeof action.toolName === 'string' ? action.toolName.trim() : '',
+      arguments: args,
+      refreshTools: Boolean(action.refreshTools),
+    };
+  }
+
+  throw new Error(`不支持的 Chrome 动作: ${type}`);
+}
+
 function normalizeCoreAction(type, action) {
   if (type === 'finish') {
     return {
@@ -314,6 +339,8 @@ export function normalizeDesktopAgentDecision(payload) {
     normalizedAction = normalizeMacOsAction(type, action);
   } else if (tool === 'ide') {
     normalizedAction = normalizeIdeAction(type, action);
+  } else if (tool === 'chrome') {
+    normalizedAction = normalizeChromeAction(type, action);
   } else if (tool === 'core') {
     normalizedAction = normalizeCoreAction(type, action);
   } else {

--- a/agent/core/tool-definitions.ts
+++ b/agent/core/tool-definitions.ts
@@ -10,6 +10,7 @@
  */
 
 import { isIdeMcpEnabled } from '../tools/ide/mcp-client.ts';
+import { isChromeMcpEnabled } from '../tools/chrome/mcp-client.ts';
 
 export function createModelTools() {
   const tools: any[] = [
@@ -308,6 +309,38 @@ export function createModelTools() {
               additionalProperties: true,
             },
             refreshTools: { type: 'boolean', description: '调用前是否刷新一次 IDE 工具列表' },
+          },
+          required: ['toolName'],
+        },
+      }
+    );
+  }
+
+  if (isChromeMcpEnabled()) {
+    tools.splice(tools.length - 1, 0,
+      {
+        name: 'chrome_list_tools',
+        description: '列出当前 Chrome DevTools MCP 暴露的工具及参数。可查看浏览器操作、截图、网络检查等可用能力。',
+        input_schema: {
+          type: 'object',
+          properties: {
+            refresh: { type: 'boolean', description: '是否强制重新拉取 Chrome 工具列表' },
+          },
+        },
+      },
+      {
+        name: 'chrome_call_tool',
+        description: '调用 Chrome DevTools MCP 的某个工具。toolName 必须来自 chrome_list_tools，arguments 传该工具要求的参数对象。',
+        input_schema: {
+          type: 'object',
+          properties: {
+            toolName: { type: 'string', description: 'Chrome MCP 工具名称，例如 take_snapshot、click、fill、navigate_page' },
+            arguments: {
+              type: 'object',
+              description: '传给 Chrome MCP 工具的参数对象',
+              additionalProperties: true,
+            },
+            refreshTools: { type: 'boolean', description: '调用前是否刷新一次 Chrome 工具列表' },
           },
           required: ['toolName'],
         },

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -34,6 +34,7 @@ import { executeBrowserAction } from '../tools/browser/execute.ts';
 import { executeFsAction } from '../tools/fs/execute.ts';
 import { createDomainRules } from '../tools/fetch/domain-rules.ts';
 import { executeIdeAction } from '../tools/ide/execute.ts';
+import { executeChromeAction } from '../tools/chrome/execute.ts';
 import { executeMacOSAction } from '../tools/macos/execute.ts';
 import { executeTerminalAction } from '../tools/terminal/run.ts';
 import { createSharedBrowserSessionManager } from './browser-session-manager.ts';
@@ -81,6 +82,7 @@ export function createDesktopAgentRunner({
       },
       fs: async (_state, action) => executeFsAction(action),
       ide: async (_state, action) => executeIdeAction(action),
+      chrome: async (_state, action) => executeChromeAction(action),
       terminal: async (_state, action) => executeTerminalAction(action),
       macos: async (state, action) =>
         executeMacOSAction(action, {
@@ -159,7 +161,7 @@ export function createDesktopAgentRunner({
       shouldObserve: (lastAction) => {
         if (!lastAction) return false;
         const tool = lastAction.tool || '';
-        return tool !== 'fs' && tool !== 'terminal';
+        return tool !== 'fs' && tool !== 'terminal' && tool !== 'ide' && tool !== 'chrome';
       },
       execute: async (state, action, context) => routeAction(state, action, context),
       cleanup: async state => {

--- a/agent/policy/classify.ts
+++ b/agent/policy/classify.ts
@@ -45,6 +45,22 @@ const CONFIRM_IDE_TOOLS = new Set([
   'execute_sql_query',
 ]);
 
+const SAFE_CHROME_TOOLS = new Set([
+  'take_snapshot',
+  'take_screenshot',
+  'list_pages',
+  'get_console_message',
+  'list_console_messages',
+  'list_network_requests',
+  'get_network_request',
+  'wait_for',
+  'lighthouse_audit',
+  'performance_start_trace',
+  'performance_stop_trace',
+  'performance_analyze_insight',
+  'take_memory_snapshot',
+]);
+
 export function classifyAgentAction(action) {
   const tool = action?.tool || '';
   const type = action?.type || '';
@@ -164,6 +180,27 @@ export function classifyAgentAction(action) {
     return {
       level: 'confirm',
       reason: `即将执行未知风险级别的 IDE 工具: ${toolName || '未命名工具'}`,
+    };
+  }
+
+  if (tool === 'chrome' && type === 'chrome_list_tools') {
+    return {
+      level: 'safe',
+      reason: '只读取 Chrome MCP 工具元数据',
+    };
+  }
+
+  if (tool === 'chrome' && type === 'chrome_call_tool') {
+    const toolName = String(action.toolName || '').trim();
+    if (SAFE_CHROME_TOOLS.has(toolName)) {
+      return {
+        level: 'safe',
+        reason: `只读 Chrome 工具: ${toolName}`,
+      };
+    }
+    return {
+      level: 'confirm',
+      reason: `即将执行 Chrome 工具: ${toolName || '未命名工具'}`,
     };
   }
 

--- a/agent/tools/chrome/execute.ts
+++ b/agent/tools/chrome/execute.ts
@@ -1,0 +1,94 @@
+import {
+  formatChromeMcpError,
+  getSharedChromeMcpClient,
+  isChromeMcpEnabled,
+  loadChromeMcpConfig,
+  serializeChromePayload,
+  summarizeChromeTool,
+} from './mcp-client.ts';
+
+const MAX_TEXT = 24000;
+
+function truncate(text, max = MAX_TEXT) {
+  const value = String(text || '');
+  return value.length > max ? `${value.slice(0, max)}\n...(内容已截断)` : value;
+}
+
+function formatToolList(tools, config) {
+  const header = [
+    `Chrome DevTools MCP 已连接 (${config.transport})`,
+    `可用工具数: ${tools.length}`,
+  ].join('\n');
+
+  const lines = tools.map(tool => {
+    const summary = summarizeChromeTool(tool);
+    const args = summary.fields ? ` (${summary.fields})` : '';
+    return `- ${summary.name}${args}${summary.description ? `: ${summary.description}` : ''}`;
+  });
+
+  return truncate(`${header}\n\n${lines.join('\n') || '当前未发现可用 Chrome 工具'}`);
+}
+
+function extractToolContent(result) {
+  const chunks = [];
+
+  if (Array.isArray(result?.content)) {
+    for (const item of result.content) {
+      if (item?.type === 'text' && item.text) {
+        chunks.push(item.text);
+        continue;
+      }
+      chunks.push(serializeChromePayload(item));
+    }
+  }
+
+  if (result?.structuredContent !== undefined) {
+    chunks.push(serializeChromePayload(result.structuredContent));
+  }
+
+  if (chunks.length === 0) {
+    chunks.push(serializeChromePayload(result));
+  }
+
+  return chunks.join('\n\n');
+}
+
+export async function executeChromeAction(action) {
+  if (!isChromeMcpEnabled()) {
+    throw new Error('Chrome MCP 未启用，请在 .env 中设置 CHROME_MCP_ENABLED=true 并配置连接参数');
+  }
+
+  const config = loadChromeMcpConfig();
+  const client = await getSharedChromeMcpClient(config);
+
+  if (action.type === 'chrome_list_tools') {
+    const tools = await client.listTools({ refresh: Boolean(action.refresh) });
+    return formatToolList(tools, config);
+  }
+
+  if (action.type === 'chrome_call_tool') {
+    const toolName = String(action.toolName || '').trim();
+    if (!toolName) {
+      throw new Error('chrome_call_tool 缺少 toolName');
+    }
+
+    const tool = await client.getTool(toolName, { refresh: Boolean(action.refreshTools) });
+    if (!tool) {
+      throw new Error(`未找到 Chrome 工具 ${toolName}，请先调用 chrome_list_tools 确认可用工具名`);
+    }
+
+    const args = action.arguments && typeof action.arguments === 'object' && !Array.isArray(action.arguments)
+      ? action.arguments : {};
+    const result = await client.callTool(toolName, args);
+    const content = extractToolContent(result);
+    const status = result?.isError ? '失败' : '完成';
+
+    return truncate([
+      `Chrome 工具 ${toolName} 执行${status}`,
+      `参数: ${serializeChromePayload(args)}`,
+      `结果:\n${content}`,
+    ].join('\n\n'));
+  }
+
+  throw new Error(formatChromeMcpError(new Error(`不支持的 Chrome 动作类型: ${action.type}`), 'Chrome MCP'));
+}

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -1,0 +1,928 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { log } from '../../../helpers/logger.ts';
+
+const DEFAULT_PROTOCOL_VERSIONS = ['2025-03-26', '2024-11-05'];
+const DEFAULT_SSE_HOST = '127.0.0.1';
+const DEFAULT_SSE_PORT = 3099;
+const DEFAULT_SSE_PATH = '/sse';
+const SSE_ENDPOINT_WAIT_MS = 250;
+const DEFAULT_STDIO_COMMAND = 'npx';
+const DEFAULT_STDIO_ARGS = ['-y', '@anthropic-ai/chrome-devtools-mcp@latest'];
+const CLIENT_INFO = { name: 'sagent', version: '1.0.0' };
+
+let sharedClientPromise = null;
+let sharedClientKey = '';
+
+function envFlag(value) {
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+function toAbsolutePath(rawPath, fallback = process.cwd()) {
+  if (typeof rawPath !== 'string' || !rawPath.trim()) {
+    return fallback;
+  }
+  return path.isAbsolute(rawPath) ? path.normalize(rawPath) : path.resolve(fallback, rawPath);
+}
+
+function parseArgs(value) {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item));
+  }
+  if (typeof value !== 'string' || !value.trim()) {
+    return [...DEFAULT_STDIO_ARGS];
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed.map(item => String(item));
+    }
+  } catch {
+    // ignore JSON parse failure and fall back to whitespace split
+  }
+  return value.trim().split(/\s+/).filter(Boolean);
+}
+
+function truncateText(text, max = 200) {
+  const value = String(text || '');
+  return value.length > max ? `${value.slice(0, max)}...` : value;
+}
+
+function buildSseUrl(config) {
+  if (config.url) {
+    return config.url;
+  }
+  return `http://${config.host}:${config.port}${config.ssePath}`;
+}
+
+function buildMessagesUrl(config, streamUrl) {
+  if (config.messagesUrl) {
+    return config.messagesUrl;
+  }
+  if (streamUrl.endsWith('/sse')) {
+    return `${streamUrl.slice(0, -4)}/messages`;
+  }
+  return null;
+}
+
+export function buildSsePostCandidates(config, streamUrl) {
+  const candidates = [];
+  const seen = new Set();
+
+  const push = value => {
+    const normalized = typeof value === 'string' && value.trim() ? value.trim() : '';
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    candidates.push(normalized);
+  };
+
+  push(config.messagesUrl);
+
+  if (streamUrl.endsWith('/sse')) {
+    const base = streamUrl.slice(0, -4);
+    push(`${base}/message`);
+    push(`${base}/messages`);
+    push(`${base}/mcp`);
+  }
+
+  push(buildMessagesUrl(config, streamUrl));
+  return candidates;
+}
+
+function safeJson(value) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function summarizeRpcParams(params, max = 600) {
+  return truncateText(safeJson(params || {}), max);
+}
+
+function summarizeRpcMessage(message, max = 800) {
+  return truncateText(safeJson(message || {}), max);
+}
+
+function logChromeRequest(transport, target, method, params, extra = '') {
+  log.info(`[Chrome MCP][${transport}] -> ${target} method=${method}${extra ? ` ${extra}` : ''} params=${summarizeRpcParams(params)}`);
+}
+
+function logChromeResponse(transport, target, method, status, body = '') {
+  const suffix = body ? ` body=${truncateText(body, 400)}` : '';
+  log.info(`[Chrome MCP][${transport}] <- ${target} method=${method} status=${status}${suffix}`);
+}
+
+function logChromeInboundEvent(transport, eventName, data) {
+  log.info(`[Chrome MCP][${transport}] event=${eventName} data=${truncateText(data, 500)}`);
+}
+
+function logChromeInboundMessage(transport, message) {
+  if (message?.error) {
+    log.info(`[Chrome MCP][${transport}] inbound error id=${message.id ?? 'n/a'} payload=${summarizeRpcMessage(message.error, 600)}`);
+    return;
+  }
+  if (message?.result !== undefined) {
+    log.info(`[Chrome MCP][${transport}] inbound result id=${message.id ?? 'n/a'} payload=${summarizeRpcMessage(message.result, 1000)}`);
+    return;
+  }
+  log.info(`[Chrome MCP][${transport}] inbound payload=${summarizeRpcMessage(message, 1000)}`);
+}
+
+function extractSchema(tool) {
+  return tool?.inputSchema || tool?.input_schema || {};
+}
+
+function clientKey(config) {
+  return JSON.stringify({
+    enabled: config.enabled,
+    transport: config.transport,
+    url: config.url,
+    host: config.host,
+    port: config.port,
+    ssePath: config.ssePath,
+    messagesUrl: config.messagesUrl,
+    command: config.command,
+    args: config.args,
+    cwd: config.cwd,
+  });
+}
+
+export function isChromeMcpEnabled(env = process.env) {
+  if (envFlag(env.CHROME_MCP_ENABLED)) {
+    return true;
+  }
+  return Boolean(
+    env.CHROME_MCP_TRANSPORT ||
+    env.CHROME_MCP_URL ||
+    env.CHROME_MCP_COMMAND ||
+    env.CHROME_MCP_HOST ||
+    env.CHROME_MCP_PORT
+  );
+}
+
+export function buildChromePromptLines(env = process.env) {
+  if (!isChromeMcpEnabled(env)) {
+    return [];
+  }
+  return [
+    '当 Chrome DevTools MCP 已启用时，可先使用 chrome_list_tools 查看 Chrome DevTools 暴露的 MCP 工具，再用 chrome_call_tool 调用具体工具。',
+    'chrome_call_tool 的 toolName 必须来自 chrome_list_tools 返回结果，arguments 传对应参数对象。',
+    'Chrome DevTools 工具可用于浏览器页面操作、截图、网络请求检查、性能分析等。',
+  ];
+}
+
+export function loadChromeMcpConfig(env = process.env) {
+  const transport = String(env.CHROME_MCP_TRANSPORT || '').trim().toLowerCase() === 'stdio' ? 'stdio' : 'sse';
+  const host = String(env.CHROME_MCP_HOST || DEFAULT_SSE_HOST).trim() || DEFAULT_SSE_HOST;
+  const port = Number(env.CHROME_MCP_PORT || DEFAULT_SSE_PORT) || DEFAULT_SSE_PORT;
+  const ssePath = String(env.CHROME_MCP_SSE_PATH || DEFAULT_SSE_PATH).trim() || DEFAULT_SSE_PATH;
+  const cwd = toAbsolutePath(env.CHROME_MCP_CWD, process.cwd());
+  const url = String(env.CHROME_MCP_URL || '').trim() || null;
+  const messagesUrl = String(env.CHROME_MCP_MESSAGES_URL || '').trim() || null;
+  const command = String(env.CHROME_MCP_COMMAND || DEFAULT_STDIO_COMMAND).trim() || DEFAULT_STDIO_COMMAND;
+  const args = parseArgs(env.CHROME_MCP_ARGS);
+
+  return {
+    enabled: isChromeMcpEnabled(env),
+    transport,
+    host,
+    port,
+    ssePath,
+    url,
+    messagesUrl,
+    command,
+    args,
+    cwd,
+  };
+}
+
+function createJsonRpcError(message, code = -32000, data = null) {
+  return {
+    jsonrpc: '2.0',
+    error: {
+      code,
+      message,
+      ...(data ? { data } : {}),
+    },
+  };
+}
+
+class ChromeMcpClient {
+  config: any;
+  transport: any;
+  toolsCache: any[] | null;
+
+  constructor(config, transport) {
+    this.config = config;
+    this.transport = transport;
+    this.toolsCache = null;
+  }
+
+  async listTools({ refresh = false } = {}) {
+    if (!refresh && this.toolsCache) {
+      return this.toolsCache;
+    }
+
+    const tools = [];
+    const seenCursors = new Set();
+    let cursor = undefined;
+
+    while (true) {
+      const params = cursor ? { cursor } : {};
+      const result = await this.transport.request('tools/list', params);
+      if (Array.isArray(result?.tools)) {
+        tools.push(...result.tools);
+      }
+
+      const nextCursor = result?.nextCursor || result?.cursor || null;
+      if (!nextCursor || seenCursors.has(nextCursor)) {
+        break;
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    }
+
+    this.toolsCache = tools;
+    return tools;
+  }
+
+  async getTool(toolName, { refresh = false } = {}) {
+    const tools = await this.listTools({ refresh });
+    return tools.find(tool => tool?.name === toolName) || null;
+  }
+
+  async callTool(toolName, args) {
+    return this.transport.request('tools/call', {
+      name: toolName,
+      arguments: args || {},
+    });
+  }
+
+  async close() {
+    await this.transport.close?.();
+  }
+}
+
+class StdioTransport {
+  config: any;
+  child: any;
+  buffer: Buffer;
+  pending: Map<any, any>;
+  nextId: number;
+  initialized: boolean;
+  connectPromise: Promise<void> | null;
+  initializePromise: Promise<void> | null;
+
+  constructor(config) {
+    this.config = config;
+    this.child = null;
+    this.buffer = Buffer.alloc(0);
+    this.pending = new Map();
+    this.nextId = 1;
+    this.initialized = false;
+    this.connectPromise = null;
+    this.initializePromise = null;
+  }
+
+  async ensureConnected() {
+    if (this.child) {
+      return;
+    }
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+
+    this.connectPromise = new Promise<void>((resolve, reject) => {
+      log.info(`[Chrome MCP][stdio] spawn command=${this.config.command} args=${safeJson(this.config.args)} cwd=${this.config.cwd}`);
+      const child = spawn(this.config.command, this.config.args, {
+        cwd: this.config.cwd,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: process.env,
+      });
+
+      let settled = false;
+      const onError = err => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        reject(new Error(`启动 Chrome MCP stdio 进程失败: ${err.message}`));
+      };
+
+      child.once('error', onError);
+      child.stdout.on('data', chunk => this.handleStdout(chunk));
+      child.stderr.on('data', chunk => {
+        log.debug(`[Chrome MCP][stderr] ${truncateText(chunk.toString().trim(), 400)}`);
+      });
+      child.on('exit', (code, signal) => {
+        const error = new Error(`Chrome MCP stdio 进程已退出 (code=${code ?? 'null'}, signal=${signal ?? 'null'})`);
+        this.rejectAllPending(error);
+        this.child = null;
+        this.initialized = false;
+        this.initializePromise = null;
+      });
+
+      this.child = child;
+      settled = true;
+      resolve();
+    }).finally(() => {
+      this.connectPromise = null;
+    });
+
+    return this.connectPromise;
+  }
+
+  handleStdout(chunk) {
+    this.buffer = Buffer.concat([this.buffer, Buffer.from(chunk)]);
+
+    while (true) {
+      const headerEnd = this.findHeaderEnd(this.buffer);
+      if (headerEnd < 0) {
+        return;
+      }
+
+      const separatorLength = this.buffer[headerEnd] === 13 ? 4 : 2;
+      const headerText = this.buffer.slice(0, headerEnd).toString('utf8');
+      const contentLength = this.getContentLength(headerText);
+      if (!Number.isFinite(contentLength) || contentLength < 0) {
+        this.rejectAllPending(new Error(`Chrome MCP 响应缺少 Content-Length: ${headerText}`));
+        this.buffer = Buffer.alloc(0);
+        return;
+      }
+
+      const bodyStart = headerEnd + separatorLength;
+      const bodyEnd = bodyStart + contentLength;
+      if (this.buffer.length < bodyEnd) {
+        return;
+      }
+
+      const body = this.buffer.slice(bodyStart, bodyEnd).toString('utf8');
+      this.buffer = this.buffer.slice(bodyEnd);
+
+      try {
+        const message = JSON.parse(body);
+        this.handleIncomingMessage(message);
+      } catch (err) {
+        this.rejectAllPending(new Error(`Chrome MCP 响应 JSON 解析失败: ${err.message}`));
+      }
+    }
+  }
+
+  findHeaderEnd(buffer) {
+    const crlf = buffer.indexOf('\r\n\r\n');
+    if (crlf >= 0) {
+      return crlf;
+    }
+    return buffer.indexOf('\n\n');
+  }
+
+  getContentLength(headerText) {
+    const line = headerText
+      .split(/\r?\n/)
+      .find(item => item.toLowerCase().startsWith('content-length:'));
+    if (!line) {
+      return NaN;
+    }
+    return Number(line.split(':')[1]?.trim());
+  }
+
+  handleIncomingMessage(message) {
+    if (message?.method && message?.id !== undefined) {
+      this.sendRaw({
+        jsonrpc: '2.0',
+        id: message.id,
+        error: { code: -32601, message: 'sagent does not handle server-initiated MCP requests' },
+      }).catch(() => {});
+      return;
+    }
+
+    if (message?.id !== undefined) {
+      const pending = this.pending.get(message.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(message.id);
+      clearTimeout(pending.timer);
+      if (message.error) {
+        pending.reject(new Error(`Chrome MCP 请求失败: ${message.error.message || safeJson(message.error)}`));
+        return;
+      }
+      pending.resolve(message.result);
+    }
+  }
+
+  rejectAllPending(error) {
+    for (const [id, pending] of this.pending.entries()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+      this.pending.delete(id);
+    }
+  }
+
+  async sendRaw(message) {
+    await this.ensureConnected();
+    const payload = Buffer.from(JSON.stringify(message), 'utf8');
+    const framed = Buffer.from(`Content-Length: ${payload.length}\r\n\r\n`, 'utf8');
+    return new Promise<void>((resolve, reject) => {
+      this.child.stdin.write(Buffer.concat([framed, payload]), err => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+
+  async ensureInitialized() {
+    if (this.initialized) {
+      return;
+    }
+    if (this.initializePromise) {
+      return this.initializePromise;
+    }
+
+    this.initializePromise = (async () => {
+      await this.ensureConnected();
+
+      let lastError = null;
+      for (const version of DEFAULT_PROTOCOL_VERSIONS) {
+        try {
+          await this.sendRequest('initialize', {
+            protocolVersion: version,
+            capabilities: {},
+            clientInfo: CLIENT_INFO,
+          }, { skipInit: true });
+          await this.sendNotification('notifications/initialized', {});
+          this.initialized = true;
+          return;
+        } catch (err) {
+          lastError = err;
+        }
+      }
+
+      throw lastError || new Error('Chrome MCP initialize 失败');
+    })().finally(() => {
+      this.initializePromise = null;
+    });
+
+    return this.initializePromise;
+  }
+
+  async sendNotification(method, params) {
+    await this.sendRaw({
+      jsonrpc: '2.0',
+      method,
+      params: params || {},
+    });
+  }
+
+  async sendRequest(method, params, { skipInit = false } = {}) {
+    if (!skipInit) {
+      await this.ensureInitialized();
+    }
+
+    const id = this.nextId++;
+    logChromeRequest('stdio', 'stdio', method, params, `id=${id}`);
+    return new Promise(async (resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Chrome MCP 请求超时: ${method}`));
+      }, 15000);
+
+      this.pending.set(id, { resolve, reject, timer });
+
+      try {
+        await this.sendRaw({
+          jsonrpc: '2.0',
+          id,
+          method,
+          params: params || {},
+        });
+      } catch (err) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  async request(method, params) {
+    return this.sendRequest(method, params);
+  }
+
+  async close() {
+    this.rejectAllPending(new Error('Chrome MCP 客户端已关闭'));
+    try {
+      this.child?.kill('SIGTERM');
+    } catch {
+      // noop
+    }
+    this.child = null;
+    this.buffer = Buffer.alloc(0);
+    this.initialized = false;
+    this.initializePromise = null;
+  }
+}
+
+class SseTransport {
+  config: any;
+  streamUrl: string;
+  postUrl: string | null;
+  fallbackPostUrls: string[];
+  pending: Map<any, any>;
+  nextId: number;
+  initialized: boolean;
+  initializePromise: Promise<void> | null;
+  streamPromise: Promise<void> | null;
+  endpointPromise: Promise<string> | null;
+  endpointResolve: ((value: string | PromiseLike<string>) => void) | null;
+  endpointReject: ((reason?: any) => void) | null;
+  abortController: AbortController | null;
+  endpointFallbackTimer: ReturnType<typeof setTimeout> | null;
+
+  constructor(config) {
+    this.config = config;
+    this.streamUrl = buildSseUrl(config);
+    this.postUrl = config.messagesUrl || null;
+    this.fallbackPostUrls = buildSsePostCandidates(config, this.streamUrl);
+    this.pending = new Map();
+    this.nextId = 1;
+    this.initialized = false;
+    this.initializePromise = null;
+    this.streamPromise = null;
+    this.endpointPromise = null;
+    this.endpointResolve = null;
+    this.endpointReject = null;
+    this.abortController = null;
+    this.endpointFallbackTimer = null;
+  }
+
+  async ensureStreamOpen(): Promise<string> {
+    if (this.streamPromise) {
+      if (!this.endpointPromise) {
+        throw new Error('Chrome MCP SSE endpoint 尚未初始化');
+      }
+      return this.endpointPromise;
+    }
+
+    this.endpointPromise = new Promise<string>((resolve, reject) => {
+      this.endpointResolve = resolve;
+      this.endpointReject = reject;
+    });
+
+    if (this.postUrl) {
+      this.endpointResolve?.(this.postUrl);
+    } else if (this.fallbackPostUrls[0]) {
+      this.endpointFallbackTimer = setTimeout(() => {
+        if (!this.postUrl && this.fallbackPostUrls[0]) {
+          this.endpointResolve?.(this.fallbackPostUrls[0]);
+        }
+      }, SSE_ENDPOINT_WAIT_MS);
+    }
+
+    this.abortController = new AbortController();
+    log.info(`[Chrome MCP][sse] opening stream url=${this.streamUrl} fallbackPostUrls=${safeJson(this.fallbackPostUrls)}`);
+
+    this.streamPromise = fetch(this.streamUrl, {
+      headers: { Accept: 'text/event-stream' },
+      signal: this.abortController.signal,
+    })
+      .then(async response => {
+        if (!response.ok || !response.body) {
+          throw new Error(`SSE 连接失败: HTTP ${response.status}`);
+        }
+        await this.consumeStream(response.body);
+      })
+      .catch(err => {
+        const error = new Error(`Chrome MCP SSE 连接失败: ${err.message}`);
+        log.warn(`[Chrome MCP][sse] stream failed url=${this.streamUrl} reason=${error.message}`);
+        this.endpointReject?.(error);
+        this.rejectAllPending(error);
+        return;
+      })
+      .finally(() => {
+        log.info(`[Chrome MCP][sse] stream closed url=${this.streamUrl}`);
+        this.streamPromise = null;
+      });
+
+    if (!this.endpointPromise) {
+      throw new Error('Chrome MCP SSE endpoint 尚未初始化');
+    }
+    return this.endpointPromise;
+  }
+
+  async consumeStream(body) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        return;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      while (true) {
+        const match = buffer.match(/\r?\n\r?\n/);
+        if (!match || match.index === undefined) {
+          break;
+        }
+
+        const boundary = match.index;
+        const eventBlock = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + match[0].length);
+        this.handleSseEvent(eventBlock);
+      }
+    }
+  }
+
+  handleSseEvent(block) {
+    const lines = block.split(/\r?\n/);
+    let eventName = 'message';
+    const dataLines = [];
+
+    for (const line of lines) {
+      if (!line || line.startsWith(':')) {
+        continue;
+      }
+      if (line.startsWith('event:')) {
+        eventName = line.slice(6).trim() || 'message';
+        continue;
+      }
+      if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5).trimStart());
+      }
+    }
+
+    const data = dataLines.join('\n').trim();
+    if (!data) {
+      return;
+    }
+
+    logChromeInboundEvent('sse', eventName, data);
+
+    if (eventName === 'endpoint') {
+      if (this.endpointFallbackTimer) {
+        clearTimeout(this.endpointFallbackTimer);
+        this.endpointFallbackTimer = null;
+      }
+      this.postUrl = new URL(data, this.streamUrl).toString();
+      log.info(`[Chrome MCP][sse] endpoint event -> ${this.postUrl}`);
+      this.endpointResolve?.(this.postUrl);
+      return;
+    }
+
+    try {
+      const message = JSON.parse(data);
+      logChromeInboundMessage('sse', message);
+      this.handleIncomingMessage(message);
+    } catch (err) {
+      log.warn(`[Chrome MCP][SSE] 无法解析事件: ${truncateText(data, 240)} (${err.message})`);
+    }
+  }
+
+  handleIncomingMessage(message) {
+    if (message?.method && message?.id !== undefined) {
+      this.postJsonRpc({
+        jsonrpc: '2.0',
+        id: message.id,
+        error: { code: -32601, message: 'sagent does not handle server-initiated MCP requests' },
+      }).catch(() => {});
+      return;
+    }
+
+    if (message?.id !== undefined) {
+      const pending = this.pending.get(message.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(message.id);
+      clearTimeout(pending.timer);
+      if (message.error) {
+        pending.reject(new Error(`Chrome MCP 请求失败: ${message.error.message || safeJson(message.error)}`));
+        return;
+      }
+      pending.resolve(message.result);
+    }
+  }
+
+  rejectAllPending(error) {
+    for (const [id, pending] of this.pending.entries()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+      this.pending.delete(id);
+    }
+  }
+
+  async postJsonRpc(message) {
+    const endpoint = await this.ensureStreamOpen();
+    const candidates = [endpoint, this.postUrl, ...this.fallbackPostUrls]
+      .filter((value, index, array) => typeof value === 'string' && value && array.indexOf(value) === index);
+
+    let lastError = null;
+    const method = message?.method || 'unknown';
+    const params = message?.params || {};
+
+    for (const candidate of candidates) {
+      logChromeRequest('sse', candidate, method, params, message?.id !== undefined ? `id=${message.id}` : 'notification=true');
+      const response = await fetch(candidate, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify(message),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        logChromeResponse('sse', candidate, method, response.status, body);
+        lastError = new Error(`HTTP ${response.status}: ${truncateText(body, 240)}`);
+        if (response.status === 404) {
+          continue;
+        }
+        throw lastError;
+      }
+
+      this.postUrl = candidate;
+      logChromeResponse('sse', candidate, method, response.status);
+      const contentType = response.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        const json = await response.json();
+        log.info(`[Chrome MCP][sse] json response method=${method} payload=${summarizeRpcMessage(json)}`);
+        this.handleIncomingMessage(json);
+      }
+      return;
+    }
+
+    throw lastError || new Error('Chrome MCP SSE 消息发送失败');
+  }
+
+  async ensureInitialized() {
+    if (this.initialized) {
+      return;
+    }
+    if (this.initializePromise) {
+      return this.initializePromise;
+    }
+
+    this.initializePromise = (async () => {
+      await this.ensureStreamOpen();
+      let lastError = null;
+
+      for (const version of DEFAULT_PROTOCOL_VERSIONS) {
+        try {
+          await this.sendRequest('initialize', {
+            protocolVersion: version,
+            capabilities: {},
+            clientInfo: CLIENT_INFO,
+          }, { skipInit: true });
+          await this.sendNotification('notifications/initialized', {});
+          this.initialized = true;
+          return;
+        } catch (err) {
+          lastError = err;
+        }
+      }
+
+      throw lastError || new Error('Chrome MCP initialize 失败');
+    })().finally(() => {
+      this.initializePromise = null;
+    });
+
+    return this.initializePromise;
+  }
+
+  async sendNotification(method, params) {
+    await this.postJsonRpc({
+      jsonrpc: '2.0',
+      method,
+      params: params || {},
+    });
+  }
+
+  async sendRequest(method, params, { skipInit = false } = {}) {
+    if (!skipInit) {
+      await this.ensureInitialized();
+    }
+
+    const id = this.nextId++;
+    return new Promise(async (resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Chrome MCP 请求超时: ${method}`));
+      }, 15000);
+
+      this.pending.set(id, { resolve, reject, timer });
+
+      try {
+        await this.postJsonRpc({
+          jsonrpc: '2.0',
+          id,
+          method,
+          params: params || {},
+        });
+      } catch (err) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  async request(method, params) {
+    return this.sendRequest(method, params);
+  }
+
+  async close() {
+    if (this.endpointFallbackTimer) {
+      clearTimeout(this.endpointFallbackTimer);
+      this.endpointFallbackTimer = null;
+    }
+    this.abortController?.abort();
+    this.abortController = null;
+    this.rejectAllPending(new Error('Chrome MCP SSE 客户端已关闭'));
+    this.initialized = false;
+    this.initializePromise = null;
+    this.streamPromise = null;
+  }
+}
+
+export function createChromeMcpClient(config = loadChromeMcpConfig()) {
+  if (!config.enabled) {
+    throw new Error('Chrome MCP 未启用，请在 .env 中设置 CHROME_MCP_ENABLED=true');
+  }
+
+  const transport = config.transport === 'stdio'
+    ? new StdioTransport(config)
+    : new SseTransport(config);
+
+  return new ChromeMcpClient(config, transport);
+}
+
+export async function getSharedChromeMcpClient(config = loadChromeMcpConfig()) {
+  const key = clientKey(config);
+  if (sharedClientPromise && sharedClientKey === key) {
+    return sharedClientPromise;
+  }
+
+  if (sharedClientPromise && sharedClientKey !== key) {
+    try {
+      const existing = await sharedClientPromise;
+      await existing.close();
+    } catch {
+      // noop
+    }
+  }
+
+  sharedClientKey = key;
+  sharedClientPromise = Promise.resolve(createChromeMcpClient(config));
+  return sharedClientPromise;
+}
+
+export async function resetChromeMcpClientForTests() {
+  if (!sharedClientPromise) {
+    sharedClientKey = '';
+    return;
+  }
+  try {
+    const client = await sharedClientPromise;
+    await client.close();
+  } catch {
+    // noop
+  } finally {
+    sharedClientPromise = null;
+    sharedClientKey = '';
+  }
+}
+
+export function formatChromeMcpError(error, context = '') {
+  const prefix = context ? `${context}: ` : '';
+  return `${prefix}${error?.message || safeJson(error)}`;
+}
+
+export function summarizeChromeTool(tool) {
+  const schema = extractSchema(tool);
+  const properties = schema?.properties || {};
+  const required = new Set(Array.isArray(schema?.required) ? schema.required : []);
+  const fields = Object.keys(properties)
+    .map(name => `${name}${required.has(name) ? '*' : ''}`)
+    .join(', ');
+
+  return {
+    name: tool?.name || '',
+    description: tool?.description || '',
+    fields,
+  };
+}
+
+export function serializeChromePayload(value) {
+  return safeJson(value);
+}

--- a/server.ts
+++ b/server.ts
@@ -38,6 +38,7 @@ import { createDesktopAgentRunner } from './agent/desktop/agent.ts';
 import { createClients, loadModelConfig, loadAgentMultiModels, isClaudeModel } from './agent/core/ai-client.ts';
 import { initWebViewDataStore } from './agent/tools/browser/webview-session.ts';
 import { loadIdeMcpConfig } from './agent/tools/ide/mcp-client.ts';
+import { loadChromeMcpConfig } from './agent/tools/chrome/mcp-client.ts';
 import { createChatRouter } from './routes/chat.ts';
 import { createAgentRouter } from './routes/agent.ts';
 import { createCompletionsRouter } from './routes/completions.ts';
@@ -144,6 +145,7 @@ async function resumeFromCheckpoint(cp) {
 app.listen(Number(PORT), HOST, async () => {
   const multiModels = loadAgentMultiModels();
   const ideConfig = loadIdeMcpConfig();
+  const chromeConfig = loadChromeMcpConfig();
   const W = 56;
   const rowPad = (s, n) => padEndW(truncateW(s, n), n);
   const row = (k, v) => `  │  ${rowPad(k, 28)}${rowPad(String(v), W - 32)}│`;
@@ -169,6 +171,7 @@ app.listen(Number(PORT), HOST, async () => {
   ${row('CHROME_PATH', process.env.AGENT_BROWSER_PATH || 'auto')}
   ${ideConfig.enabled ? row('IDE_MCP', `${ideConfig.transport} @ ${ideConfig.transport === 'stdio' ? ideConfig.command : (ideConfig.url || `${ideConfig.host}:${ideConfig.port}${ideConfig.ssePath}`)}`) : row('IDE_MCP', 'disabled')}
   ${ideConfig.enabled ? row('IDE_PROJECT_PATH', ideConfig.projectPath) : ''}
+  ${chromeConfig.enabled ? row('CHROME_MCP', `${chromeConfig.transport} @ ${chromeConfig.transport === 'stdio' ? chromeConfig.command : (chromeConfig.url || `${chromeConfig.host}:${chromeConfig.port}`)}`) : row('CHROME_MCP', 'disabled')}
   ${hLine}
   ${row('NVIDIA_API_KEY', process.env.NVIDIA_API_KEY ? '✓ configured' : '✗ not set')}
   ${row('ANTHROPIC_API_KEY', process.env.ANTHROPIC_API_KEY ? '✓ configured' : '✗ not set')}

--- a/test/chrome-tools.test.ts
+++ b/test/chrome-tools.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createModelTools } from '../agent/core/tool-definitions.ts';
+import { normalizeDesktopAgentDecision } from '../agent/core/schemas.ts';
+import { classifyAgentAction } from '../agent/policy/classify.ts';
+import {
+  loadChromeMcpConfig,
+  resetChromeMcpClientForTests,
+} from '../agent/tools/chrome/mcp-client.ts';
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(async () => {
+  process.env = { ...ORIGINAL_ENV };
+  await resetChromeMcpClientForTests();
+});
+
+describe('Chrome MCP tool exposure', () => {
+  it('does not expose Chrome tools when Chrome MCP is disabled', () => {
+    delete process.env.CHROME_MCP_ENABLED;
+    delete process.env.CHROME_MCP_TRANSPORT;
+    delete process.env.CHROME_MCP_URL;
+
+    const names = createModelTools().map(tool => tool.name);
+
+    expect(names).not.toContain('chrome_list_tools');
+    expect(names).not.toContain('chrome_call_tool');
+  });
+
+  it('exposes Chrome tools when Chrome MCP is enabled', () => {
+    process.env.CHROME_MCP_ENABLED = 'true';
+
+    const names = createModelTools().map(tool => tool.name);
+
+    expect(names).toContain('chrome_list_tools');
+    expect(names).toContain('chrome_call_tool');
+  });
+});
+
+describe('Chrome MCP action normalization', () => {
+  it('normalizes chrome_call_tool payloads', () => {
+    const result = normalizeDesktopAgentDecision({
+      rationale: '调用 Chrome 工具',
+      action: {
+        type: 'chrome_call_tool',
+        toolName: ' take_screenshot ',
+        arguments: { format: 'png' },
+        refreshTools: 1,
+      },
+    });
+
+    expect(result.action).toEqual({
+      tool: 'chrome',
+      type: 'chrome_call_tool',
+      toolName: 'take_screenshot',
+      arguments: { format: 'png' },
+      refreshTools: true,
+    });
+  });
+
+  it('normalizes chrome_list_tools payloads', () => {
+    const result = normalizeDesktopAgentDecision({
+      action: {
+        type: 'chrome_list_tools',
+        refresh: 'yes',
+      },
+    });
+
+    expect(result.action).toEqual({
+      tool: 'chrome',
+      type: 'chrome_list_tools',
+      refresh: true,
+    });
+  });
+
+  it('normalizes chrome_call alias', () => {
+    const result = normalizeDesktopAgentDecision({
+      action: {
+        type: 'chrome_call',
+        toolName: 'click',
+        arguments: { uid: 'abc123' },
+      },
+    });
+
+    expect(result.action.type).toBe('chrome_call_tool');
+    expect(result.action.toolName).toBe('click');
+  });
+});
+
+describe('Chrome MCP policy classification', () => {
+  it('treats chrome_list_tools as safe', () => {
+    const result = classifyAgentAction({
+      tool: 'chrome',
+      type: 'chrome_list_tools',
+    });
+
+    expect(result.level).toBe('safe');
+  });
+
+  it('treats known read-only Chrome tools as safe', () => {
+    for (const toolName of ['take_snapshot', 'take_screenshot', 'list_pages', 'list_console_messages']) {
+      const result = classifyAgentAction({
+        tool: 'chrome',
+        type: 'chrome_call_tool',
+        toolName,
+      });
+      expect(result.level).toBe('safe');
+    }
+  });
+
+  it('treats mutating Chrome tools as confirm', () => {
+    for (const toolName of ['click', 'fill', 'navigate_page', 'evaluate_script', 'press_key']) {
+      const result = classifyAgentAction({
+        tool: 'chrome',
+        type: 'chrome_call_tool',
+        toolName,
+      });
+      expect(result.level).toBe('confirm');
+    }
+  });
+
+  it('treats unknown Chrome tools as confirm', () => {
+    const result = classifyAgentAction({
+      tool: 'chrome',
+      type: 'chrome_call_tool',
+      toolName: 'some_unknown_tool',
+    });
+
+    expect(result.level).toBe('confirm');
+  });
+});
+
+describe('Chrome MCP config', () => {
+  it('loads defaults when disabled', () => {
+    delete process.env.CHROME_MCP_ENABLED;
+    const config = loadChromeMcpConfig();
+
+    expect(config.enabled).toBe(false);
+    expect(config.transport).toBe('sse');
+    expect(config.port).toBe(3099);
+  });
+
+  it('detects enabled via CHROME_MCP_ENABLED', () => {
+    process.env.CHROME_MCP_ENABLED = 'true';
+    const config = loadChromeMcpConfig();
+
+    expect(config.enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- 新增 Chrome DevTools MCP 集成，架构完全对标现有 IDE MCP
- 支持 SSE 和 stdio 两种传输方式，默认通过 `npx -y @anthropic-ai/chrome-devtools-mcp@latest` 启动
- 环境变量配置：`CHROME_MCP_ENABLED`, `CHROME_MCP_TRANSPORT`, `CHROME_MCP_HOST`, `CHROME_MCP_PORT`, `CHROME_MCP_URL`, `CHROME_MCP_COMMAND`, `CHROME_MCP_ARGS`
- Agent 可通过 `chrome_list_tools` 发现 Chrome 工具，通过 `chrome_call_tool` 调用

## 新建文件
- `agent/tools/chrome/mcp-client.ts` — MCP 客户端（Stdio + SSE 双传输）
- `agent/tools/chrome/execute.ts` — 动作执行桥接
- `test/chrome-tools.test.ts` — 11 个测试用例

## 修改文件
- `agent/core/action-types.ts` — 添加 chrome 动作类型映射
- `agent/core/schemas.ts` — 添加 normalizeChromeAction
- `agent/core/tool-definitions.ts` — 条件注册 chrome 工具
- `agent/core/prompts.ts` — 注入 Chrome 工具提示和 JSON 示例
- `agent/policy/classify.ts` — 安全策略（只读工具 safe，其余 confirm）
- `agent/desktop/agent.ts` — 注册 chrome 处理器
- `server.ts` — 启动 banner 显示 Chrome MCP 状态

## 安全策略
- **safe（自动执行）**: take_snapshot, take_screenshot, list_pages, list_console_messages, list_network_requests, wait_for, lighthouse_audit 等
- **confirm（需用户确认）**: click, fill, navigate_page, evaluate_script 等所有变更操作

## Test plan
- [x] `npx tsc --noEmit` 编译通过
- [x] `npx vitest run` 全部 51 测试通过（含 11 个新 Chrome 测试）
- [ ] 设置 `CHROME_MCP_ENABLED=true` 启动，banner 显示 Chrome MCP 状态
- [ ] Agent 运行时通过 `chrome_list_tools` 发现 Chrome 工具并调用