### PR TITLE
fix: improve 429 rate limit retry strategy

### DIFF
--- a/agent/core/ai-client.ts
+++ b/agent/core/ai-client.ts
@@ -67,7 +67,7 @@ export function createClients() {
   const anthropicKey = process.env.ANTHROPIC_API_KEY;
 
   const openai_client = nvidiaKey
-    ? new OpenAI({ apiKey: nvidiaKey, baseURL: 'https://integrate.api.nvidia.com/v1' })
+    ? new OpenAI({ apiKey: nvidiaKey, baseURL: 'https://integrate.api.nvidia.com/v1', maxRetries: 0 })
     : null;
 
   const anthropic_client = anthropicKey

--- a/helpers/retry.ts
+++ b/helpers/retry.ts
@@ -2,6 +2,7 @@ import { log } from './logger.ts';
 
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
+const RATE_LIMIT_BASE_MS = 5000;
 
 function isRetryableError(err) {
   const msg = err?.message || '';
@@ -9,6 +10,11 @@ function isRetryableError(err) {
   if (status === 429 || status >= 500) return true;
   if (/rate.?limit|overloaded|timeout|ECONNRESET|ECONNREFUSED|ETIMEDOUT|socket hang up|fetch failed/i.test(msg)) return true;
   return false;
+}
+
+function isRateLimitError(err) {
+  const status = err?.status || err?.statusCode || 0;
+  return status === 429;
 }
 
 function extractRetryDelayMs(err) {
@@ -34,10 +40,13 @@ export async function retryAsync(fn, maxRetries = MAX_RETRIES) {
     } catch (err) {
       if (attempt === maxRetries || !isRetryableError(err)) throw err;
       const retryAfterMs = extractRetryDelayMs(err);
-      const delay = retryAfterMs != null
-        ? Math.min(retryAfterMs + Math.random() * 500, 60000)
-        : Math.min(BASE_DELAY_MS * 2 ** attempt + Math.random() * 500, 15000);
-      log.warn(`[Retry] attempt=${attempt + 1}/${maxRetries} delay=${Math.round(delay)}ms${retryAfterMs != null ? ' (retry-after)' : ''} error=${err.message}`);
+      const is429 = isRateLimitError(err);
+      const base = retryAfterMs != null
+        ? retryAfterMs
+        : is429 ? RATE_LIMIT_BASE_MS : BASE_DELAY_MS;
+      const cap = is429 ? 60000 : 15000;
+      const delay = Math.min(base * 2 ** attempt + Math.random() * 500, cap);
+      log.warn(`[Retry] attempt=${attempt + 1}/${maxRetries} delay=${Math.round(delay)}ms${retryAfterMs != null ? ' (retry-after)' : is429 ? ' (429-backoff)' : ''} error=${err.message}`);
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }


### PR DESCRIPTION
## Summary
- 429 无 Retry-After 时退避从 1s/2s/4s 提升到 5s/10s/20s，cap 从 15s 提升到 60s
- 禁用 OpenAI SDK 内置重试（`maxRetries: 0`），避免与 `retryAsync` 双重重试浪费配额
- 日志新增 `(429-backoff)` 标记，便于区分 429 退避和普通重试

## Test plan
- [ ] 触发 kimi-k2.6 的 429 限速，确认延迟为 ~5s/10s/20s 而非 ~1s/2s/4s
- [ ] 确认非 429 错误的重试行为不变（1s/2s/4s cap 15s）
- [ ] 确认有 Retry-After 头时仍优先使用服务端返回的值