### PR TITLE
feat: add Chrome MCP config to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,13 @@ IDE_PROJECT_PATH=.
 # ─── Memory & Storage ────────────────────────────────────
 # MEMORY_DIR=data
 
+# ─── Chrome MCP（可选） ───────────────────────────────────
+# 启用后，Agent 可通过 Chrome DevTools MCP 控制浏览器进行网页操作
+CHROME_MCP_ENABLED=true
+CHROME_MCP_TRANSPORT=stdio
+CHROME_MCP_COMMAND=node_modules/.bin/chrome-devtools-mcp
+CHROME_MCP_ARGS=["--autoConnect"]
+
 # ─── Logging ──────────────────────────────────────────────
 # debug | info (default) | warn | error
 LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- Add Chrome DevTools MCP configuration section to `.env.example`
- Includes `CHROME_MCP_ENABLED`, `CHROME_MCP_TRANSPORT`, `CHROME_MCP_COMMAND`, `CHROME_MCP_ARGS`

## Test plan
- [ ] Verify `.env.example` contains the new Chrome MCP section
- [ ] Confirm the config keys match what the code expects