### PR TITLE
fix: Chrome MCP auto-snapshot + cancel/rollback bug fixes + UI improvements

### DIFF
--- a/agent/core/checkpoint.ts
+++ b/agent/core/checkpoint.ts
@@ -94,6 +94,16 @@ function sessionDir(dir: string, runId: string) {
   return join(dir, 'session-checkpoints', runId);
 }
 
+export async function listSessionCheckpointRuns(dir: string) {
+  const scDir = join(dir, 'session-checkpoints');
+  try {
+    const entries = await readdir(scDir);
+    return entries.filter(e => !e.startsWith('.'));
+  } catch {
+    return [];
+  }
+}
+
 function healthyPath(dir: string, runId: string, step: number) {
   return join(sessionDir(dir, runId), `session-healthy-${step}.json`);
 }

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -142,7 +142,7 @@ export function buildNvidiaTaskMessages({
     },
     {
       role: 'user',
-      content: JSON.stringify({ task, step, history, observation }, null, 2),
+      content: JSON.stringify({ task, step, history, observation }),
     },
   ];
 }

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -46,7 +46,7 @@ export function buildClaudeTaskMessages({
   }
   messages.push({
     role: 'user',
-    content: JSON.stringify({ task, step, history, observation }, null, 2),
+    content: JSON.stringify({ task, step, history, observation }),
   });
   return messages;
 }
@@ -138,7 +138,7 @@ export function buildNvidiaTaskMessages({
         conversationSummary,
       ]
         .filter(Boolean)
-        .join('\n'),
+        .join(' '),
     },
     {
       role: 'user',

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -117,26 +117,25 @@ export async function runAgentRuntime({
       if (sessionCheckpointDir && runRecord && shouldRollback(runRecord)) {
         const targetStep = runRecord.pendingRollback;
         log.info(`[Runtime] 执行回滚到第 ${targetStep} 步, dir=${sessionCheckpointDir}, runId=${runRecord.runId}`);
-        const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, targetStep);
+        const snapshot = await loadLatestHealthySnapshot(sessionCheckpointDir, runRecord.runId, targetStep - 1);
         if (snapshot) {
           history.length = 0;
           for (const h of snapshot.history) {
             history.push({ ...h });
           }
-          step = targetStep - 1;
-          runRecord.pendingRollback = null;
-          runRecord.rolledBack = true;
-
-          onEvent?.({
-            type: "rollback",
-            targetStep,
-            message: `已回滚到第 ${targetStep} 步`,
-          });
-          continue;
         } else {
-          log.warn(`[Runtime] 回滚失败: 未找到第 ${targetStep} 步的健康快照`);
-          runRecord.pendingRollback = null;
+          history.length = 0;
         }
+        step = targetStep - 1;
+        runRecord.pendingRollback = null;
+        runRecord.rolledBack = true;
+
+        onEvent?.({
+          type: "rollback",
+          targetStep,
+          message: `已回滚到第 ${targetStep} 步`,
+        });
+        continue;
       }
 
       // ---- 观察 ----

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -162,6 +162,11 @@ export async function runAgentRuntime({
 
       const compactHistory = compressHistory(history, MAX_HISTORY_STEPS);
 
+      // ---- 决策前再次检查取消 ----
+      if (cancelled()) {
+        throw new Error("Agent 已取消");
+      }
+
       // ---- 决策 ----
       const decision = await decide({
         task,

--- a/agent/desktop/planner.ts
+++ b/agent/desktop/planner.ts
@@ -243,9 +243,54 @@ export function createDesktopPlanner({
     return new Promise((resolve, reject) => {
       let settled = false;
       let launched = 0;
+      let pendingFinishResult: any = null;
+      let pendingFinishModel: string | null = null;
       const failures: string[] = [];
       const timers: NodeJS.Timeout[] = [];
       const raceAc = new AbortController();
+
+      // 用 setTimeout 延迟 resolve：如果第一个结果不是 finish，等一小段时间看是否有 finish
+      let resolveTimer: NodeJS.Timeout | null = null;
+      const FINISH_WAIT_MS = 3000;
+
+      function doResolve(result: any) {
+        if (resolveTimer) { clearTimeout(resolveTimer); resolveTimer = null; }
+        settled = true;
+        raceAc.abort();
+        timers.forEach(timer => clearTimeout(timer));
+        resolve(result);
+      }
+
+      function onModelResult(candidate: string, result: any) {
+        const isFinish = result.action?.type === 'finish';
+
+        if (settled) {
+          onEvent?.({ type: 'model_plan', stage: 'cancelled', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
+          return;
+        }
+
+        if (isFinish) {
+          // finish 优先：立即采纳
+          log.info(`[MultiModel] ${candidate} 返回 finish，立即采纳`);
+          onEvent?.({ type: 'model_plan', stage: 'winner', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
+          doResolve(result);
+          return;
+        }
+
+        // 非 finish 结果
+        log.info(`[MultiModel] 使用 ${candidate} 的结果（${activeModels.join(', ')}）`);
+        onEvent?.({ type: 'model_plan', stage: 'winner', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
+
+        // 延迟 resolve：给其他模型一点时间返回 finish
+        pendingFinishResult = result;
+        pendingFinishModel = candidate;
+        if (resolveTimer) clearTimeout(resolveTimer);
+        resolveTimer = setTimeout(() => {
+          if (!settled && pendingFinishResult) {
+            doResolve(pendingFinishResult);
+          }
+        }, FINISH_WAIT_MS);
+      }
 
       function launchModel(candidate: string) {
         if (settled || cancelSignal?.aborted) return;
@@ -253,16 +298,7 @@ export function createDesktopPlanner({
         onEvent?.({ type: 'model_plan', stage: 'thinking', model: candidate, step });
         planWithTimeout(candidate, planCtx, cancelSignal, raceAc.signal)
           .then(result => {
-            if (settled) {
-              onEvent?.({ type: 'model_plan', stage: 'cancelled', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
-              return;
-            }
-            settled = true;
-            raceAc.abort();
-            timers.forEach(timer => clearTimeout(timer));
-            log.info(`[MultiModel] 使用 ${candidate} 的结果（${activeModels.join(', ')}）`);
-            onEvent?.({ type: 'model_plan', stage: 'winner', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
-            resolve(result);
+            onModelResult(candidate, result);
           })
           .catch((err: any) => {
             if (settled) {

--- a/agent/desktop/planner.ts
+++ b/agent/desktop/planner.ts
@@ -243,54 +243,9 @@ export function createDesktopPlanner({
     return new Promise((resolve, reject) => {
       let settled = false;
       let launched = 0;
-      let pendingFinishResult: any = null;
-      let pendingFinishModel: string | null = null;
       const failures: string[] = [];
       const timers: NodeJS.Timeout[] = [];
       const raceAc = new AbortController();
-
-      // 用 setTimeout 延迟 resolve：如果第一个结果不是 finish，等一小段时间看是否有 finish
-      let resolveTimer: NodeJS.Timeout | null = null;
-      const FINISH_WAIT_MS = 3000;
-
-      function doResolve(result: any) {
-        if (resolveTimer) { clearTimeout(resolveTimer); resolveTimer = null; }
-        settled = true;
-        raceAc.abort();
-        timers.forEach(timer => clearTimeout(timer));
-        resolve(result);
-      }
-
-      function onModelResult(candidate: string, result: any) {
-        const isFinish = result.action?.type === 'finish';
-
-        if (settled) {
-          onEvent?.({ type: 'model_plan', stage: 'cancelled', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
-          return;
-        }
-
-        if (isFinish) {
-          // finish 优先：立即采纳
-          log.info(`[MultiModel] ${candidate} 返回 finish，立即采纳`);
-          onEvent?.({ type: 'model_plan', stage: 'winner', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
-          doResolve(result);
-          return;
-        }
-
-        // 非 finish 结果
-        log.info(`[MultiModel] 使用 ${candidate} 的结果（${activeModels.join(', ')}）`);
-        onEvent?.({ type: 'model_plan', stage: 'winner', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
-
-        // 延迟 resolve：给其他模型一点时间返回 finish
-        pendingFinishResult = result;
-        pendingFinishModel = candidate;
-        if (resolveTimer) clearTimeout(resolveTimer);
-        resolveTimer = setTimeout(() => {
-          if (!settled && pendingFinishResult) {
-            doResolve(pendingFinishResult);
-          }
-        }, FINISH_WAIT_MS);
-      }
 
       function launchModel(candidate: string) {
         if (settled || cancelSignal?.aborted) return;
@@ -298,7 +253,16 @@ export function createDesktopPlanner({
         onEvent?.({ type: 'model_plan', stage: 'thinking', model: candidate, step });
         planWithTimeout(candidate, planCtx, cancelSignal, raceAc.signal)
           .then(result => {
-            onModelResult(candidate, result);
+            if (settled) {
+              onEvent?.({ type: 'model_plan', stage: 'cancelled', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
+              return;
+            }
+            settled = true;
+            raceAc.abort();
+            timers.forEach(timer => clearTimeout(timer));
+            log.info(`[MultiModel] 使用 ${candidate} 的结果（${activeModels.join(', ')}）`);
+            onEvent?.({ type: 'model_plan', stage: 'winner', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
+            resolve(result);
           })
           .catch((err: any) => {
             if (settled) {

--- a/agent/tools/chrome/execute.ts
+++ b/agent/tools/chrome/execute.ts
@@ -7,7 +7,7 @@ import {
   summarizeChromeTool,
 } from './mcp-client.ts';
 
-const MAX_TEXT = 24000;
+const MAX_TEXT = 48000;
 
 function truncate(text, max = MAX_TEXT) {
   const value = String(text || '');

--- a/agent/tools/chrome/execute.ts
+++ b/agent/tools/chrome/execute.ts
@@ -89,15 +89,15 @@ export async function executeChromeAction(action) {
       `结果:\n${content}`,
     ];
 
-    // navigate_page / new_page 成功后自动截图，让 LLM 立即看到页面
+    // navigate_page / new_page 成功后自动获取页面快照，让 LLM 立即看到页面内容
     const NAVIGATE_TOOLS = new Set(['navigate_page', 'new_page']);
     if (!result?.isError && NAVIGATE_TOOLS.has(toolName)) {
       try {
-        const screenshotResult = await client.callTool('take_screenshot', {});
-        const screenshotContent = extractToolContent(screenshotResult);
-        parts.push(`\n[自动截图]\n${screenshotContent}`);
+        const snapshotResult = await client.callTool('take_snapshot', {});
+        const snapshotContent = extractToolContent(snapshotResult);
+        parts.push(`\n[页面快照]\n${snapshotContent}`);
       } catch {
-        parts.push('\n[自动截图失败，页面可能仍在加载]');
+        parts.push('\n[页面快照获取失败，页面可能仍在加载]');
       }
     }
 

--- a/agent/tools/chrome/execute.ts
+++ b/agent/tools/chrome/execute.ts
@@ -83,11 +83,25 @@ export async function executeChromeAction(action) {
     const content = extractToolContent(result);
     const status = result?.isError ? '失败' : '完成';
 
-    return truncate([
+    const parts = [
       `Chrome 工具 ${toolName} 执行${status}`,
       `参数: ${serializeChromePayload(args)}`,
       `结果:\n${content}`,
-    ].join('\n\n'));
+    ];
+
+    // navigate_page / new_page 成功后自动截图，让 LLM 立即看到页面
+    const NAVIGATE_TOOLS = new Set(['navigate_page', 'new_page']);
+    if (!result?.isError && NAVIGATE_TOOLS.has(toolName)) {
+      try {
+        const screenshotResult = await client.callTool('take_screenshot', {});
+        const screenshotContent = extractToolContent(screenshotResult);
+        parts.push(`\n[自动截图]\n${screenshotContent}`);
+      } catch {
+        parts.push('\n[自动截图失败，页面可能仍在加载]');
+      }
+    }
+
+    return truncate(parts.join('\n\n'));
   }
 
   throw new Error(formatChromeMcpError(new Error(`不支持的 Chrome 动作类型: ${action.type}`), 'Chrome MCP'));

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1868,6 +1868,9 @@ textarea {
 
 .model-card-body { margin-top: 4px; }
 .model-card-body p { margin: 0; color: var(--c-text-secondary); line-height: 1.3; font-size: 11px; }
+.model-card-head .copy-btn { opacity: 0; width: 22px; height: 22px; border-radius: 4px; margin-left: auto; }
+.model-card:hover .model-card-head .copy-btn { opacity: 1; }
+.model-card-head .copy-btn.copied { opacity: 1; }
 
 .model-card-thinking {
   display: flex;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2498,7 +2498,7 @@ export default function App() {
         strategy: selectedAgentModels.length > 1 ? agentStrategy : 'race',
         memory: agentMemory,
         signal: controller.signal,
-        messages: isRetry ? [] : history.slice(-10),
+        messages: isRetry ? [] : messages.filter(m => m.role === 'user').slice(-5).map(m => ({ role: m.role, content: m.content })),
         ...extraBody,
         async onEvent(event) {
           console.log(`[AgentUI] event type=${event.type} step=${event.step ?? '-'} stage=${event.stage ?? '-'} model=${event.model || '-'}`);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2470,15 +2470,10 @@ export default function App() {
       setInput('');
       setAgentTrace([]);
     } else {
-      // Retry from checkpoint — remove old agent answers for this task to avoid duplicates
+      // Retry from checkpoint — keep filtered trace (handleRollback already removed steps > target)
       const cpStep = extraBody?.fromCheckpoint?.step;
       updateSession(sessionId, session => {
         const msgs = [...session.messages];
-        // 从后往前移除该任务的所有旧助手回复（含 placeholder 和已完成答案）
-        const taskIdx = msgs.findLastIndex(m => m.role === 'user' && m.content === text);
-        if (taskIdx >= 0) {
-          msgs.splice(taskIdx + 1); // 移除用户消息之后的所有消息
-        }
         const stepInfo = cpStep ? `从第 ${cpStep} 步` : '';
         msgs.push({ role: 'assistant', content: `Desktop Agent 正在${stepInfo}重新执行任务：${text}`, ts: Date.now() });
         return touchSession(session, { messages: msgs });
@@ -2503,7 +2498,7 @@ export default function App() {
         strategy: selectedAgentModels.length > 1 ? agentStrategy : 'race',
         memory: agentMemory,
         signal: controller.signal,
-        messages: history.slice(-10),
+        messages: isRetry ? [] : history.slice(-10),
         ...extraBody,
         async onEvent(event) {
           console.log(`[AgentUI] event type=${event.type} step=${event.step ?? '-'} stage=${event.stage ?? '-'} model=${event.model || '-'}`);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -563,7 +563,7 @@ function CopyButton({ text }) {
   };
 
   return (
-    <button className={`copy-btn ${copied ? 'copied' : ''}`} onClick={handle} title="复制">
+    <button className={`copy-btn ${copied ? 'copied' : ''}`} onClick={(e) => { e.stopPropagation(); handle(); }} title="复制">
       {copied ? <Check size={14} /> : <Copy size={14} />}
     </button>
   );
@@ -1059,12 +1059,22 @@ function ModelPlanCard({ event, isWinner, modelList, result, forceExpanded, onMa
 
   if (stage === 'start') return null;
 
+  // 拼接整个决策节点的可复制文本
+  const copyText = [
+    event.rationale,
+    event.reasoning,
+    event.action ? JSON.stringify(event.action, null, 2) : '',
+    event.error,
+    result,
+  ].filter(Boolean).join('\n\n');
+
   return (
     <div className={`model-card ${stage} ${isWinner ? 'winner' : ''} ${effectiveExpanded ? 'expanded' : ''}`} onClick={() => { if (forceExpanded != null) onManualToggle?.(); setExpanded(v => !v); }}>
       <div className="model-card-head">
         <span className="model-card-icon">{PLAN_STAGE_ICON[stage] || '·'}</span>
         <span className="model-card-label">{label}</span>
         <span className={`model-card-status ${stage}`}>{PLAN_STAGE_LABELS[stage] || stage}</span>
+        {copyText && <CopyButton text={copyText} />}
         <span className="model-card-expand-icon">{effectiveExpanded ? <ChevronUp size={10} /> : <ChevronDown size={10} />}</span>
       </div>
       {stage === 'pending' && (

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1175,7 +1175,7 @@ function ModelPlanCard({ event, isWinner, modelList, result, forceExpanded, onMa
 
 // 多模型一步会产生多条 model_plan 事件。这个组件负责把零散事件重新聚合成
 // 一个“按 step 分组”的展示块，让用户能看到同一步里不同模型如何竞争/投票。
-function ModelPlanGroup({ trace, step, models, modelList, running, cardsExpanded, onManualToggle }) {
+function ModelPlanGroup({ trace, step, models, modelList, running, cardsExpanded, onManualToggle, onRollback, rollbackLoading }) {
   let strategyMode = 'race';
   let consensusEvent = null;
   const modelEvents = {};
@@ -1219,6 +1219,9 @@ function ModelPlanGroup({ trace, step, models, modelList, running, cardsExpanded
       <span className="agent-trace-badge plan">
         {strategyMode === 'vote' ? '投票' : '决策'}
       </span>
+      <button className="trace-rollback-btn" onClick={(e) => { e.stopPropagation(); onRollback?.(step); }} disabled={rollbackLoading} title={`从 Step ${step} 重新执行`}>
+        <RotateCcw size={10} />
+      </button>
       <div className="model-plan-cards">
         {visibleModels.map(m => (
           <ModelPlanCard
@@ -1556,7 +1559,7 @@ function AgentPanel({ mode, running, trace, startedAt, modelList, collapsed, onT
             // (other stages like thinking/success/failed are collected inside ModelPlanGroup)
             if (event.type === 'model_plan' && event.stage !== 'start' && event.stage !== 'consensus') return null;
             if (event.type === 'model_plan' && event.stage === 'start') {
-              return <ModelPlanGroup key={`model-plan-step-${event.step || index}`} trace={trace} step={event.step} models={event.models} modelList={modelList} running={running} cardsExpanded={cardsExpanded} onManualToggle={() => setCardsExpanded(null)} />;
+              return <ModelPlanGroup key={`model-plan-step-${event.step || index}`} trace={trace} step={event.step} models={event.models} modelList={modelList} running={running} cardsExpanded={cardsExpanded} onManualToggle={() => setCardsExpanded(null)} onRollback={onRollback} rollbackLoading={rollbackLoading} />;
             }
             // For multi-model steps, skip separate action/result items (shown inside model cards)
             if (event.type === 'step' && (event.stage === 'action' || event.stage === 'result') && multiModelSteps.has(event.step)) {
@@ -1655,6 +1658,9 @@ function AgentPanel({ mode, running, trace, startedAt, modelList, collapsed, onT
                           </span>
                         </span>
                       )}
+                      <button className="trace-rollback-btn" onClick={(e) => { e.stopPropagation(); onRollback(event.step); }} disabled={rollbackLoading} title={`从 Step ${event.step} 重新执行`}>
+                        <RotateCcw size={10} />
+                      </button>
                     </div>
                     {event.rationale && <p>{event.rationale}</p>}
                     <pre className="agent-json">{JSON.stringify(event.action, null, 2)}</pre>
@@ -1795,9 +1801,6 @@ function AgentPanel({ mode, running, trace, startedAt, modelList, collapsed, onT
                   <div className="agent-trace-content">
                     <strong>Step {event.step} 健康快照已保存</strong>
                   </div>
-                  <button className="trace-rollback-btn" onClick={() => onRollback(event.step)} disabled={rollbackLoading || running} title={`回滚到 Step ${event.step}`}>
-                    <RotateCcw size={10} />
-                  </button>
                 </>
               )}
             </div>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2470,10 +2470,15 @@ export default function App() {
       setInput('');
       setAgentTrace([]);
     } else {
-      // Retry from checkpoint — keep filtered trace (handleRollback already removed steps > target)
+      // Retry from checkpoint — remove old agent answers for this task to avoid duplicates
       const cpStep = extraBody?.fromCheckpoint?.step;
       updateSession(sessionId, session => {
         const msgs = [...session.messages];
+        // 从后往前移除该任务的所有旧助手回复（含 placeholder 和已完成答案）
+        const taskIdx = msgs.findLastIndex(m => m.role === 'user' && m.content === text);
+        if (taskIdx >= 0) {
+          msgs.splice(taskIdx + 1); // 移除用户消息之后的所有消息
+        }
         const stepInfo = cpStep ? `从第 ${cpStep} 步` : '';
         msgs.push({ role: 'assistant', content: `Desktop Agent 正在${stepInfo}重新执行任务：${text}`, ts: Date.now() });
         return touchSession(session, { messages: msgs });

--- a/helpers/run-agent.ts
+++ b/helpers/run-agent.ts
@@ -34,12 +34,14 @@ export async function loadMemoryForPrompt(memoryDir: string) {
   }
 }
 
-export async function cleanupAgentRun(checkpointDir: string | undefined, runId: string, agentRunStore: any) {
+export async function cleanupAgentRun(checkpointDir: string | undefined, runId: string, agentRunStore: any, { removeSnapshots = false }: { removeSnapshots?: boolean } = {}) {
   if (checkpointDir) {
-    await Promise.all([
-      removeCheckpoint(checkpointDir, runId).catch(() => {}),
-      removeSessionCheckpoints(checkpointDir, runId).catch(() => {}),
-    ]);
+    // step-level checkpoint 只用于崩溃恢复，任务完成后可删除
+    await removeCheckpoint(checkpointDir, runId).catch(() => {});
+    // session snapshots 用于回滚，只在启动新任务时才清理
+    if (removeSnapshots) {
+      await removeSessionCheckpoints(checkpointDir, runId).catch(() => {});
+    }
   }
   agentRunStore.closeRun(runId);
 }

--- a/routes/agent-run-control.ts
+++ b/routes/agent-run-control.ts
@@ -1,16 +1,22 @@
 import { Router } from 'express';
 import type { AgentRouterContext } from './agent-types.ts';
+import { removeCheckpoint, removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
 
-export function createAgentRunControlRouter({ agentRunStore, approvalStore }: AgentRouterContext) {
+export function createAgentRunControlRouter({ agentRunStore, approvalStore, checkpointDir }: AgentRouterContext) {
   const router = Router();
 
-  router.post('/api/agent/cancel', (req, res) => {
+  router.post('/api/agent/cancel', async (req, res) => {
     const { runId } = req.body ?? {};
     if (typeof runId !== 'string' || !runId) {
       return res.status(400).json({ error: 'runId 不能为空' });
     }
     agentRunStore.cancelRun(runId);
     approvalStore.rejectAll();
+    // 立即清理 checkpoint，防止重启后恢复已取消的任务
+    await Promise.all([
+      removeCheckpoint(checkpointDir, runId),
+      removeSessionCheckpoints(checkpointDir, runId),
+    ]);
     return res.json({ ok: true });
   });
 

--- a/routes/agent-run-control.ts
+++ b/routes/agent-run-control.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import type { AgentRouterContext } from './agent-types.ts';
 import { removeCheckpoint, removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
+import { log } from '../helpers/logger.ts';
 
 export function createAgentRunControlRouter({ agentRunStore, approvalStore, checkpointDir }: AgentRouterContext) {
   const router = Router();
@@ -10,13 +11,21 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
     if (typeof runId !== 'string' || !runId) {
       return res.status(400).json({ error: 'runId 不能为空' });
     }
+    log.warn(`[Cancel] 用户手动停止任务 runId=${runId}`);
     agentRunStore.cancelRun(runId);
+    log.warn(`[Cancel] cancelRun 完成 runId=${runId}`);
     approvalStore.rejectAll();
+    log.warn(`[Cancel] rejectAll 完成 runId=${runId}`);
     // 立即清理 checkpoint，防止重启后恢复已取消的任务
-    await Promise.all([
-      removeCheckpoint(checkpointDir, runId),
-      removeSessionCheckpoints(checkpointDir, runId),
-    ]);
+    try {
+      await Promise.all([
+        removeCheckpoint(checkpointDir, runId),
+        removeSessionCheckpoints(checkpointDir, runId),
+      ]);
+      log.warn(`[Cancel] checkpoint 清理完成 runId=${runId}`);
+    } catch (err: any) {
+      log.warn(`[Cancel] checkpoint 清理失败 runId=${runId}: ${err.message}`);
+    }
     return res.json({ ok: true });
   });
 

--- a/routes/agent-run-request.ts
+++ b/routes/agent-run-request.ts
@@ -36,10 +36,15 @@ export async function resolveCheckpointSeed(checkpointDir: string, fromCheckpoin
     const cpRunId = fromCheckpoint.runId;
     const cpStep = fromCheckpoint.step;
     if (typeof cpRunId === 'string' && typeof cpStep === 'number') {
-      const snapshot = await loadLatestHealthySnapshot(checkpointDir, cpRunId, cpStep);
+      // 加载目标步骤前一步的快照，保留之前的上下文，从目标步重新执行
+      const snapshot = await loadLatestHealthySnapshot(checkpointDir, cpRunId, cpStep - 1);
       if (snapshot) {
-        checkpointInitialStep = snapshot.step + 1;
+        checkpointInitialStep = cpStep;
         checkpointInitialHistory = snapshot.history || [];
+      } else {
+        // 目标是第 1 步且无更早快照 → 从头开始
+        checkpointInitialStep = 1;
+        checkpointInitialHistory = [];
       }
     }
   }

--- a/routes/agent-run-start.ts
+++ b/routes/agent-run-start.ts
@@ -6,6 +6,7 @@ import { persistAgentRunMemory } from './agent-run-memory-persist.ts';
 import { createAgentRunSession } from './agent-run-session.ts';
 import { parseAgentRunRequest, resolveCheckpointSeed } from './agent-run-request.ts';
 import { executeAgentRun } from './agent-run-execution.ts';
+import { removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
 
 export function createAgentRunStartRouter({
   runDesktopAgent,
@@ -33,6 +34,16 @@ export function createAgentRunStartRouter({
     }
 
     const { checkpointInitialStep, checkpointInitialHistory } = await resolveCheckpointSeed(checkpointDir, fromCheckpoint);
+
+    // 清理上一个 run 的 session snapshots（fromCheckpoint 回滚时保留当前 run 的快照）
+    const prevRunId = fromCheckpoint?.runId;
+    if (checkpointDir && !fromCheckpoint) {
+      const { listSessionCheckpointRuns } = await import('../agent/core/checkpoint.ts');
+      const runs = await listSessionCheckpointRuns(checkpointDir);
+      for (const rid of runs) {
+        removeSessionCheckpoints(checkpointDir, rid).catch(() => {});
+      }
+    }
 
     const normalizedTask = task.trim();
     const agentHeadless = typeof headless === 'boolean' ? headless : process.env.AGENT_HEADLESS === 'true';

--- a/test/rollback.test.ts
+++ b/test/rollback.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { saveHealthySnapshot } from '../agent/core/checkpoint.ts';
+import { resolveCheckpointSeed } from '../routes/agent-run-request.ts';
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-rollback-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+function makeHistory(steps: number[]) {
+  return steps.map(s => ({
+    step: s,
+    rationale: `step ${s} rationale`,
+    action: { type: 'click', elementId: `el-${s}` },
+    result: `step ${s} result`,
+  }));
+}
+
+describe('resolveCheckpointSeed: rollback history correctness', () => {
+  it('rollback to step 3 loads step 2 snapshot, starts from step 3', async () => {
+    const runId = 'run_rollback_3';
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 1, history: makeHistory([1]), state: null, result: 'ok' });
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 2, history: makeHistory([1, 2]), state: null, result: 'ok' });
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 3, history: makeHistory([1, 2, 3]), state: null, result: 'ok' });
+
+    const { checkpointInitialStep, checkpointInitialHistory } = await resolveCheckpointSeed(tmpDir, {
+      runId,
+      step: 3,
+    });
+
+    // 应从 step 3 开始（不是 step 4）
+    expect(checkpointInitialStep).toBe(3);
+    // history 应只包含 step 1, 2 的结果（step 2 的快照）
+    expect(checkpointInitialHistory).toHaveLength(2);
+    expect(checkpointInitialHistory[0].step).toBe(1);
+    expect(checkpointInitialHistory[1].step).toBe(2);
+  });
+
+  it('rollback to step 1 with no prior snapshot starts fresh', async () => {
+    const runId = 'run_rollback_1';
+    await saveHealthySnapshot({ dir: tmpDir, runId, step: 1, history: makeHistory([1]), state: null, result: 'ok' });
+
+    const { checkpointInitialStep, checkpointInitialHistory } = await resolveCheckpointSeed(tmpDir, {
+      runId,
+      step: 1,
+    });
+
+    // 无 step 0 快照 → 从 step 1 开始，空 history
+    expect(checkpointInitialStep).toBe(1);
+    expect(checkpointInitialHistory).toEqual([]);
+  });
+
+  it('rollback to step 5 loads step 4 snapshot', async () => {
+    const runId = 'run_rollback_5';
+    for (let s = 1; s <= 5; s++) {
+      await saveHealthySnapshot({ dir: tmpDir, runId, step: s, history: makeHistory([1, 2, 3, 4, 5].slice(0, s)), state: null, result: 'ok' });
+    }
+
+    const { checkpointInitialStep, checkpointInitialHistory } = await resolveCheckpointSeed(tmpDir, {
+      runId,
+      step: 5,
+    });
+
+    expect(checkpointInitialStep).toBe(5);
+    expect(checkpointInitialHistory).toHaveLength(4);
+    expect(checkpointInitialHistory.map((h: any) => h.step)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('no fromCheckpoint returns undefined', async () => {
+    const { checkpointInitialStep, checkpointInitialHistory } = await resolveCheckpointSeed(tmpDir, null);
+    expect(checkpointInitialStep).toBeUndefined();
+    expect(checkpointInitialHistory).toBeUndefined();
+  });
+});

--- a/test/session-checkpoint.test.ts
+++ b/test/session-checkpoint.test.ts
@@ -260,7 +260,7 @@ describe('runtime: session checkpoint integration', () => {
 
     const result = await runAgentRuntime({
       task: 'test',
-      maxSteps: 3,
+      maxSteps: 101,
       onEvent,
       cancelSignal,
       sessionCheckpointDir: tmpDir,
@@ -274,8 +274,9 @@ describe('runtime: session checkpoint integration', () => {
     });
 
     expect(runRecord.pendingRollback).toBeNull();
-    expect(evtLog.some(e => e.type === 'rollback')).toBe(false);
-    // Runtime returns result, it doesn't emit 'done' event itself
+    // 即使无快照，回滚仍会执行（清空 history，从 targetStep 重新开始）
+    expect(evtLog.some(e => e.type === 'rollback')).toBe(true);
+    expect(evtLog.find(e => e.type === 'rollback').targetStep).toBe(99);
     expect(result.answer).toBe('done');
     // Wait for fire-and-forget snapshot writes to complete
     await new Promise(r => setTimeout(r, 200));


### PR DESCRIPTION
## Summary

### Chrome MCP
- 导航后自动调用 `take_snapshot` 获取页面文本内容（非截图，避免 base64 截断）
- Chrome MCP 结果截断限制从 24k → 48k 字符，减少内容丢失

### Cancel 修复
- 取消任务时立即清理 checkpoint 文件，防止重启后恢复已取消任务
- `decide()` 前增加 cancel 检查，点击停止后不再发送 LLM 请求
- 用户手动停止时打印 WARN 日志，记录每步操作是否成功

### Rollback 修复
- 修复回滚历史：加载 step N-1 快照而非 step N，正确从目标步重新执行
- 任务结束后保留 session checkpoints（不再删除），回滚可用
- 回滚时不传旧 conversationHistory，避免污染 prompt
- 新任务启动时清理旧 session snapshots

### Prompt 优化
- system prompt 改为单行拼接（减少无效换行和 token）
- user message JSON 去掉缩进格式化
- 普通任务只传最近 5 条用户消息（不含 assistant 回复）

### UI
- 决策节点卡片头部加复制按钮（hover 显示，复制整个决策内容）
- 回滚按钮从快照事件移至每步标题旁（执行中也可见）

### 测试
- 新增 `test/rollback.test.ts`：验证 `resolveCheckpointSeed` 加载正确快照
- 更新 `session-checkpoint.test.ts`：适配回滚行为变更

### Revert
- 回退 finish 优先竞速逻辑（存在严重 bug）

## Test plan
- [x] `npx vitest run` 全部 55 个测试通过
- [ ] Chrome MCP `navigate_page` 后自动返回页面文本快照
- [ ] 点击停止后不再发起新的 LLM 请求
- [ ] 取消任务后重启不再恢复，日志记录完整
- [ ] 任务结束后点击任意步回滚按钮，验证从正确步骤重新执行
- [ ] 决策节点 hover 显示复制按钮，点击不折叠卡片