### PR TITLE
feat: macOS approval dialog + mobile expand/collapse fix

### DIFF
--- a/agent/policy/approvals.ts
+++ b/agent/policy/approvals.ts
@@ -1,17 +1,58 @@
-import { spawn } from 'node:child_process';
+import { spawn, execSync } from 'node:child_process';
 import { classifyAgentAction } from './classify.ts';
 import { cleanText } from '../core/utils.ts';
 import { log } from '../../helpers/logger.ts';
 
-function sendMacosNotification(title, body) {
-  if (process.platform !== 'darwin') {
-    log.warn(`[Notification] macOS 通知不可用，当前平台: ${process.platform}`);
-    return;
-  }
+const HOST = `http://127.0.0.1:${process.env.PORT || 3001}`;
+
+function showApprovalDialog(runId: string, approvalId: string, message: string) {
+  if (process.platform !== 'darwin') return;
+  const safeMsg = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ').slice(0, 200);
+  // 异步弹对话框，用户点击后回调 API
+  const script = `
+    set dialogResult to display alert "Agent 审批请求" message "${safeMsg}" as informational buttons {"拒绝", "批准"} default button "批准" cancel button "拒绝" giving up after 120
+    if button returned of dialogResult is "批准" then
+      return "approve"
+    else
+      return "reject"
+    end if`;
+  const child = spawn('osascript', ['-e', script], { stdio: ['pipe', 'pipe', 'pipe'] });
+  let stdout = '';
+  child.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
+  child.on('close', (code: number) => {
+    const decision = code === 0 ? 'approve' : 'reject';
+    log.info(`[ApprovalDialog] 用户${decision === 'approve' ? '批准' : '拒绝'} runId=${runId}`);
+    // 调 API 解除审批阻塞
+    const body = JSON.stringify({ runId, approvalId, decision });
+    spawn('curl', ['-s', '-X', 'POST', `${HOST}/api/agent/approvals`, '-H', 'Content-Type: application/json', '-d', body], { stdio: 'ignore' });
+  });
+}
+
+function showQuestionDialog(runId: string, approvalId: string, question: string) {
+  if (process.platform !== 'darwin') return;
+  const safeQ = question.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ').slice(0, 200);
+  const script = `
+    set dialogResult to display dialog "${safeQ}" default answer "" with title "Agent 提问" buttons {"跳过", "回答"} default button "回答" cancel button "跳过" giving up after 120
+    set userResponse to text returned of dialogResult
+    if userResponse is "" then return "__skip__"
+    return userResponse`;
+  const child = spawn('osascript', ['-e', script], { stdio: ['pipe', 'pipe', 'pipe'] });
+  let stdout = '';
+  child.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
+  child.on('close', (code: number) => {
+    const response = code === 0 ? stdout.trim() : '';
+    log.info(`[QuestionDialog] 用户回答: ${response || '(跳过)'} runId=${runId}`);
+    const body = JSON.stringify({ runId, approvalId, response: response === '__skip__' ? '' : response });
+    spawn('curl', ['-s', '-X', 'POST', `${HOST}/api/agent/question`, '-H', 'Content-Type: application/json', '-d', body], { stdio: 'ignore' });
+  });
+}
+
+function sendMacosNotification(title: string, body: string) {
+  if (process.platform !== 'darwin') return;
   const script = `display notification "${body.replace(/"/g, '\\"')}" with title "${title.replace(/"/g, '\\"')}" sound name "Glass"`;
   try {
     spawn('osascript', ['-e', script], { stdio: 'ignore' });
-  } catch (err) {
+  } catch (err: any) {
     log.warn(`[Notification] osascript 调用失败: ${err.message}`);
   }
 }
@@ -63,15 +104,11 @@ export function createAgentAuthorizer({
     });
 
     if (isQuestion) {
-      sendMacosNotification(
-        'Desktop Agent 提问',
-        `${cleanText(action.question, 120)}`
-      );
+      sendMacosNotification('Desktop Agent 提问', `${cleanText(action.question, 120)}`);
+      showQuestionDialog(runId, approvalId, cleanText(action.question, 200));
     } else {
-      sendMacosNotification(
-        'Desktop Agent 需要审批',
-        `${cleanText(policy.reason, 120)}\n\nrunId: ${runId}`
-      );
+      sendMacosNotification('Desktop Agent 需要审批', `${cleanText(policy.reason, 120)}`);
+      showApprovalDialog(runId, approvalId, cleanText(policy.reason, 200));
     }
 
     const decision = await promise;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1820,22 +1820,22 @@ textarea {
     border-radius: var(--r-sm);
     cursor: pointer;
   }
+}
 
-  .model-card-body {
-    display: none;
-  }
+.model-card-body {
+  display: none;
+}
 
-  .model-card.expanded .model-card-body {
-    display: block;
-  }
+.model-card.expanded .model-card-body {
+  display: block;
+}
 
-  .model-card-json {
-    display: none;
-  }
+.model-card-json {
+  display: none;
+}
 
-  .model-card.expanded .model-card-json {
-    display: block;
-  }
+.model-card.expanded .model-card-json {
+  display: block;
 }
 
 .model-card-icon { font-size: 12px; }

--- a/scripts/notify-approve.sh
+++ b/scripts/notify-approve.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# notify-approve.sh — 监听 Agent SSE 流，审批请求弹出 macOS 原生对话框
+#
+# 用法:
+#   ./notify-approve.sh [run_id]           # 监听指定 run（不传则自动获取活跃 run）
+#   ./notify-approve.sh auto               # 持续轮询，自动监听活跃 run
+#
+# 依赖: curl, osascript (macOS 自带)
+
+set -euo pipefail
+
+HOST="${SAGENT_HOST:-http://127.0.0.1:3001}"
+RUN_ID="${1:-}"
+
+approve() {
+  local run_id="$1" approval_id="$2"
+  curl -s -X POST "$HOST/api/agent/approvals" \
+    -H 'Content-Type: application/json' \
+    -d "{\"runId\":\"$run_id\",\"approvalId\":\"$approval_id\",\"decision\":\"approve\"}" \
+    | python3 -c "import sys,json; print('✅ 已批准' if json.load(sys.stdin).get('ok') else '❌ 批准失败')"
+}
+
+reject() {
+  local run_id="$1" approval_id="$2"
+  curl -s -X POST "$HOST/api/agent/approvals" \
+    -H 'Content-Type: application/json' \
+    -d "{\"runId\":\"$run_id\",\"approvalId\":\"$approval_id\",\"decision\":\"reject\"}" \
+    | python3 -c "import sys,json; print('⛔ 已拒绝' if json.load(sys.stdin).get('ok') else '❌ 拒绝失败')"
+}
+
+show_dialog() {
+  local run_id="$1" approval_id="$2" message="$3" action_json="$4"
+  # 截断过长内容
+  local display_msg
+  display_msg=$(echo "$message" | head -5 | cut -c1-300)
+  local result
+  result=$(osascript -e "display dialog \"$display_msg\" with title \"Agent 审批请求\" buttons {\"拒绝\", \"批准\"} default button \"批准\" cancel button \"拒绝\"" 2>/dev/null)
+  if [[ "$result" == *"批准"* ]]; then
+    echo "  → 批准"
+    approve "$run_id" "$approval_id"
+  else
+    echo "  → 拒绝"
+    reject "$run_id" "$approval_id"
+  fi
+}
+
+# 获取活跃 run
+get_active_run() {
+  curl -s "$HOST/api/agent/active" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if d.get('active'):
+    print(d['runId'])
+else:
+    print('')
+"
+}
+
+listen_stream() {
+  local run_id="$1"
+  echo "🎧 监听 run=$run_id ..."
+  curl -sN "$HOST/api/agent/stream/$run_id" | while IFS= read -r line; do
+    # SSE 格式: "data: {json}"
+    if [[ "$line" != data:* ]]; then
+      continue
+    fi
+    local json="${line#data: }"
+
+    # 提取事件类型
+    local event_type
+    event_type=$(echo "$json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('type',''))" 2>/dev/null || echo "")
+
+    if [[ "$event_type" == "approval_required" ]]; then
+      echo "🔔 收到审批请求"
+      local approval_id message action_str
+      approval_id=$(echo "$json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('approvalId',''))" 2>/dev/null)
+      message=$(echo "$json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('message',''))" 2>/dev/null)
+      action_str=$(echo "$json" | python3 -c "import sys,json; a=json.load(sys.stdin).get('action',{}); print(f\"{a.get('tool','')}.{a.get('type','')}\")" 2>/dev/null)
+      echo "  approvalId=$approval_id action=$action_str"
+      echo "  message: $message"
+      show_dialog "$run_id" "$approval_id" "$message" "$action_str"
+    elif [[ "$event_type" == "done" ]]; then
+      echo "✅ 任务完成"
+      break
+    elif [[ "$event_type" == "error" ]]; then
+      echo "❌ 任务失败"
+      break
+    elif [[ "$event_type" == "cancelled" ]]; then
+      echo "⛔ 任务已取消"
+      break
+    fi
+  done
+}
+
+# 主逻辑
+if [[ -z "$RUN_ID" || "$RUN_ID" == "auto" ]]; then
+  echo "🔍 轮询活跃任务..."
+  while true; do
+    rid=$(get_active_run)
+    if [[ -n "$rid" ]]; then
+      listen_stream "$rid"
+      echo ""
+      echo "🔍 继续轮询..."
+    fi
+    sleep 3
+  done
+else
+  listen_stream "$RUN_ID"
+fi


### PR DESCRIPTION
## Summary

### macOS 审批对话框
- Agent 需要审批时弹出 macOS 原生对话框（display alert），带"批准"/"拒绝"按钮
- Agent 提问时弹出带输入框的对话框
- 点击按钮直接回调 API，无需打开浏览器
- 同时保留通知中心提醒

### 移动端修复
- 修复决策节点展开/折叠在移动端无效的问题
- 原因：展开/折叠 CSS 规则仅在 `@media (min-width: 1100px)` 内，移至全局作用域

## Test plan
- [ ] macOS 审批对话框弹出并可点击批准/拒绝
- [ ] 提问对话框可输入回答
- [ ] 移动端点击决策节点可正常展开/折叠
- [ ] 桌面端行为不受影响