### PR TITLE
fix: Windows support, agent reliability, frontend refactor & trace persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ data
 artifacts
 
 todo.md
+
+.claude/

--- a/agent/core/llm-logger.ts
+++ b/agent/core/llm-logger.ts
@@ -12,6 +12,7 @@
 import { mkdir, appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { log } from '../../helpers/logger.ts';
+import { extractErrorDiagnostics, formatErrorDiagnostics } from '../../helpers/retry.ts';
 
 let logDir = 'data/llm-logs';
 
@@ -69,4 +70,10 @@ export function logLlmResponse(model, response) {
   enqueueLog(join(todayDir(), modelFileName(model)), line);
   const tokens = (usage.prompt_tokens || 0) + (usage.completion_tokens || usage.output_tokens || 0);
   log.debug(`[LLM] ← ${model} tokens=${tokens}`);
+}
+
+export function logLlmError(model, err, context = {}) {
+  const line = JSON.stringify({ time: timeStr(), type: 'error', model, context, error: extractErrorDiagnostics(err) });
+  enqueueLog(join(todayDir(), modelFileName(model)), line);
+  log.warn(`[LLM] ✕ ${model} ${formatErrorDiagnostics(err)}`);
 }

--- a/agent/core/planner.ts
+++ b/agent/core/planner.ts
@@ -13,7 +13,7 @@
 
 import { cleanText, safeJson } from './utils.ts';
 import { createModelResponseParser } from './nvidia-response-parsers.ts';
-import { logLlmRequest, logLlmResponse } from './llm-logger.ts';
+import { logLlmError, logLlmRequest, logLlmResponse } from './llm-logger.ts';
 import { retryAsync } from '../../helpers/retry.ts';
 import { log } from '../../helpers/logger.ts';
 
@@ -39,8 +39,23 @@ export function createJsonPlanner({
       messages,
     };
     const reqOpts = signal ? { signal } : undefined;
+    const retryContext = {
+      operation: 'desktop.plan',
+      phase: 'initial',
+      provider: 'openai-compatible',
+      model,
+      step: context.step,
+      message_count: messages.length,
+      max_tokens: maxTokens,
+    };
 
-    const response = await retryAsync(() => client.chat.completions.create(createOpts, reqOpts));
+    let response;
+    try {
+      response = await retryAsync(() => client.chat.completions.create(createOpts, reqOpts), undefined, retryContext);
+    } catch (err) {
+      logLlmError(model, err, retryContext);
+      throw err;
+    }
 
     logLlmResponse(model, response);
 
@@ -73,7 +88,16 @@ export function createJsonPlanner({
         messages: retryMessages,
       };
 
-      const retryResponse = await retryAsync(() => client.chat.completions.create(retryOpts, reqOpts));
+      const retryContext = {
+        operation: 'desktop.plan',
+        phase: 'parser-retry',
+        provider: 'openai-compatible',
+        model,
+        step: context.step,
+        message_count: retryMessages.length,
+        max_tokens: maxTokens,
+      };
+      const retryResponse = await retryAsync(() => client.chat.completions.create(retryOpts, reqOpts), undefined, retryContext);
       const retryParsed = parser(retryResponse);
 
       if (!retryParsed.parseFailed) {
@@ -81,6 +105,13 @@ export function createJsonPlanner({
         return { ...result, usage: retryParsed.usage || parsed.usage, reasoning: retryParsed.reasoning || null };
       }
     } catch (retryErr) {
+      logLlmError(model, retryErr, {
+        operation: 'desktop.plan',
+        phase: 'parser-retry',
+        provider: 'openai-compatible',
+        model,
+        step: context.step,
+      });
       log.warn(`[Planner] 重试也失败: ${retryErr.message}`);
     }
 

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -36,7 +36,7 @@ import {
 } from "./checkpoint.js";
 
 const MAX_HISTORY_STEPS = Number(process.env.AGENT_MAX_HISTORY_STEPS || 20);
-const MAX_RESULT_CHARS = Number(process.env.AGENT_MAX_RESULT_CHARS || 1000);
+const MAX_RESULT_CHARS = Number(process.env.AGENT_MAX_RESULT_CHARS || 5000);
 
 function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
   // Progressive truncation: recent steps keep more context, old steps get shorter results
@@ -44,7 +44,7 @@ function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
     // Last 3 steps: full (up to MAX_RESULT_CHARS)
     // Steps 4-10: 500 chars
     // Steps 11+: 200 chars
-    const limit = remaining <= 3 ? MAX_RESULT_CHARS : remaining <= 10 ? 500 : 200;
+    const limit = remaining <= 3 ? MAX_RESULT_CHARS : remaining <= 10 ? 2500 : 1000;
     const str = h.result == null ? '' : String(h.result);
     if (str.length <= limit) return h;
     return { ...h, result: str.slice(0, limit) + '…[truncated]' };

--- a/agent/desktop/planner.ts
+++ b/agent/desktop/planner.ts
@@ -9,6 +9,7 @@ import {
 } from '../core/prompts.ts';
 import { isClaudeModel, claudeAgentPlan } from '../core/ai-client.ts';
 import { log } from '../../helpers/logger.ts';
+import { extractErrorDiagnostics } from '../../helpers/retry.ts';
 
 export const DEFAULT_MODEL_TIMEOUT_MS = 10_000;
 
@@ -101,6 +102,7 @@ function logModelFailure(model: string, elapsedMs: number, err: any) {
   const errLine = `  !!! LLM FAILED   ${shortModel}  ${elapsed}s  ${err.message.slice(0, 60)}`;
   const width = Math.max(displayWidth(errLine) + 4, 52);
   log.warn(`\n  ${'╔' + '═'.repeat(width) + '╗'}\n  ║${padEndW(errLine, width)}║\n  ${'╚' + '═'.repeat(width) + '╝'}`);
+  log.warn(`[LLM Failure] model=${model} elapsed=${elapsed}s diagnostics=${JSON.stringify(extractErrorDiagnostics(err))}`);
 }
 
 export function createDesktopPlanner({
@@ -189,7 +191,7 @@ export function createDesktopPlanner({
         onEvent?.({ type: 'model_plan', stage: 'thinking', model: candidate, step });
       }
 
-      const settled = await Promise.allSettled(
+      const votePromise = Promise.allSettled(
         activeModels.map((candidate: string) =>
           planWithTimeout(candidate, planCtx, cancelSignal, undefined)
             .then(result => {
@@ -208,6 +210,18 @@ export function createDesktopPlanner({
             })
         )
       );
+
+      // Race the vote against cancel so we don't wait for all models to timeout
+      const cancelPromise = cancelSignal
+        ? new Promise<typeof votePromise>((_, reject) => {
+            if (cancelSignal.aborted) { reject(new Error('Agent 已取消')); return; }
+            const onAbort = () => { cancelSignal.removeEventListener('abort', onAbort); reject(new Error('Agent 已取消')); };
+            cancelSignal.addEventListener('abort', onAbort);
+            votePromise.finally(() => cancelSignal.removeEventListener('abort', onAbort));
+          })
+        : new Promise(() => {});
+
+      const settled = await Promise.race([votePromise, cancelPromise]) as PromiseSettledResult<any>[];
 
       const successes = settled
         .filter((result: any) => result.status === 'fulfilled' && result.value !== null)
@@ -247,6 +261,19 @@ export function createDesktopPlanner({
       const timers: NodeJS.Timeout[] = [];
       const raceAc = new AbortController();
 
+      // Reject immediately if already cancelled, or on future cancel
+      if (cancelSignal?.aborted) {
+        reject(new Error('Agent 已取消'));
+        return;
+      }
+      const onCancel = () => {
+        if (settled) return;
+        settled = true;
+        timers.forEach(timer => clearTimeout(timer));
+        reject(new Error('Agent 已取消'));
+      };
+      cancelSignal?.addEventListener('abort', onCancel);
+
       function launchModel(candidate: string) {
         if (settled || cancelSignal?.aborted) return;
         launched++;
@@ -260,6 +287,7 @@ export function createDesktopPlanner({
             settled = true;
             raceAc.abort();
             timers.forEach(timer => clearTimeout(timer));
+            cancelSignal?.removeEventListener('abort', onCancel);
             log.info(`[MultiModel] 使用 ${candidate} 的结果（${activeModels.join(', ')}）`);
             onEvent?.({ type: 'model_plan', stage: 'winner', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
             resolve(result);
@@ -280,6 +308,7 @@ export function createDesktopPlanner({
               tryLaunchBatch(true);
             }
             if (!settled && launched === activeModels.length && launched === failures.length) {
+              cancelSignal?.removeEventListener('abort', onCancel);
               reject(new Error(`所有模型均失败: ${failures.join(', ')}`));
             }
           });

--- a/agent/policy/approvals.ts
+++ b/agent/policy/approvals.ts
@@ -6,11 +6,47 @@ import { log } from '../../helpers/logger.ts';
 const HOST = `http://127.0.0.1:${process.env.PORT || 3001}`;
 
 function showApprovalDialog(runId: string, approvalId: string, message: string) {
+  const safeMsg = message.replace(/\n/g, ' ').slice(0, 200);
+
+  if (process.platform === 'win32') {
+    const escapedMsg = safeMsg.replace(/'/g, "''");
+    const script = `
+      try {
+        Add-Type -AssemblyName System.Windows.Forms
+        $result = [System.Windows.Forms.MessageBox]::Show(
+          '${escapedMsg}',
+          'Agent 审批请求',
+          'YesNo',
+          'Question'
+        )
+        Write-Output $result
+      } catch {
+        Write-Error $_.Exception.Message
+        exit 2
+      }
+    `;
+    const child = spawn('pwsh', ['-NoProfile', '-Command', script], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+    child.on('close', (code: number) => {
+      if (code === 2) {
+        log.warn(`[ApprovalDialog] Windows 弹窗失败: ${stderr.trim()}，等待 Web UI 处理`);
+        return;
+      }
+      const decision = stdout.trim() === 'Yes' ? 'approve' : 'reject';
+      log.info(`[ApprovalDialog] 用户${decision === 'approve' ? '批准' : '拒绝'} runId=${runId}`);
+      const body = JSON.stringify({ runId, approvalId, decision });
+      spawn('pwsh', ['-NoProfile', '-Command', `Invoke-RestMethod -Uri '${HOST}/api/agent/approvals' -Method Post -ContentType 'application/json' -Body '${body}'`], { stdio: 'ignore' });
+    });
+    return;
+  }
+
   if (process.platform !== 'darwin') return;
-  const safeMsg = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ').slice(0, 200);
-  // 异步弹对话框，用户点击后回调 API
+  const escapedMsg = safeMsg.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   const script = `
-    set dialogResult to display alert "Agent 审批请求" message "${safeMsg}" as informational buttons {"拒绝", "批准"} default button "批准" cancel button "拒绝" giving up after 120
+    set dialogResult to display alert "Agent 审批请求" message "${escapedMsg}" as informational buttons {"拒绝", "批准"} default button "批准" cancel button "拒绝" giving up after 120
     if button returned of dialogResult is "批准" then
       return "approve"
     else
@@ -22,17 +58,53 @@ function showApprovalDialog(runId: string, approvalId: string, message: string) 
   child.on('close', (code: number) => {
     const decision = code === 0 ? 'approve' : 'reject';
     log.info(`[ApprovalDialog] 用户${decision === 'approve' ? '批准' : '拒绝'} runId=${runId}`);
-    // 调 API 解除审批阻塞
     const body = JSON.stringify({ runId, approvalId, decision });
     spawn('curl', ['-s', '-X', 'POST', `${HOST}/api/agent/approvals`, '-H', 'Content-Type: application/json', '-d', body], { stdio: 'ignore' });
   });
 }
 
 function showQuestionDialog(runId: string, approvalId: string, question: string) {
+  const safeQ = question.replace(/\n/g, ' ').slice(0, 200);
+
+  if (process.platform === 'win32') {
+    const escapedQ = safeQ.replace(/'/g, "''");
+    const script = `
+      try {
+        Add-Type -AssemblyName Microsoft.VisualBasic
+        $result = [Microsoft.VisualBasic.Interaction]::InputBox(
+          '${escapedQ}',
+          'Agent 提问',
+          ''
+        )
+        if ($result -eq '') { Write-Output '__skip__' } else { Write-Output $result }
+      } catch {
+        Write-Error $_.Exception.Message
+        exit 2
+      }
+    `;
+    const child = spawn('pwsh', ['-NoProfile', '-Command', script], { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+    child.on('close', (code: number) => {
+      if (code === 2) {
+        log.warn(`[QuestionDialog] Windows 弹窗失败: ${stderr.trim()}，等待 Web UI 处理`);
+        return;
+      }
+      const response = stdout.trim();
+      const skipped = !response || response === '__skip__';
+      log.info(`[QuestionDialog] 用户回答: ${skipped ? '(跳过)' : response} runId=${runId}`);
+      const body = JSON.stringify({ runId, approvalId, response: skipped ? '' : response });
+      spawn('pwsh', ['-NoProfile', '-Command', `Invoke-RestMethod -Uri '${HOST}/api/agent/question' -Method Post -ContentType 'application/json' -Body '${body}'`], { stdio: 'ignore' });
+    });
+    return;
+  }
+
   if (process.platform !== 'darwin') return;
-  const safeQ = question.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ').slice(0, 200);
+  const escapedQ = safeQ.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   const script = `
-    set dialogResult to display dialog "${safeQ}" default answer "" with title "Agent 提问" buttons {"跳过", "回答"} default button "回答" cancel button "跳过" giving up after 120
+    set dialogResult to display dialog "${escapedQ}" default answer "" with title "Agent 提问" buttons {"跳过", "回答"} default button "回答" cancel button "跳过" giving up after 120
     set userResponse to text returned of dialogResult
     if userResponse is "" then return "__skip__"
     return userResponse`;
@@ -48,6 +120,14 @@ function showQuestionDialog(runId: string, approvalId: string, question: string)
 }
 
 function sendMacosNotification(title: string, body: string) {
+  if (process.platform === 'win32') {
+    const safeTitle = title.replace(/'/g, "''");
+    const safeBody = body.replace(/'/g, "''");
+    spawn('pwsh', ['-NoProfile', '-Command',
+      `Add-Type -AssemblyName System.Windows.Forms; $n = New-Object System.Windows.Forms.NotifyIcon; $n.Icon = [System.Drawing.SystemIcons]::Question; $n.BalloonTipTitle = '${safeTitle}'; $n.BalloonTipText = '${safeBody}'; $n.Visible = $true; $n.ShowBalloonTip(5000); Start-Sleep -Seconds 6; $n.Dispose()`,
+    ], { stdio: 'ignore' });
+    return;
+  }
   if (process.platform !== 'darwin') return;
   const script = `display notification "${body.replace(/"/g, '\\"')}" with title "${title.replace(/"/g, '\\"')}" sound name "Glass"`;
   try {

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
+import fs from 'node:fs';
 import { log } from '../../../helpers/logger.ts';
 
 const DEFAULT_PROTOCOL_VERSIONS = ['2025-03-26', '2024-11-05'];
@@ -8,8 +9,9 @@ const DEFAULT_SSE_PORT = 3099;
 const DEFAULT_SSE_PATH = '/sse';
 const SSE_ENDPOINT_WAIT_MS = 250;
 const DEFAULT_STDIO_COMMAND = 'npx';
-const DEFAULT_STDIO_ARGS = ['-y', 'chrome-devtools-mcp@latest', '--autoConnect'];
+const DEFAULT_STDIO_ARGS = ['-y', 'chrome-devtools-mcp@latest'];
 const CLIENT_INFO = { name: 'sagent', version: '1.0.0' };
+const IS_WINDOWS = process.platform === 'win32';
 
 let sharedClientPromise = null;
 let sharedClientKey = '';
@@ -23,6 +25,26 @@ function toAbsolutePath(rawPath, fallback = process.cwd()) {
     return fallback;
   }
   return path.isAbsolute(rawPath) ? path.normalize(rawPath) : path.resolve(fallback, rawPath);
+}
+
+function resolveCommandOnWindows(command, args) {
+  if (!IS_WINDOWS) {
+    return { command, args };
+  }
+  if (path.extname(command)) {
+    return { command, args };
+  }
+  const binDir = path.resolve('node_modules', '.bin');
+  const base = path.basename(command);
+  const cmdPath = path.join(binDir, base + '.cmd');
+  if (!fs.existsSync(cmdPath)) {
+    return { command, args };
+  }
+  const pkgJs = path.resolve('node_modules', base, 'build', 'src', 'bin', base + '.js');
+  if (fs.existsSync(pkgJs)) {
+    return { command: 'node', args: [pkgJs, ...args] };
+  }
+  return { command, args };
 }
 
 function parseArgs(value) {
@@ -255,11 +277,88 @@ class ChromeMcpClient {
     return tools.find(tool => tool?.name === toolName) || null;
   }
 
-  async callTool(toolName, args) {
-    return this.transport.request('tools/call', {
+  async callTool(toolName, toolArgs) {
+    const doCall = async () => this.transport.request('tools/call', {
       name: toolName,
-      arguments: args || {},
+      arguments: toolArgs || {},
     });
+
+    try {
+      const result = await doCall();
+      // MCP returns tool errors as { isError: true } in a successful JSON-RPC response,
+      // not as a JSON-RPC error — so we must check result.isError explicitly.
+      if (result?.isError && this._isChromeConnectionResult(result)) {
+        return await this._retryWithoutAutoConnect(toolName, toolArgs);
+      }
+      return result;
+    } catch (err) {
+      if (this._isChromeConnectionError(err)) {
+        return await this._retryWithoutAutoConnect(toolName, toolArgs);
+      }
+      throw err;
+    }
+  }
+
+  async _retryWithoutAutoConnect(toolName, toolArgs) {
+    if (!this._stripAutoConnect()) {
+      throw new Error('Chrome MCP 连接失败且无法回退');
+    }
+    log.info(`[Chrome MCP] 工具调用 ${toolName} 连接失败，移除 --autoConnect 重试（将自动启动浏览器）`);
+    const client = await getSharedChromeMcpClient(this.config);
+
+    // Without --autoConnect, the MCP server launches Chrome in the background.
+    // Chrome needs time to start, so retry the tool call on error.
+    const MAX_RETRIES = 3;
+    const RETRY_DELAY_MS = 3000;
+
+    for (let attempt = 0; ; attempt++) {
+      const result = await client.transport.request('tools/call', {
+        name: toolName,
+        arguments: toolArgs || {},
+      });
+
+      if (!result?.isError) {
+        return result;
+      }
+
+      if (attempt >= MAX_RETRIES - 1) {
+        log.info(`[Chrome MCP] 工具调用 ${toolName} 浏览器启动后仍失败（已重试 ${MAX_RETRIES} 次）`);
+        return result;
+      }
+
+      log.info(`[Chrome MCP] 等待浏览器启动，${RETRY_DELAY_MS}ms 后重试 ${toolName}（第 ${attempt + 1}/${MAX_RETRIES} 次）`);
+      await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+    }
+  }
+
+  _isChromeConnectionResult(result) {
+    const text = Array.isArray(result?.content)
+      ? result.content.map(c => c?.text || '').join(' ')
+      : '';
+    return text.includes('Could not connect to Chrome')
+      || text.includes('DevToolsActivePort')
+      || text.includes('Could not find');
+  }
+
+  _isChromeConnectionError(err) {
+    const msg = err?.message || '';
+    return msg.includes('Could not connect to Chrome')
+      || msg.includes('DevToolsActivePort')
+      || msg.includes('Could not find');
+  }
+
+  _stripAutoConnect() {
+    const config = this.transport?.config;
+    if (!config || !Array.isArray(config.args) || !config.args.includes('--autoConnect')) {
+      return false;
+    }
+    config.args = config.args.filter(a => a !== '--autoConnect');
+    // Close and reset so the next request spawns a fresh MCP process without --autoConnect
+    this.transport.close?.().catch(() => {});
+    this.toolsCache = null;
+    sharedClientPromise = null;
+    sharedClientKey = '';
+    return true;
   }
 
   async close() {
@@ -289,8 +388,14 @@ class StdioTransport {
   }
 
   async ensureConnected() {
-    if (this.child) {
+    if (this.child && !this.child.stdin?.destroyed) {
       return;
+    }
+    if (this.child?.stdin?.destroyed) {
+      this.child = null;
+      this.initialized = false;
+      this.initializePromise = null;
+      this.connectPromise = null;
     }
     if (this.connectPromise) {
       return this.connectPromise;
@@ -298,7 +403,8 @@ class StdioTransport {
 
     this.connectPromise = new Promise<void>((resolve, reject) => {
       log.info(`[Chrome MCP][stdio] spawn command=${this.config.command} args=${safeJson(this.config.args)} cwd=${this.config.cwd}`);
-      const child = spawn(this.config.command, this.config.args, {
+      const resolved = resolveCommandOnWindows(this.config.command, this.config.args);
+      const child = spawn(resolved.command, resolved.args, {
         cwd: this.config.cwd,
         stdio: ['pipe', 'pipe', 'pipe'],
         env: process.env,
@@ -324,6 +430,7 @@ class StdioTransport {
         this.child = null;
         this.initialized = false;
         this.initializePromise = null;
+        this.connectPromise = null;
       });
 
       this.child = child;
@@ -443,10 +550,18 @@ class StdioTransport {
 
   async sendRaw(message) {
     await this.ensureConnected();
+    if (!this.child || this.child.stdin?.destroyed) {
+      throw new Error('Chrome MCP stdio 连接已断开，请重试');
+    }
     const payload = Buffer.from(JSON.stringify(message) + '\n', 'utf8');
     return new Promise<void>((resolve, reject) => {
       this.child.stdin.write(payload, err => {
         if (err) {
+          if (err.code === 'ERR_STREAM_DESTROYED') {
+            this.child = null;
+            this.initialized = false;
+            this.initializePromise = null;
+          }
           reject(err);
           return;
         }
@@ -479,6 +594,30 @@ class StdioTransport {
           return;
         } catch (err) {
           lastError = err;
+        }
+      }
+
+      // If --autoConnect was used and failed, retry without it so the MCP server
+      // launches its own Chrome instance in the background
+      if (this.config.args?.includes('--autoConnect')) {
+        log.info('[Chrome MCP][stdio] --autoConnect 连接失败，移除该参数重试（将自动启动浏览器）');
+        await this.close();
+        this.config = { ...this.config, args: this.config.args.filter(a => a !== '--autoConnect') };
+        await this.ensureConnected();
+
+        for (const version of DEFAULT_PROTOCOL_VERSIONS) {
+          try {
+            await this.sendRequest('initialize', {
+              protocolVersion: version,
+              capabilities: {},
+              clientInfo: CLIENT_INFO,
+            }, { skipInit: true });
+            await this.sendNotification('notifications/initialized', {});
+            this.initialized = true;
+            return;
+          } catch (err) {
+            lastError = err;
+          }
         }
       }
 
@@ -885,10 +1024,12 @@ export function createChromeMcpClient(config = loadChromeMcpConfig()) {
 }
 
 export async function getSharedChromeMcpClient(config = loadChromeMcpConfig()) {
-  const key = clientKey(config);
-  if (sharedClientPromise && sharedClientKey === key) {
+  // Reuse existing client even if config key differs (e.g. _stripAutoConnect removed
+  // --autoConnect at runtime but loadChromeMcpConfig() re-reads it from .env).
+  if (sharedClientPromise) {
     return sharedClientPromise;
   }
+  const key = clientKey(config);
 
   if (sharedClientPromise && sharedClientKey !== key) {
     try {

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -1,4 +1,5 @@
-import { spawn } from 'node:child_process';
+import { spawn, execSync } from 'node:child_process';
+import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
 import { log } from '../../../helpers/logger.ts';
@@ -12,6 +13,28 @@ const DEFAULT_STDIO_COMMAND = 'npx';
 const DEFAULT_STDIO_ARGS = ['-y', 'chrome-devtools-mcp@latest'];
 const CLIENT_INFO = { name: 'sagent', version: '1.0.0' };
 const IS_WINDOWS = process.platform === 'win32';
+
+function killOrphanChrome() {
+  const profileDir = path.join(os.homedir(), '.cache', 'chrome-devtools-mcp', 'chrome-profile');
+  if (!fs.existsSync(profileDir)) return;
+
+  if (IS_WINDOWS) {
+    spawn('pwsh', ['-NoProfile', '-Command',
+      `Get-Process chrome -ErrorAction SilentlyContinue | Where-Object { $_.CommandLine -like '*chrome-profile*' } | Stop-Process -Force`],
+      { stdio: 'ignore' });
+    return;
+  }
+
+  try {
+    const pids = execSync(
+      `pgrep -f 'Google Chrome.*chrome-profile' 2>/dev/null || true`,
+      { encoding: 'utf8' },
+    ).trim();
+    if (!pids) return;
+    spawn('bash', ['-c', `pkill -f 'Google Chrome.*chrome-profile' 2>/dev/null || true`], { stdio: 'ignore' });
+    log.info(`[Chrome MCP] 已清理孤儿 Chrome 进程 (PIDs: ${pids.replace(/\n/g, ',')})`);
+  } catch { /* ignore */ }
+}
 
 let sharedClientPromise = null;
 let sharedClientKey = '';
@@ -288,14 +311,51 @@ class ChromeMcpClient {
       // MCP returns tool errors as { isError: true } in a successful JSON-RPC response,
       // not as a JSON-RPC error — so we must check result.isError explicitly.
       if (result?.isError && this._isChromeConnectionResult(result)) {
+        if (this._isAlreadyRunningResult(result)) {
+          return await this._recoverFromAlreadyRunning(toolName, toolArgs);
+        }
         return await this._retryWithoutAutoConnect(toolName, toolArgs);
       }
       return result;
     } catch (err) {
       if (this._isChromeConnectionError(err)) {
+        if (this._isAlreadyRunningErrorMsg(err)) {
+          return await this._recoverFromAlreadyRunning(toolName, toolArgs);
+        }
         return await this._retryWithoutAutoConnect(toolName, toolArgs);
       }
       throw err;
+    }
+  }
+
+  async _recoverFromAlreadyRunning(toolName, toolArgs) {
+    log.info(`[Chrome MCP] 检测到 Chrome already running 冲突，清理孤儿进程后重试`);
+    killOrphanChrome();
+    await new Promise(r => setTimeout(r, 2000));
+    // Reset transport so MCP server launches a fresh Chrome
+    this.transport.close?.().catch(() => {});
+    this.toolsCache = null;
+    const client = await getSharedChromeMcpClient(this.config);
+    const MAX_RETRIES = 3;
+    const RETRY_DELAY_MS = 3000;
+
+    for (let attempt = 0; ; attempt++) {
+      const result = await client.transport.request('tools/call', {
+        name: toolName,
+        arguments: toolArgs || {},
+      });
+
+      if (!result?.isError) {
+        return result;
+      }
+
+      if (attempt >= MAX_RETRIES - 1) {
+        log.info(`[Chrome MCP] 清理 Chrome 后工具调用 ${toolName} 仍失败（已重试 ${MAX_RETRIES} 次）`);
+        return result;
+      }
+
+      log.info(`[Chrome MCP] 等待浏览器启动，${RETRY_DELAY_MS}ms 后重试 ${toolName}（第 ${attempt + 1}/${MAX_RETRIES} 次）`);
+      await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
     }
   }
 
@@ -337,14 +397,27 @@ class ChromeMcpClient {
       : '';
     return text.includes('Could not connect to Chrome')
       || text.includes('DevToolsActivePort')
-      || text.includes('Could not find');
+      || text.includes('Could not find')
+      || text.includes('already running');
   }
 
   _isChromeConnectionError(err) {
     const msg = err?.message || '';
     return msg.includes('Could not connect to Chrome')
       || msg.includes('DevToolsActivePort')
-      || msg.includes('Could not find');
+      || msg.includes('Could not find')
+      || msg.includes('already running');
+  }
+
+  _isAlreadyRunningResult(result) {
+    const text = Array.isArray(result?.content)
+      ? result.content.map(c => c?.text || '').join(' ')
+      : '';
+    return text.includes('already running');
+  }
+
+  _isAlreadyRunningErrorMsg(err) {
+    return (err?.message || '').includes('already running');
   }
 
   _stripAutoConnect() {
@@ -354,6 +427,7 @@ class ChromeMcpClient {
     }
     config.args = config.args.filter(a => a !== '--autoConnect');
     // Close and reset so the next request spawns a fresh MCP process without --autoConnect
+    killOrphanChrome();
     this.transport.close?.().catch(() => {});
     this.toolsCache = null;
     sharedClientPromise = null;
@@ -362,6 +436,7 @@ class ChromeMcpClient {
   }
 
   async close() {
+    killOrphanChrome();
     await this.transport.close?.();
   }
 }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1998,21 +1998,6 @@ textarea {
 }
 .model-card-result-toggle:hover { text-decoration: underline; }
 
-.agent-done-answer {
-  margin-top: 8px;
-  padding: 8px 10px;
-  background: #f0fdf4;
-  border: 1px solid #bbf7d0;
-  border-radius: var(--r-sm);
-  font-size: var(--f-xs);
-  line-height: 1.6;
-  max-height: 300px;
-  overflow-y: auto;
-  word-break: break-word;
-}
-.agent-done-answer :first-child { margin-top: 0; }
-.agent-done-answer :last-child { margin-bottom: 0; }
-
 /* ── Strategy Toggle ── */
 
 .model-tags-wrap {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,6 +13,14 @@ import bash from 'highlight.js/lib/languages/bash';
 import sql from 'highlight.js/lib/languages/sql';
 import 'highlight.js/styles/github.css';
 import './App.css';
+import { streamAgentRun, streamChatCompletion, submitAgentApproval, submitAgentQuestion } from './api/streams.js';
+import { AgentPane } from './components/AgentPane.jsx';
+import { ChatPane } from './components/ChatPane.jsx';
+import { SessionSidebar } from './components/SessionSidebar.jsx';
+import { useAgentRun } from './hooks/useAgentRun.js';
+import { createSession, getSessionTitle, normalizeChatState, touchSession, useChatSessions } from './hooks/useChatSessions.js';
+import { booleanStorage, jsonStorage, usePersistentState } from './hooks/usePersistentState.js';
+import { useResponsiveLayout } from './hooks/useResponsiveLayout.js';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('js', javascript);
@@ -48,10 +56,6 @@ class ErrorBoundary extends Component {
     return this.props.children;
   }
 }
-
-const API_URL = '/api/chat';
-const AGENT_API_URL = '/api/agent';
-const AGENT_APPROVAL_API_URL = '/api/agent/approvals';
 
 const DEFAULT_MODELS = [
   { id: 'minimaxai/minimax-m2.7', label: 'MiniMax M2.7' },
@@ -163,142 +167,11 @@ function shuffled(arr) {
   return a;
 }
 
-const LEGACY_MESSAGES_KEY = 'nvidia_chat_messages';
-const LEGACY_MODEL_KEY = 'nvidia_chat_model';
-const SESSIONS_KEY = 'nvidia_chat_sessions';
-const ACTIVE_SESSION_KEY = 'nvidia_chat_active_session';
-const LAST_MODE_KEY = 'nvidia_chat_last_mode';
 const PHONE_BREAKPOINT = 640;
 const TABLET_BREAKPOINT = 768;
 const DOCKED_LAYOUT_BREAKPOINT = 1100;
 const APP_BG_COLOR = '#f5f5fa';
 const APP_SURFACE_COLOR = '#ffffff';
-
-// 会话 id 会同时承担 React key、本地持久化索引、切换会话时的主键。
-// 这里不要求全局唯一，只要在当前浏览器存储范围内稳定即可。
-function generateSessionId() {
-  return `session_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-}
-
-// 浏览器本地存储里的消息历史可能来自旧版本、异常写入，或者手工改动。
-// 统一做一次清洗，后面的 UI/流式更新逻辑就可以直接假设结构正常。
-function normalizeMessages(value) {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value
-    .filter(item => item && (item.role === 'user' || item.role === 'assistant') && typeof item.content === 'string')
-    .map(item => ({
-      role: item.role,
-      content: item.content,
-      ...(item.ts ? { ts: item.ts } : {}),
-    }));
-}
-
-function createSession({
-  id = generateSessionId(),
-  messages = [],
-  model,
-  agentTrace = [],
-  createdAt = Date.now(),
-  updatedAt = Date.now(),
-} = {}) {
-  return {
-    id,
-    messages: normalizeMessages(messages),
-    model: model || DEFAULT_MODELS[0].id,
-    agentTrace: Array.isArray(agentTrace) ? agentTrace : [],
-    createdAt,
-    updatedAt,
-  };
-}
-
-// 统一修正整个聊天状态的外形：
-// 1. sessions 至少保留一个
-// 2. activeSessionId 必须落在现有 sessions 里
-// 3. 每个 session 都走 createSession，保证字段完整
-function normalizeChatState(rawState) {
-  const sessions = Array.isArray(rawState?.sessions)
-    ? rawState.sessions
-        .map(session => {
-          if (!session || typeof session !== 'object') {
-            return null;
-          }
-
-          return createSession({
-            id: typeof session.id === 'string' && session.id ? session.id : undefined,
-            messages: session.messages,
-            model: session.model,
-            agentTrace: session.agentTrace,
-            createdAt: Number.isFinite(session.createdAt) ? session.createdAt : Date.now(),
-            updatedAt: Number.isFinite(session.updatedAt) ? session.updatedAt : Date.now(),
-          });
-        })
-        .filter(Boolean)
-    : [];
-
-  const nextSessions = sessions.length > 0 ? sessions : [createSession()];
-  const activeSessionId = nextSessions.some(session => session.id === rawState?.activeSessionId)
-    ? rawState.activeSessionId
-    : nextSessions[0].id;
-
-  return { sessions: nextSessions, activeSessionId };
-}
-
-// 首先尝试读取新版多会话结构；如果不存在，再从旧版单会话存储迁移。
-// 这样老用户刷新后不会丢历史，同时后续代码始终只处理新版状态。
-function loadChatState() {
-  try {
-    const storedSessions = JSON.parse(localStorage.getItem(SESSIONS_KEY) || 'null');
-    if (Array.isArray(storedSessions) && storedSessions.length > 0) {
-      return normalizeChatState({
-        sessions: storedSessions,
-        activeSessionId: localStorage.getItem(ACTIVE_SESSION_KEY),
-      });
-    }
-  } catch {
-    // ignore malformed storage and fall back to migration/default state
-  }
-
-  let legacyMessages = [];
-  try {
-    legacyMessages = JSON.parse(localStorage.getItem(LEGACY_MESSAGES_KEY) || '[]');
-  } catch {
-    legacyMessages = [];
-  }
-
-  const migratedSession = createSession({
-    messages: legacyMessages,
-    model: localStorage.getItem(LEGACY_MODEL_KEY) || DEFAULT_MODELS[0].id,
-  });
-
-  return normalizeChatState({
-    sessions: [migratedSession],
-    activeSessionId: migratedSession.id,
-  });
-}
-
-// 对单个 session 做浅更新，同时刷新 updatedAt，保证会话排序或后续扩展
-// 可以依赖这个时间戳，而不是到处手动补 Date.now()。
-function touchSession(session, patch = {}) {
-  return {
-    ...session,
-    ...patch,
-    updatedAt: Date.now(),
-  };
-}
-
-function getSessionTitle(messages) {
-  const firstUserMessage = messages.find(item => item.role === 'user' && item.content.trim());
-  if (!firstUserMessage) {
-    return '新对话';
-  }
-
-  const text = firstUserMessage.content.replace(/\s+/g, ' ').trim();
-  return text.length > 20 ? `${text.slice(0, 20)}…` : text;
-}
-
 
 function formatMsgTime(ts) {
   if (!ts) return '';
@@ -309,190 +182,6 @@ function formatMsgTime(ts) {
     hour12: false,
     timeZone: 'Asia/Shanghai',
   }).format(ts);
-}
-
-// 通用 SSE 读取器。Chat / Agent 两种流式接口都走这里，
-// 上层只关心“每收到一个 data 事件该怎么处理”。
-async function streamSseJson({ url, body, signal, onEvent }) {
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    signal,
-  });
-
-  if (!res.ok) {
-    const errorText = await res.text();
-    try {
-      const parsed = JSON.parse(errorText);
-      throw new Error(parsed.error || `HTTP ${res.status}`);
-    } catch (parseErr) {
-      if (parseErr.message && !parseErr.message.startsWith('HTTP')) throw parseErr;
-      throw new Error(errorText || `HTTP ${res.status}`);
-    }
-  }
-
-  if (!res.body) {
-    throw new Error('响应流不可用');
-  }
-
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-
-  const handleEvent = async rawEvent => {
-    const line = rawEvent
-      .split('\n')
-      .map(item => item.trim())
-      .find(item => item.startsWith('data: '));
-
-    if (!line) {
-      return;
-    }
-
-    const json = JSON.parse(line.slice(6));
-    if (json.error && !json.type) {
-      throw new Error(json.error);
-    }
-    await onEvent?.(json);
-  };
-
-  const flushBuffer = async final => {
-    const events = buffer.split('\n\n');
-    buffer = final ? '' : events.pop() ?? '';
-    for (const rawEvent of events) {
-      if (rawEvent.trim()) {
-        await handleEvent(rawEvent);
-      }
-    }
-  };
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
-    buffer += decoder.decode(value, { stream: true });
-    await flushBuffer(false);
-  }
-
-  buffer += decoder.decode();
-  await flushBuffer(true);
-}
-
-// 普通对话的流式包装。它只负责把 token 增量回调给调用方，
-// 不关心 UI 更新方式，方便 sendChatMessage 统一处理消息替换。
-async function streamChatCompletion({
-  messages,
-  model,
-  signal,
-  temperature = 1,
-  top_p = 0.95,
-  max_tokens = 8192,
-  onContent,
-  onDone,
-}) {
-  let donePayload = null;
-
-  await streamSseJson({
-    url: API_URL,
-    body: { messages, model, temperature, top_p, max_tokens },
-    signal,
-    onEvent(json) {
-      if (json.content) {
-        onContent?.(json.content);
-      }
-      if (json.done) {
-        donePayload = json;
-        onDone?.(json);
-      }
-    },
-  });
-
-  return donePayload;
-}
-
-// Agent 的首个 POST 既负责发起任务，也承载最初的一段 SSE。
-// 如果这段连接中途断开，但服务端 run 已经创建成功，就退化为
-// 通过 runId 继续订阅 /stream/:runId，而不是直接把整次任务判失败。
-async function streamAgentRun({ task, model, models, strategy, memory, signal, onEvent, messages, ...extra }) {
-  let runId = null;
-  let gotDone = false;
-
-  const wrappedEvent = (event) => {
-    if (event.runId) runId = event.runId;
-    if (event.type === 'done' || event.type === 'error') gotDone = true;
-    onEvent(event);
-  };
-
-  try {
-    await streamSseJson({
-      url: AGENT_API_URL,
-      body: { task, model, models, strategy, memory, messages, ...extra },
-      signal,
-      onEvent: wrappedEvent,
-    });
-  } catch {
-    // initial POST may fail/disconnect, fall through to reconnect
-  }
-
-  // If SSE disconnected before done, reconnect to the stream
-  if (!gotDone && runId && !signal.aborted) {
-    try {
-      const res = await fetch(`/api/agent/stream/${runId}`, { signal });
-      if (!res.ok) return;
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n\n');
-        buffer = lines.pop() || '';
-        for (const line of lines) {
-          const dataLine = line.replace(/^data:\s*/, '');
-          if (!dataLine || dataLine === '[DONE]') continue;
-          try {
-            const event = JSON.parse(dataLine);
-            wrappedEvent(event);
-          } catch { /* skip malformed */ }
-        }
-      }
-    } catch {
-      // reconnect also failed
-    }
-  }
-}
-
-async function submitAgentApproval({ runId, approvalId, decision }) {
-  const res = await fetch(AGENT_APPROVAL_API_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ runId, approvalId, decision }),
-  });
-
-  if (!res.ok) {
-    const errorText = await res.text();
-    throw new Error(errorText || `HTTP ${res.status}`);
-  }
-
-  return res.json();
-}
-
-async function submitAgentQuestion({ runId, approvalId, response }) {
-  const res = await fetch('/api/agent/question', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ runId, approvalId, response }),
-  });
-
-  if (!res.ok) {
-    const errorText = await res.text();
-    throw new Error(errorText || `HTTP ${res.status}`);
-  }
-
-  return res.json();
 }
 
 const PANEL_MIN = 280;
@@ -1822,45 +1511,70 @@ function AgentPanel({ mode, running, trace, startedAt, modelList, collapsed, onT
 }
 
 export default function App() {
-  // chatState 是“会话级业务状态”的根对象：消息历史、会话列表、当前激活会话。
-  // 其余 state 大多是 UI 控件状态或运行时状态。
-  const [chatState, setChatState] = useState(loadChatState);
+  const {
+    setChatState,
+    sessions,
+    activeSession,
+    messages,
+    chatModel,
+    updateSession,
+  } = useChatSessions();
   const [availableModels, setAvailableModels] = useState(DEFAULT_MODELS);
   // availableModels 在首屏渲染时先用 DEFAULT_MODELS 占位；
   // modelsLoaded 用来区分“占位值”和“真实从后端拿到的列表”，
   // 避免启动阶段误把用户已选的多模型裁成一个。
   const [modelsLoaded, setModelsLoaded] = useState(false);
   const [input, setInput] = useState('');
-  const [mode, setMode] = useState(() => localStorage.getItem(LAST_MODE_KEY) || 'chat');
+  const [mode, setMode] = usePersistentState('nvidia_chat_last_mode', 'chat');
   const [suggestionSeed, setSuggestionSeed] = useState(0);
-  const [streaming, setStreaming] = useState(false);
-  const [agentRunning, setAgentRunning] = useState(false);
-  const [agentStopping, setAgentStopping] = useState(false);
-  const [_agentRunId, setAgentRunId] = useState(null);
-  const [reconnectedRun, setReconnectedRun] = useState(false);
-  const agentRunIdRef = useRef(null);
-  const [agentMemory, setAgentMemory] = useState(() => localStorage.getItem('agent_memory') !== 'false');
-  const [agentTrace, setAgentTrace] = useState([]);
+  const {
+    streaming,
+    setStreaming,
+    agentRunning,
+    setAgentRunning,
+    agentStopping,
+    setAgentStopping,
+    setAgentRunId,
+    reconnectedRun,
+    setReconnectedRun,
+    agentTrace,
+    setAgentTrace,
+    pendingApproval,
+    setPendingApproval,
+    approvalSubmitting,
+    setApprovalSubmitting,
+    agentCollapsed,
+    setAgentCollapsed,
+    showMemoryPanel,
+    setShowMemoryPanel,
+    rollbackLoading,
+    setRollbackLoading,
+    agentMobileTab,
+    setAgentMobileTab,
+    pendingQuestion,
+    setPendingQuestion,
+    questionSubmitting,
+    setQuestionSubmitting,
+    agentStartedAt,
+    setAgentStartedAt,
+    agentRunIdRef,
+    agentAbortRef,
+    approvalRequestRef,
+    questionRequestRef,
+    touchStartRef,
+    reconnectTaskRef,
+    lastAgentTaskRef,
+  } = useAgentRun();
+  const [agentMemory, setAgentMemory] = usePersistentState('agent_memory', true, booleanStorage);
   const [showReset, setShowReset] = useState(false);
-  const [pendingApproval, setPendingApproval] = useState(null);
-  const [approvalSubmitting, setApprovalSubmitting] = useState(false);
-  const [agentCollapsed, setAgentCollapsed] = useState(false);
-  const [showMemoryPanel, setShowMemoryPanel] = useState(false);
-  const [rollbackLoading, setRollbackLoading] = useState(false);
-  const [agentMobileTab, setAgentMobileTab] = useState('agent');
-  const touchStartRef = useRef(null);
-  const [pendingQuestion, setPendingQuestion] = useState(null);
-  const [questionSubmitting, setQuestionSubmitting] = useState(false);
-  const [showSessions, setShowSessions] = useState(window.innerWidth >= DOCKED_LAYOUT_BREAKPOINT);
-  const [agentStartedAt, setAgentStartedAt] = useState(null);
+  const { showSessions, setShowSessions } = useResponsiveLayout({
+    dockedBreakpoint: DOCKED_LAYOUT_BREAKPOINT,
+    tabletBreakpoint: TABLET_BREAKPOINT,
+    panelSizeKey: PANEL_SIZE_KEY,
+  });
   // Agent 的模型集合、策略、headless、memory 目前是“应用级偏好”，
   // 不跟随 chat session 存储；chat session 只保存单模型对话所用的 model。
-  const [selectedAgentModels, setSelectedAgentModels] = useState(() => {
-    try {
-      const saved = localStorage.getItem('agent_models');
-      return saved ? JSON.parse(saved) : [];
-    } catch { return []; }
-  });
+  const [selectedAgentModels, setSelectedAgentModels] = usePersistentState('agent_models', [], jsonStorage);
   // Filter out models no longer available
   useEffect(() => {
     if (!modelsLoaded) {
@@ -1873,22 +1587,14 @@ export default function App() {
       const valid = selectedAgentModels.filter(m => availableModels.some(avail => avail.id === m));
       if (valid.length !== selectedAgentModels.length) {
         setSelectedAgentModels(valid);
-        localStorage.setItem('agent_models', JSON.stringify(valid));
       }
     }
-  }, [availableModels, modelsLoaded, selectedAgentModels]);
-  const [agentStrategy, setAgentStrategy] = useState(() => localStorage.getItem('agent_strategy') || 'race');
+  }, [availableModels, modelsLoaded, selectedAgentModels, setSelectedAgentModels]);
+  const [agentStrategy, setAgentStrategy] = usePersistentState('agent_strategy', 'race');
 
   const abortRef = useRef(null);
-  const agentAbortRef = useRef(null);
-  // 当前待审批/待回答的问题不只要进 state 展示，还要持有 resolve，
-  // 方便 UI 按钮点击后继续推进被 Promise 阻塞的 Agent 流程。
-  const approvalRequestRef = useRef(null);
-  const questionRequestRef = useRef(null);
   const bottomRef = useRef(null);
   const textareaRef = useRef(null);
-  const reconnectTaskRef = useRef(null);
-  const lastAgentTaskRef = useRef(null);
 
   // 拉取后端可用模型。这里除了更新下拉/模型标签，
   // 还要顺手修正那些引用了已下线模型的历史聊天会话。
@@ -1916,26 +1622,10 @@ export default function App() {
       .finally(() => {
         setModelsLoaded(true);
       });
-  }, []);
+  }, [setChatState]);
 
-  const { sessions, activeSessionId } = chatState;
-  const activeSession = sessions.find(session => session.id === activeSessionId) || sessions[0];
-  const messages = activeSession.messages;
-  const chatModel = activeSession.model;
   const selectedChatModelLabel = availableModels.find(item => item.id === chatModel)?.label || chatModel;
   const sessionLocked = streaming || agentRunning;
-
-  // 会话历史和当前激活会话 id 都是持久化状态；这里统一落盘。
-  useEffect(() => {
-    localStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
-    localStorage.setItem(ACTIVE_SESSION_KEY, activeSession.id);
-    localStorage.removeItem(LEGACY_MESSAGES_KEY);
-    localStorage.removeItem(LEGACY_MODEL_KEY);
-  }, [activeSession.id, sessions]);
-
-  useEffect(() => {
-    localStorage.setItem(LAST_MODE_KEY, mode);
-  }, [mode]);
 
   // 在移动端/窄屏时，会话侧栏和 Agent 面板会改变页面主色块区域。
   // 同步 <meta name="theme-color"> 是为了让浏览器地址栏颜色也跟着切换。
@@ -2105,6 +1795,8 @@ export default function App() {
       aborted = true;
       controller.abort();
     };
+  // 这段只负责页面首次加载后的运行态接回；依赖更新不应该重新订阅同一个 run。
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -2132,6 +1824,8 @@ export default function App() {
     setAgentStartedAt(null);
     setPendingApproval(null);
     approvalRequestRef.current = null;
+  // 这里按会话切换同步 trace，不能跟随消息增量每次重置运行态。
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeSession.id]);
 
   // Keyboard shortcuts: Cmd/Ctrl+Shift+E collapse panel, Cmd/Ctrl+Shift+M toggle memory
@@ -2151,7 +1845,7 @@ export default function App() {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [mode]);
+  }, [mode, setAgentCollapsed, setShowMemoryPanel, setShowSessions, showMemoryPanel]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -2174,49 +1868,7 @@ export default function App() {
       agentAbortRef.current?.abort();
       approvalRequestRef.current?.resolve?.('reject');
     };
-  }, []);
-
-  const updateSession = (sessionId, updater) => {
-    setChatState(prev =>
-      normalizeChatState({
-        ...prev,
-        sessions: prev.sessions.map(session => (session.id === sessionId ? updater(session) : session)),
-      })
-    );
-  };
-
-  // Restore saved agent panel width on mount
-  useEffect(() => {
-    const saved = localStorage.getItem(PANEL_SIZE_KEY);
-    if (saved && window.innerWidth >= DOCKED_LAYOUT_BREAKPOINT) {
-      const panel = document.querySelector('.layout-body > .agent-panel-wrap');
-      if (panel) panel.style.flex = `0 0 ${saved}px`;
-    }
-  }, []);
-
-  useEffect(() => {
-    // 这里统一处理窗口宽度变化带来的布局状态同步：
-    // - 面板宽度在桌面端恢复拖拽值
-    // - 平板/手机端自动关闭侧栏
-    const syncResponsiveState = () => {
-      const panel = document.querySelector('.layout-body > .agent-panel-wrap');
-      if (panel) {
-        if (window.innerWidth >= DOCKED_LAYOUT_BREAKPOINT) {
-          const saved = localStorage.getItem(PANEL_SIZE_KEY);
-          panel.style.flex = saved ? `0 0 ${saved}px` : '';
-        } else {
-          panel.style.flex = '';
-        }
-      }
-
-      if (window.innerWidth < TABLET_BREAKPOINT) {
-        setShowSessions(false);
-      }
-    };
-
-    window.addEventListener('resize', syncResponsiveState);
-    return () => window.removeEventListener('resize', syncResponsiveState);
-  }, []);
+  }, [agentAbortRef, approvalRequestRef]);
 
   const stopGeneration = () => abortRef.current?.abort();
   const stopAgent = () => {
@@ -2672,6 +2324,8 @@ export default function App() {
   const sessionStarted = messages.length > 0;
 
   const suggestions = useMemo(() => {
+    void activeSession.id;
+    void suggestionSeed;
     const pool = SUGGESTIONS[mode];
     const count = mode === 'agent' ? 8 : 4;
     return shuffled(pool).slice(0, count);
@@ -2691,7 +2345,6 @@ export default function App() {
   const toggleAgentModel = id => {
     setSelectedAgentModels(prev => {
       const next = prev.includes(id) ? prev.filter(m => m !== id) : [...prev, id];
-      localStorage.setItem('agent_models', JSON.stringify(next));
       return next;
     });
   };
@@ -2704,7 +2357,6 @@ export default function App() {
       const swap = idx + dir;
       if (swap < 0 || swap >= next.length) return prev;
       [next[idx], next[swap]] = [next[swap], next[idx]];
-      localStorage.setItem('agent_models', JSON.stringify(next));
       return next;
     });
   };
@@ -2741,13 +2393,13 @@ export default function App() {
           <div className="strategy-toggle">
             <button
               className={`strategy-btn ${agentStrategy === 'race' ? 'active' : ''}`}
-              onClick={() => { setAgentStrategy('race'); localStorage.setItem('agent_strategy', 'race'); }}
+              onClick={() => setAgentStrategy('race')}
               disabled={sessionLocked}
               title="按优先级分批启动，先到先得"
             >竞速</button>
             <button
               className={`strategy-btn ${agentStrategy === 'vote' ? 'active' : ''}`}
-              onClick={() => { setAgentStrategy('vote'); localStorage.setItem('agent_strategy', 'vote'); }}
+              onClick={() => setAgentStrategy('vote')}
               disabled={sessionLocked}
               title="等待所有模型完成，投票选最优"
             >汇总</button>
@@ -2778,7 +2430,7 @@ export default function App() {
   const memoryToggle = mode === 'agent' && !sessionStarted && (
     <button
       className={`toolbar-chip ${agentMemory ? 'active' : ''}`}
-      onClick={() => { setAgentMemory(v => { const n = !v; localStorage.setItem('agent_memory', String(n)); return n; }); }}
+      onClick={() => setAgentMemory(v => !v)}
       title={agentMemory ? '使用历史记忆辅助任务' : '不使用记忆'}
     >
       <Brain size={12} /> {agentMemory ? '记忆开' : '记忆关'}
@@ -2790,7 +2442,7 @@ export default function App() {
   return (
     <ErrorBoundary>
     <div className="app-shell">
-      <div className={`sidebar ${showSessions ? 'open' : ''}`}>
+      <SessionSidebar open={showSessions} onClose={() => setShowSessions(false)}>
         <SessionList
           sessions={sessions}
           activeSessionId={activeSession.id}
@@ -2803,12 +2455,7 @@ export default function App() {
           showMemoryPanel={showMemoryPanel}
           onToggleMemory={() => setShowMemoryPanel(v => !v)}
         />
-      </div>
-      <button
-        className={`sidebar-backdrop ${showSessions ? 'visible' : ''}`}
-        onClick={() => setShowSessions(false)}
-        aria-label="关闭会话列表"
-      />
+      </SessionSidebar>
 
       <div className="main-area">
       {showHero ? (
@@ -2892,37 +2539,13 @@ export default function App() {
 
           <div className={`layout-body ${mode === 'agent' ? 'agent-layout' : 'chat-layout'}`}>
           {mode === 'agent' && (
-            <>
-              <div className="agent-mobile-tabs">
-                <button className={`agent-mobile-tab ${agentMobileTab === 'agent' ? 'active' : ''}`} onClick={() => setAgentMobileTab('agent')}>
-                  Agent{agentRunning && <span className="tab-status-dot" />}
-                </button>
-                {agentTrace.length > 0 && (() => {
-                  const lastStep = agentTrace.reduce((max, e) => (e.step != null ? Math.max(max, e.step) : max), 0);
-                  const totalTokens = agentTrace.reduce((sum, e) => {
-                    if (e.type === 'step' && e.stage === 'action' && e.usage) return sum + e.usage.prompt_tokens + e.usage.completion_tokens;
-                    return sum;
-                  }, 0);
-                  const doneEvent = [...agentTrace].reverse().find(e => e.type === 'done');
-                  const stepCount = doneEvent?.meta?.step_count || lastStep;
-                  return (
-                    <div className="agent-mobile-metrics">
-                      {lastStep > 0 && <span className="agent-mobile-metric">Step {lastStep}/{stepCount}</span>}
-                      {totalTokens > 0 && <span className="agent-mobile-metric">{totalTokens > 999 ? `${(totalTokens / 1000).toFixed(1)}k` : totalTokens} tok</span>}
-                    </div>
-                  );
-                })()}
-                <button className={`agent-mobile-tab ${agentMobileTab === 'chat' ? 'active' : ''}`} onClick={() => setAgentMobileTab('chat')}>对话</button>
-              </div>
-              <div className={`agent-panel-wrap ${agentMobileTab === 'chat' ? 'mobile-hidden' : ''}`}
-                onTouchStart={e => { touchStartRef.current = e.touches[0].clientX; }}
-                onTouchEnd={e => {
-                  if (touchStartRef.current == null) return;
-                  const delta = e.changedTouches[0].clientX - touchStartRef.current;
-                  if (delta < -60 && agentMobileTab === 'agent') setAgentMobileTab('chat');
-                  touchStartRef.current = null;
-                }}
-              >
+            <AgentPane
+              agentMobileTab={agentMobileTab}
+              setAgentMobileTab={setAgentMobileTab}
+              agentRunning={agentRunning}
+              agentTrace={agentTrace}
+              touchStartRef={touchStartRef}
+              agentPanel={(
                 <AgentPanel
                   mode={mode}
                   running={agentRunning}
@@ -2937,69 +2560,33 @@ export default function App() {
                   onRollback={handleRollback}
                   rollbackLoading={rollbackLoading}
                 />
-              </div>
-
-              <ResizeDivider side="agent" />
-            </>
+              )}
+              resizeDivider={<ResizeDivider side="agent" />}
+            />
           )}
 
           {messages.length > 0 && (
-            <div className={`chat-panel-wrap ${mode === 'agent' && agentMobileTab === 'agent' ? 'mobile-hidden' : ''}`}
-              onTouchStart={e => { touchStartRef.current = e.touches[0].clientX; }}
-              onTouchEnd={e => {
-                if (touchStartRef.current == null) return;
-                const delta = e.changedTouches[0].clientX - touchStartRef.current;
-                if (delta > 60 && agentMobileTab === 'chat') setAgentMobileTab('agent');
-                touchStartRef.current = null;
-              }}
-            >
-              <div className="messages">
-              {messages.map((msg, i) => (
-                <div key={i} className={`bubble-row ${msg.role}`}>
-                  {msg.role === 'assistant' && (
-                    <>
-                      <div className={`bubble assistant ${hasThinkContent(msg.content) ? 'has-think' : ''}`}>
-                        <MessageContent role="assistant" content={msg.content} showCursor={streaming && i === messages.length - 1} />
-                        {msg.ts && <div className="msg-time">{formatMsgTime(msg.ts)}</div>}
-                      </div>
-                      <CopyButton text={msg.content} />
-                    </>
-                  )}
-                  {msg.role === 'user' && (
-                    <>
-                      <CopyButton text={msg.content} />
-                      <div className="bubble user">
-                        <MessageContent role="user" content={msg.content} />
-                        {msg.ts && <div className="msg-time">{formatMsgTime(msg.ts)}</div>}
-                      </div>
-                    </>
-                  )}
-                </div>
-              ))}
-              <div ref={bottomRef} />
-              <div className="input-area">
-                <div className="input-card">
-                  <textarea
-                    ref={textareaRef}
-                    value={input}
-                    onChange={e => setInput(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                    placeholder={
-                      mode === 'agent'
-                        ? '描述要让 Agent 完成的任务…'
-                        : '输入消息…'
-                    }
-                    rows={1}
-                    disabled={sessionLocked}
-                  />
-                  <div className="input-toolbar">
-                    {memoryToggle}
-                    {sendButton}
-                  </div>
-                </div>
-              </div>
-              </div>
-            </div>
+            <ChatPane
+              hidden={mode === 'agent' && agentMobileTab === 'agent'}
+              messages={messages}
+              streaming={streaming}
+              bottomRef={bottomRef}
+              textareaRef={textareaRef}
+              inputValue={input}
+              setInput={setInput}
+              handleKeyDown={handleKeyDown}
+              placeholder={mode === 'agent' ? '描述要让 Agent 完成的任务…' : '输入消息…'}
+              disabled={sessionLocked}
+              memoryToggle={memoryToggle}
+              sendButton={sendButton}
+              touchStartRef={touchStartRef}
+              agentMobileTab={agentMobileTab}
+              setAgentMobileTab={setAgentMobileTab}
+              renderMessageContent={props => <MessageContent {...props} />}
+              renderCopyButton={props => <CopyButton {...props} />}
+              hasThinkContent={hasThinkContent}
+              formatMsgTime={formatMsgTime}
+            />
           )}
 
           </div>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2498,7 +2498,7 @@ export default function App() {
         strategy: selectedAgentModels.length > 1 ? agentStrategy : 'race',
         memory: agentMemory,
         signal: controller.signal,
-        messages: isRetry ? [] : messages.filter(m => m.role === 'user').slice(-5).map(m => ({ role: m.role, content: m.content })),
+        messages: isRetry ? [] : messages.slice(-10).map(m => ({ role: m.role, content: m.content })),
         ...extraBody,
         async onEvent(event) {
           console.log(`[AgentUI] event type=${event.type} step=${event.step ?? '-'} stage=${event.stage ?? '-'} model=${event.model || '-'}`);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,7 +13,7 @@ import bash from 'highlight.js/lib/languages/bash';
 import sql from 'highlight.js/lib/languages/sql';
 import 'highlight.js/styles/github.css';
 import './App.css';
-import { streamAgentRun, streamChatCompletion, submitAgentApproval, submitAgentQuestion } from './api/streams.js';
+import { fetchAgentTrace, streamAgentRun, streamChatCompletion, submitAgentApproval, submitAgentQuestion } from './api/streams.js';
 import { AgentPane } from './components/AgentPane.jsx';
 import { ChatPane } from './components/ChatPane.jsx';
 import { SessionSidebar } from './components/SessionSidebar.jsx';
@@ -1684,6 +1684,7 @@ export default function App() {
               { role: 'user', content: task, ts: data.startedAt || Date.now() },
               { role: 'assistant', content: 'Desktop Agent 正在执行任务，请稍候…', ts: Date.now() },
             ],
+            agentRunId: data.runId,
           });
           return normalizeChatState({
             sessions: [cleanSession, ...prev.sessions],
@@ -1768,7 +1769,7 @@ export default function App() {
                     msgs.push({ role: 'user', content: reconnectTaskRef.current || data.task || 'Agent 任务', ts: data.startedAt || Date.now() });
                     msgs.push({ role: 'assistant', content: event.answer || 'Agent 已完成任务。', ts: Date.now() });
                   }
-                  return touchSession(session, { messages: msgs });
+                  return touchSession(session, { messages: msgs, agentRunId: data.runId });
                 });
               }
 
@@ -1802,13 +1803,23 @@ export default function App() {
     // 普通切换会话时，Agent trace 跟着 active session 走；
     // 但如果当前正处在“刷新后重连中的运行态”，不要被旧 session 覆盖掉。
     if (agentRunning) return;
+    const controller = new AbortController();
     const savedTrace = activeSession.agentTrace || [];
+    const savedRunId = activeSession.agentRunId || savedTrace.find(e => e.runId)?.runId || null;
     setAgentTrace(savedTrace);
-    // Recover runId from saved trace (survives page refresh / backend restart)
-    const runEvent = savedTrace.find(e => e.runId);
-    if (runEvent) {
-      agentRunIdRef.current = runEvent.runId;
-      setAgentRunId(runEvent.runId);
+    if (savedRunId) {
+      agentRunIdRef.current = savedRunId;
+      setAgentRunId(savedRunId);
+      fetchAgentTrace(savedRunId, { signal: controller.signal })
+        .then(events => {
+          if (events.length === 0 || controller.signal.aborted) return;
+          setAgentTrace(events);
+          updateSession(activeSession.id, session => touchSession(session, {
+            agentRunId: savedRunId,
+            agentTrace: events,
+          }));
+        })
+        .catch(() => {});
     } else {
       agentRunIdRef.current = null;
       setAgentRunId(null);
@@ -1819,6 +1830,7 @@ export default function App() {
     setAgentStartedAt(null);
     setPendingApproval(null);
     approvalRequestRef.current = null;
+    return () => controller.abort();
   // 这里按会话切换同步 trace，不能跟随消息增量每次重置运行态。
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeSession.id]);
@@ -2118,10 +2130,14 @@ export default function App() {
       updateSession(sessionId, session =>
         touchSession(session, {
           messages: [...history, { role: 'assistant', content: 'Desktop Agent 正在执行任务，请稍候…', ts: Date.now() }],
+          agentTrace: [],
+          agentRunId: null,
         })
       );
       setInput('');
       setAgentTrace([]);
+      agentRunIdRef.current = null;
+      setAgentRunId(null);
     } else {
       // Retry from checkpoint — keep filtered trace (handleRollback already removed steps > target)
       const cpStep = extraBody?.fromCheckpoint?.step;
@@ -2165,9 +2181,10 @@ export default function App() {
             return [...prev, event];
           });
 
-          if (event.runId && !agentRunIdRef.current) {
+          if (event.runId && event.runId !== agentRunIdRef.current) {
             agentRunIdRef.current = event.runId;
             setAgentRunId(event.runId);
+            updateSession(sessionId, session => touchSession(session, { agentRunId: event.runId }));
           }
 
           if (event.type === 'approval_required') {
@@ -2206,7 +2223,7 @@ export default function App() {
                     ts: Date.now(),
                   };
                 }
-                return touchSession(session, { messages: nextMessages, agentTrace: prev });
+                return touchSession(session, { messages: nextMessages, agentTrace: prev, agentRunId: agentRunIdRef.current });
               });
               return prev;
             });
@@ -2226,7 +2243,7 @@ export default function App() {
                     ts: Date.now(),
                   };
                 }
-                return touchSession(session, { messages: nextMessages, agentTrace: prev });
+                return touchSession(session, { messages: nextMessages, agentTrace: prev, agentRunId: agentRunIdRef.current });
               });
               return prev;
             });
@@ -2267,9 +2284,9 @@ export default function App() {
               } else {
                 next[lastIdx] = { role: 'assistant', content: `⚠️ Desktop Agent 失败：${errorEvent.error || '连接中断'}`, ts: Date.now() };
               }
-              return touchSession(session, { messages: next, agentTrace: prev });
+              return touchSession(session, { messages: next, agentTrace: prev, agentRunId: agentRunIdRef.current });
             }
-            return touchSession(session, { agentTrace: prev });
+            return touchSession(session, { agentTrace: prev, agentRunId: agentRunIdRef.current });
           });
         } else if (prev.length === 0 || !prev.some(e => e.type === 'done' || e.type === 'error')) {
           // No events received at all or SSE disconnected without done/error
@@ -2279,9 +2296,9 @@ export default function App() {
             if (lastIdx >= 0 && msgs[lastIdx].role === 'assistant' && msgs[lastIdx].content.includes('正在执行任务')) {
               const next = [...msgs];
               next[lastIdx] = { role: 'assistant', content: '⚠️ Desktop Agent 连接中断，未收到执行结果。', ts: Date.now() };
-              return touchSession(session, { messages: next, agentTrace: prev });
+              return touchSession(session, { messages: next, agentTrace: prev, agentRunId: agentRunIdRef.current });
             }
-            return touchSession(session, { agentTrace: prev });
+            return touchSession(session, { agentTrace: prev, agentRunId: agentRunIdRef.current });
           });
         }
         return prev;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1753,7 +1753,7 @@ export default function App() {
               if (event.type === 'rollback') {
                 setAgentTrace(prev => {
                   const target = event.targetStep;
-                  return prev.filter(e => (e.step == null && e.type !== 'done' && e.type !== 'error') || e.step <= target);
+                  return prev.filter(e => (e.step == null && e.type !== 'done' && e.type !== 'error') || e.step < target);
                 });
               }
 
@@ -1886,7 +1886,7 @@ export default function App() {
 
   const handleRollback = async targetStep => {
     const rid = agentRunIdRef.current;
-    console.log('[Rollback] targetStep:', targetStep, 'runId:', rid, 'running:', agentRunning);
+    console.log('[Rollback] targetStep:', targetStep, 'runId:', rid, 'running:', agentRunning, 'traceLen:', agentTrace.length);
     if (!rid) {
       console.warn('[Rollback] no runId, cannot rollback');
       return;
@@ -1895,6 +1895,7 @@ export default function App() {
     try {
       if (agentRunning) {
         // Running task — use pendingRollback for in-place rollback
+        console.log('[Rollback] calling POST /api/agent/rollback');
         const res = await fetch('/api/agent/rollback', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -1906,7 +1907,12 @@ export default function App() {
         }
       } else {
         // Finished task — restart from checkpoint
-        setAgentTrace(prev => prev.filter(e => (e.step == null && e.type !== 'done' && e.type !== 'error') || e.step <= targetStep));
+        console.log('[Rollback] finished task, filtering trace and restarting from checkpoint');
+        setAgentTrace(prev => {
+          const filtered = prev.filter(e => (e.step == null && e.type !== 'done' && e.type !== 'error') || e.step < targetStep);
+          console.log('[Rollback] trace filtered:', prev.length, '->', filtered.length);
+          return filtered;
+        });
         await sendAgentTask(lastAgentTaskRef.current || '继续任务', {
           fromCheckpoint: { runId: rid, step: targetStep },
         });

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1396,11 +1396,6 @@ function AgentPanel({ mode, running, trace, startedAt, modelList, collapsed, onT
                         })}
                       </div>
                     )}
-                    {event.answer && (
-                      <div className="agent-done-answer">
-                        <MarkdownBlock content={event.answer} />
-                      </div>
-                    )}
                   </div>
                 </>
               )}

--- a/client/src/api/streams.js
+++ b/client/src/api/streams.js
@@ -1,0 +1,179 @@
+const API_URL = '/api/chat';
+const AGENT_API_URL = '/api/agent';
+const AGENT_APPROVAL_API_URL = '/api/agent/approvals';
+
+async function streamSseJson({ url, body, signal, onEvent }) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    try {
+      const parsed = JSON.parse(errorText);
+      throw new Error(parsed.error || `HTTP ${res.status}`);
+    } catch (parseErr) {
+      if (parseErr.message && !parseErr.message.startsWith('HTTP')) throw parseErr;
+      throw new Error(errorText || `HTTP ${res.status}`);
+    }
+  }
+
+  if (!res.body) {
+    throw new Error('响应流不可用');
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const handleEvent = async rawEvent => {
+    const line = rawEvent
+      .split('\n')
+      .map(item => item.trim())
+      .find(item => item.startsWith('data: '));
+
+    if (!line) {
+      return;
+    }
+
+    const json = JSON.parse(line.slice(6));
+    if (json.error && !json.type) {
+      throw new Error(json.error);
+    }
+    await onEvent?.(json);
+  };
+
+  const flushBuffer = async final => {
+    const events = buffer.split('\n\n');
+    buffer = final ? '' : events.pop() ?? '';
+    for (const rawEvent of events) {
+      if (rawEvent.trim()) {
+        await handleEvent(rawEvent);
+      }
+    }
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    await flushBuffer(false);
+  }
+
+  buffer += decoder.decode();
+  await flushBuffer(true);
+}
+
+export async function streamChatCompletion({
+  messages,
+  model,
+  signal,
+  temperature = 1,
+  top_p = 0.95,
+  max_tokens = 8192,
+  onContent,
+  onDone,
+}) {
+  let donePayload = null;
+
+  await streamSseJson({
+    url: API_URL,
+    body: { messages, model, temperature, top_p, max_tokens },
+    signal,
+    onEvent(json) {
+      if (json.content) {
+        onContent?.(json.content);
+      }
+      if (json.done) {
+        donePayload = json;
+        onDone?.(json);
+      }
+    },
+  });
+
+  return donePayload;
+}
+
+export async function streamAgentRun({ task, model, models, strategy, memory, signal, onEvent, messages, ...extra }) {
+  let runId = null;
+  let gotDone = false;
+
+  const wrappedEvent = event => {
+    if (event.runId) runId = event.runId;
+    if (event.type === 'done' || event.type === 'error') gotDone = true;
+    onEvent(event);
+  };
+
+  try {
+    await streamSseJson({
+      url: AGENT_API_URL,
+      body: { task, model, models, strategy, memory, messages, ...extra },
+      signal,
+      onEvent: wrappedEvent,
+    });
+  } catch {
+    // initial POST may fail/disconnect, fall through to reconnect
+  }
+
+  if (!gotDone && runId && !signal.aborted) {
+    try {
+      const res = await fetch(`/api/agent/stream/${runId}`, { signal });
+      if (!res.ok) return;
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          const dataLine = line.replace(/^data:\s*/, '');
+          if (!dataLine || dataLine === '[DONE]') continue;
+          try {
+            const event = JSON.parse(dataLine);
+            wrappedEvent(event);
+          } catch { /* skip malformed */ }
+        }
+      }
+    } catch {
+      // reconnect also failed
+    }
+  }
+}
+
+export async function submitAgentApproval({ runId, approvalId, decision }) {
+  const res = await fetch(AGENT_APPROVAL_API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ runId, approvalId, decision }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(errorText || `HTTP ${res.status}`);
+  }
+
+  return res.json();
+}
+
+export async function submitAgentQuestion({ runId, approvalId, response }) {
+  const res = await fetch('/api/agent/question', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ runId, approvalId, response }),
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(errorText || `HTTP ${res.status}`);
+  }
+
+  return res.json();
+}

--- a/client/src/api/streams.js
+++ b/client/src/api/streams.js
@@ -177,3 +177,16 @@ export async function submitAgentQuestion({ runId, approvalId, response }) {
 
   return res.json();
 }
+
+export async function fetchAgentTrace(runId, { signal } = {}) {
+  if (!runId) return [];
+
+  const res = await fetch(`/api/agent/traces/${encodeURIComponent(runId)}`, { signal });
+  if (res.status === 404) return [];
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(errorText || `HTTP ${res.status}`);
+  }
+  const data = await res.json();
+  return Array.isArray(data.events) ? data.events : [];
+}

--- a/client/src/components/AgentPane.jsx
+++ b/client/src/components/AgentPane.jsx
@@ -1,0 +1,62 @@
+function getAgentStepMetrics(trace) {
+  const lastStep = trace.reduce((max, event) => (event.step != null ? Math.max(max, event.step) : max), 0);
+  const totalTokens = trace.reduce((sum, event) => {
+    if (event.type === 'step' && event.stage === 'action' && event.usage) {
+      return sum + event.usage.prompt_tokens + event.usage.completion_tokens;
+    }
+    return sum;
+  }, 0);
+  const doneEvent = [...trace].reverse().find(event => event.type === 'done');
+  return {
+    lastStep,
+    totalTokens,
+    stepCount: doneEvent?.meta?.step_count || lastStep,
+  };
+}
+
+function formatTokenCount(value) {
+  return value > 999 ? `${(value / 1000).toFixed(1)}k` : value;
+}
+
+export function AgentPane({
+  agentMobileTab,
+  setAgentMobileTab,
+  agentRunning,
+  agentTrace,
+  touchStartRef,
+  agentPanel,
+  resizeDivider,
+}) {
+  const metrics = getAgentStepMetrics(agentTrace);
+
+  return (
+    <>
+      <div className="agent-mobile-tabs">
+        <button className={`agent-mobile-tab ${agentMobileTab === 'agent' ? 'active' : ''}`} onClick={() => setAgentMobileTab('agent')}>
+          Agent{agentRunning && <span className="tab-status-dot" />}
+        </button>
+        {agentTrace.length > 0 && (
+          <div className="agent-mobile-metrics">
+            {metrics.lastStep > 0 && <span className="agent-mobile-metric">Step {metrics.lastStep}/{metrics.stepCount}</span>}
+            {metrics.totalTokens > 0 && <span className="agent-mobile-metric">{formatTokenCount(metrics.totalTokens)} tok</span>}
+          </div>
+        )}
+        <button className={`agent-mobile-tab ${agentMobileTab === 'chat' ? 'active' : ''}`} onClick={() => setAgentMobileTab('chat')}>对话</button>
+      </div>
+      <div
+        className={`agent-panel-wrap ${agentMobileTab === 'chat' ? 'mobile-hidden' : ''}`}
+        onTouchStart={event => { touchStartRef.current = event.touches[0].clientX; }}
+        onTouchEnd={event => {
+          if (touchStartRef.current == null) return;
+          const delta = event.changedTouches[0].clientX - touchStartRef.current;
+          if (delta < -60 && agentMobileTab === 'agent') setAgentMobileTab('chat');
+          touchStartRef.current = null;
+        }}
+      >
+        {agentPanel}
+      </div>
+
+      {resizeDivider}
+    </>
+  );
+}

--- a/client/src/components/ChatPane.jsx
+++ b/client/src/components/ChatPane.jsx
@@ -1,0 +1,77 @@
+export function ChatPane({
+  hidden,
+  messages,
+  streaming,
+  bottomRef,
+  textareaRef,
+  inputValue,
+  setInput,
+  handleKeyDown,
+  placeholder,
+  disabled,
+  memoryToggle,
+  sendButton,
+  touchStartRef,
+  agentMobileTab,
+  setAgentMobileTab,
+  renderMessageContent,
+  renderCopyButton,
+  hasThinkContent,
+  formatMsgTime,
+}) {
+  return (
+    <div
+      className={`chat-panel-wrap ${hidden ? 'mobile-hidden' : ''}`}
+      onTouchStart={event => { touchStartRef.current = event.touches[0].clientX; }}
+      onTouchEnd={event => {
+        if (touchStartRef.current == null) return;
+        const delta = event.changedTouches[0].clientX - touchStartRef.current;
+        if (delta > 60 && agentMobileTab === 'chat') setAgentMobileTab('agent');
+        touchStartRef.current = null;
+      }}
+    >
+      <div className="messages">
+        {messages.map((message, index) => (
+          <div key={index} className={`bubble-row ${message.role}`}>
+            {message.role === 'assistant' && (
+              <>
+                <div className={`bubble assistant ${hasThinkContent(message.content) ? 'has-think' : ''}`}>
+                  {renderMessageContent({ role: 'assistant', content: message.content, showCursor: streaming && index === messages.length - 1 })}
+                  {message.ts && <div className="msg-time">{formatMsgTime(message.ts)}</div>}
+                </div>
+                {renderCopyButton({ text: message.content })}
+              </>
+            )}
+            {message.role === 'user' && (
+              <>
+                {renderCopyButton({ text: message.content })}
+                <div className="bubble user">
+                  {renderMessageContent({ role: 'user', content: message.content })}
+                  {message.ts && <div className="msg-time">{formatMsgTime(message.ts)}</div>}
+                </div>
+              </>
+            )}
+          </div>
+        ))}
+        <div ref={bottomRef} />
+        <div className="input-area">
+          <div className="input-card">
+            <textarea
+              ref={textareaRef}
+              value={inputValue}
+              onChange={event => setInput(event.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              rows={1}
+              disabled={disabled}
+            />
+            <div className="input-toolbar">
+              {memoryToggle}
+              {sendButton}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/SessionSidebar.jsx
+++ b/client/src/components/SessionSidebar.jsx
@@ -1,0 +1,14 @@
+export function SessionSidebar({ open, onClose, children }) {
+  return (
+    <>
+      <div className={`sidebar ${open ? 'open' : ''}`}>
+        {children}
+      </div>
+      <button
+        className={`sidebar-backdrop ${open ? 'visible' : ''}`}
+        onClick={onClose}
+        aria-label="关闭会话列表"
+      />
+    </>
+  );
+}

--- a/client/src/hooks/useAgentRun.js
+++ b/client/src/hooks/useAgentRun.js
@@ -1,0 +1,67 @@
+import { useRef, useState } from 'react';
+
+export function useAgentRun() {
+  const [streaming, setStreaming] = useState(false);
+  const [agentRunning, setAgentRunning] = useState(false);
+  const [agentStopping, setAgentStopping] = useState(false);
+  const [_agentRunId, setAgentRunId] = useState(null);
+  const [reconnectedRun, setReconnectedRun] = useState(false);
+  const [agentTrace, setAgentTrace] = useState([]);
+  const [pendingApproval, setPendingApproval] = useState(null);
+  const [approvalSubmitting, setApprovalSubmitting] = useState(false);
+  const [agentCollapsed, setAgentCollapsed] = useState(false);
+  const [showMemoryPanel, setShowMemoryPanel] = useState(false);
+  const [rollbackLoading, setRollbackLoading] = useState(false);
+  const [agentMobileTab, setAgentMobileTab] = useState('agent');
+  const [pendingQuestion, setPendingQuestion] = useState(null);
+  const [questionSubmitting, setQuestionSubmitting] = useState(false);
+  const [agentStartedAt, setAgentStartedAt] = useState(null);
+
+  const agentRunIdRef = useRef(null);
+  const agentAbortRef = useRef(null);
+  const approvalRequestRef = useRef(null);
+  const questionRequestRef = useRef(null);
+  const touchStartRef = useRef(null);
+  const reconnectTaskRef = useRef(null);
+  const lastAgentTaskRef = useRef(null);
+
+  return {
+    streaming,
+    setStreaming,
+    agentRunning,
+    setAgentRunning,
+    agentStopping,
+    setAgentStopping,
+    _agentRunId,
+    setAgentRunId,
+    reconnectedRun,
+    setReconnectedRun,
+    agentTrace,
+    setAgentTrace,
+    pendingApproval,
+    setPendingApproval,
+    approvalSubmitting,
+    setApprovalSubmitting,
+    agentCollapsed,
+    setAgentCollapsed,
+    showMemoryPanel,
+    setShowMemoryPanel,
+    rollbackLoading,
+    setRollbackLoading,
+    agentMobileTab,
+    setAgentMobileTab,
+    pendingQuestion,
+    setPendingQuestion,
+    questionSubmitting,
+    setQuestionSubmitting,
+    agentStartedAt,
+    setAgentStartedAt,
+    agentRunIdRef,
+    agentAbortRef,
+    approvalRequestRef,
+    questionRequestRef,
+    touchStartRef,
+    reconnectTaskRef,
+    lastAgentTaskRef,
+  };
+}

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -30,6 +30,7 @@ export function createSession({
   messages = [],
   model,
   agentTrace = [],
+  agentRunId = null,
   createdAt = Date.now(),
   updatedAt = Date.now(),
 } = {}) {
@@ -38,6 +39,7 @@ export function createSession({
     messages: normalizeMessages(messages),
     model: model || DEFAULT_MODEL_ID,
     agentTrace: Array.isArray(agentTrace) ? agentTrace : [],
+    agentRunId: typeof agentRunId === 'string' ? agentRunId : null,
     createdAt,
     updatedAt,
   };
@@ -56,6 +58,7 @@ export function normalizeChatState(rawState) {
             messages: session.messages,
             model: session.model,
             agentTrace: session.agentTrace,
+            agentRunId: session.agentRunId,
             createdAt: Number.isFinite(session.createdAt) ? session.createdAt : Date.now(),
             updatedAt: Number.isFinite(session.updatedAt) ? session.updatedAt : Date.now(),
           });

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const DEFAULT_MODEL_ID = 'minimaxai/minimax-m2.7';
+
+const LEGACY_MESSAGES_KEY = 'nvidia_chat_messages';
+const LEGACY_MODEL_KEY = 'nvidia_chat_model';
+const SESSIONS_KEY = 'nvidia_chat_sessions';
+const ACTIVE_SESSION_KEY = 'nvidia_chat_active_session';
+
+function generateSessionId() {
+  return `session_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function normalizeMessages(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter(item => item && (item.role === 'user' || item.role === 'assistant') && typeof item.content === 'string')
+    .map(item => ({
+      role: item.role,
+      content: item.content,
+      ...(item.ts ? { ts: item.ts } : {}),
+    }));
+}
+
+export function createSession({
+  id = generateSessionId(),
+  messages = [],
+  model,
+  agentTrace = [],
+  createdAt = Date.now(),
+  updatedAt = Date.now(),
+} = {}) {
+  return {
+    id,
+    messages: normalizeMessages(messages),
+    model: model || DEFAULT_MODEL_ID,
+    agentTrace: Array.isArray(agentTrace) ? agentTrace : [],
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function normalizeChatState(rawState) {
+  const sessions = Array.isArray(rawState?.sessions)
+    ? rawState.sessions
+        .map(session => {
+          if (!session || typeof session !== 'object') {
+            return null;
+          }
+
+          return createSession({
+            id: typeof session.id === 'string' && session.id ? session.id : undefined,
+            messages: session.messages,
+            model: session.model,
+            agentTrace: session.agentTrace,
+            createdAt: Number.isFinite(session.createdAt) ? session.createdAt : Date.now(),
+            updatedAt: Number.isFinite(session.updatedAt) ? session.updatedAt : Date.now(),
+          });
+        })
+        .filter(Boolean)
+    : [];
+
+  const nextSessions = sessions.length > 0 ? sessions : [createSession()];
+  const activeSessionId = nextSessions.some(session => session.id === rawState?.activeSessionId)
+    ? rawState.activeSessionId
+    : nextSessions[0].id;
+
+  return { sessions: nextSessions, activeSessionId };
+}
+
+function loadChatState() {
+  try {
+    const storedSessions = JSON.parse(localStorage.getItem(SESSIONS_KEY) || 'null');
+    if (Array.isArray(storedSessions) && storedSessions.length > 0) {
+      return normalizeChatState({
+        sessions: storedSessions,
+        activeSessionId: localStorage.getItem(ACTIVE_SESSION_KEY),
+      });
+    }
+  } catch {
+    // ignore malformed storage and fall back to migration/default state
+  }
+
+  let legacyMessages = [];
+  try {
+    legacyMessages = JSON.parse(localStorage.getItem(LEGACY_MESSAGES_KEY) || '[]');
+  } catch {
+    legacyMessages = [];
+  }
+
+  const migratedSession = createSession({
+    messages: legacyMessages,
+    model: localStorage.getItem(LEGACY_MODEL_KEY) || DEFAULT_MODEL_ID,
+  });
+
+  return normalizeChatState({
+    sessions: [migratedSession],
+    activeSessionId: migratedSession.id,
+  });
+}
+
+export function touchSession(session, patch = {}) {
+  return {
+    ...session,
+    ...patch,
+    updatedAt: Date.now(),
+  };
+}
+
+export function getSessionTitle(messages) {
+  const firstUserMessage = messages.find(item => item.role === 'user' && item.content.trim());
+  if (!firstUserMessage) {
+    return '新对话';
+  }
+
+  const text = firstUserMessage.content.replace(/\s+/g, ' ').trim();
+  return text.length > 20 ? `${text.slice(0, 20)}…` : text;
+}
+
+export function useChatSessions() {
+  const [chatState, setChatState] = useState(loadChatState);
+  const { sessions, activeSessionId } = chatState;
+  const activeSession = sessions.find(session => session.id === activeSessionId) || sessions[0];
+
+  useEffect(() => {
+    localStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions));
+    localStorage.setItem(ACTIVE_SESSION_KEY, activeSession.id);
+    localStorage.removeItem(LEGACY_MESSAGES_KEY);
+    localStorage.removeItem(LEGACY_MODEL_KEY);
+  }, [activeSession.id, sessions]);
+
+  const updateSession = useCallback((sessionId, updater) => {
+    setChatState(prev =>
+      normalizeChatState({
+        ...prev,
+        sessions: prev.sessions.map(session => (session.id === sessionId ? updater(session) : session)),
+      })
+    );
+  }, []);
+
+  return {
+    chatState,
+    setChatState,
+    sessions,
+    activeSession,
+    messages: activeSession.messages,
+    chatModel: activeSession.model,
+    updateSession,
+  };
+}

--- a/client/src/hooks/usePersistentState.js
+++ b/client/src/hooks/usePersistentState.js
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'react';
+
+const parseString = value => value;
+const serializeString = value => String(value);
+
+const resolveInitialValue = initialValue =>
+  typeof initialValue === 'function' ? initialValue() : initialValue;
+
+export const jsonStorage = {
+  parse: JSON.parse,
+  serialize: JSON.stringify,
+};
+
+export const booleanStorage = {
+  parse: value => value !== 'false',
+  serialize: String,
+};
+
+export function usePersistentState(
+  key,
+  initialValue,
+  {
+    parse = parseString,
+    serialize = serializeString,
+  } = {}
+) {
+  const [value, setValue] = useState(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored == null) {
+        return resolveInitialValue(initialValue);
+      }
+      return parse(stored);
+    } catch {
+      return resolveInitialValue(initialValue);
+    }
+  });
+
+  const setPersistentValue = useCallback(updater => {
+    setValue(previousValue => {
+      const nextValue = typeof updater === 'function' ? updater(previousValue) : updater;
+      try {
+        localStorage.setItem(key, serialize(nextValue));
+      } catch {
+        // Storage can be unavailable in private mode; keep in-memory state usable.
+      }
+      return nextValue;
+    });
+  }, [key, serialize]);
+
+  return [value, setPersistentValue];
+}

--- a/client/src/hooks/useResponsiveLayout.js
+++ b/client/src/hooks/useResponsiveLayout.js
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+export function useResponsiveLayout({ dockedBreakpoint, tabletBreakpoint, panelSizeKey }) {
+  const [showSessions, setShowSessions] = useState(() => window.innerWidth >= dockedBreakpoint);
+
+  useEffect(() => {
+    const restorePanelWidth = () => {
+      const panel = document.querySelector('.layout-body > .agent-panel-wrap');
+      if (!panel) {
+        return;
+      }
+
+      if (window.innerWidth >= dockedBreakpoint) {
+        const saved = localStorage.getItem(panelSizeKey);
+        panel.style.flex = saved ? `0 0 ${saved}px` : '';
+        return;
+      }
+
+      panel.style.flex = '';
+    };
+
+    const syncResponsiveState = () => {
+      restorePanelWidth();
+      if (window.innerWidth < tabletBreakpoint) {
+        setShowSessions(false);
+      }
+    };
+
+    restorePanelWidth();
+    window.addEventListener('resize', syncResponsiveState);
+    return () => window.removeEventListener('resize', syncResponsiveState);
+  }, [dockedBreakpoint, panelSizeKey, tabletBreakpoint]);
+
+  return { showSessions, setShowSessions };
+}

--- a/helpers/retry.ts
+++ b/helpers/retry.ts
@@ -1,8 +1,8 @@
 import { log } from './logger.ts';
 
-const MAX_RETRIES = 3;
+const MAX_RETRIES = 4;
 const BASE_DELAY_MS = 1000;
-const RATE_LIMIT_BASE_MS = 5000;
+const RATE_LIMIT_BASE_MS = 30000;
 
 function isRetryableError(err) {
   const msg = err?.message || '';

--- a/helpers/retry.ts
+++ b/helpers/retry.ts
@@ -4,6 +4,60 @@ const MAX_RETRIES = 4;
 const BASE_DELAY_MS = 1000;
 const RATE_LIMIT_BASE_MS = 30000;
 
+function pickHeader(headers, name) {
+  if (!headers) return undefined;
+  return headers.get ? headers.get(name) : headers[name] || headers[name.toLowerCase()];
+}
+
+function extractHeaders(err) {
+  const headers = err?.headers || err?.error?.headers;
+  const result = {};
+  for (const name of ['retry-after', 'x-ratelimit-reset', 'x-ratelimit-remaining', 'x-request-id']) {
+    const value = pickHeader(headers, name);
+    if (value != null) result[name] = value;
+  }
+  return Object.keys(result).length ? result : undefined;
+}
+
+export function extractErrorDiagnostics(err) {
+  const cause = err?.cause;
+  const diagnostics = {
+    name: err?.name,
+    message: err?.message,
+    status: err?.status,
+    statusCode: err?.statusCode,
+    code: err?.code,
+    type: err?.type,
+    request_id: err?.request_id || err?.requestID,
+    headers: extractHeaders(err),
+    cause: cause ? {
+      name: cause.name,
+      message: cause.message,
+      code: cause.code,
+      errno: cause.errno,
+      syscall: cause.syscall,
+      hostname: cause.hostname,
+      host: cause.host,
+      port: cause.port,
+    } : undefined,
+  };
+  return Object.fromEntries(Object.entries(diagnostics).filter(([, value]) => value !== undefined));
+}
+
+export function formatErrorDiagnostics(err) {
+  const d = extractErrorDiagnostics(err);
+  const parts = [];
+  for (const key of ['name', 'status', 'statusCode', 'code', 'type', 'request_id']) {
+    if (d[key] != null) parts.push(`${key}=${d[key]}`);
+  }
+  if (d.cause) {
+    for (const key of ['name', 'code', 'errno', 'syscall', 'hostname', 'host', 'port']) {
+      if (d.cause[key] != null) parts.push(`cause.${key}=${d.cause[key]}`);
+    }
+  }
+  return parts.length ? `${d.message || 'Error'} (${parts.join(' ')})` : (d.message || String(err));
+}
+
 function isRetryableError(err) {
   const msg = err?.message || '';
   const status = err?.status || err?.statusCode || 0;
@@ -33,12 +87,16 @@ function extractRetryDelayMs(err) {
   return null;
 }
 
-export async function retryAsync(fn, maxRetries = MAX_RETRIES) {
+export async function retryAsync(fn, maxRetries = MAX_RETRIES, context = {}) {
+  const contextText = Object.keys(context).length ? ` context=${JSON.stringify(context)}` : '';
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
     try {
       return await fn();
     } catch (err) {
-      if (attempt === maxRetries || !isRetryableError(err)) throw err;
+      if (attempt === maxRetries || !isRetryableError(err)) {
+        log.warn(`[Retry] final failure${contextText} error=${formatErrorDiagnostics(err)}`);
+        throw err;
+      }
       const retryAfterMs = extractRetryDelayMs(err);
       const is429 = isRateLimitError(err);
       const base = retryAfterMs != null
@@ -46,7 +104,7 @@ export async function retryAsync(fn, maxRetries = MAX_RETRIES) {
         : is429 ? RATE_LIMIT_BASE_MS : BASE_DELAY_MS;
       const cap = is429 ? 60000 : 15000;
       const delay = Math.min(base * 2 ** attempt + Math.random() * 500, cap);
-      log.warn(`[Retry] attempt=${attempt + 1}/${maxRetries} delay=${Math.round(delay)}ms${retryAfterMs != null ? ' (retry-after)' : is429 ? ' (429-backoff)' : ''} error=${err.message}`);
+      log.warn(`[Retry] attempt=${attempt + 1}/${maxRetries} delay=${Math.round(delay)}ms${retryAfterMs != null ? ' (retry-after)' : is429 ? ' (429-backoff)' : ''}${contextText} error=${formatErrorDiagnostics(err)}`);
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }

--- a/helpers/run-agent.ts
+++ b/helpers/run-agent.ts
@@ -9,12 +9,20 @@
 
 import { loadMemory, buildMemoryPrompt } from '../agent/core/memory.ts';
 import { removeCheckpoint, removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
+import { appendTraceEvent } from './trace-store.ts';
 import { log } from './logger.ts';
 
-export function createBaseEventSender(runId: string, agentRunStore: any) {
+export function createBaseEventSender(runId: string, agentRunStore: any, memoryDir?: string) {
   return (payload: any) => {
     agentRunStore.addEvent(runId, payload);
+    const traceWrite = appendTraceEvent(memoryDir, runId, payload).catch((err: any) => {
+      log.warn(`[TraceStore] append failed runId=${runId}: ${err.message}`);
+    });
     const run = agentRunStore.getRun(runId);
+    if (run) {
+      run.traceWrites = run.traceWrites || [];
+      run.traceWrites.push(traceWrite);
+    }
     if (run?._reconnectWriters) {
       for (const writer of run._reconnectWriters) {
         writer(payload);

--- a/helpers/trace-store.ts
+++ b/helpers/trace-store.ts
@@ -1,0 +1,68 @@
+import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { log } from './logger.ts';
+
+function tracesDir(memoryDir: string) {
+  return join(memoryDir, 'traces');
+}
+
+function tracePath(memoryDir: string, runId: string) {
+  return join(tracesDir(memoryDir), `${runId}.jsonl`);
+}
+
+function validRunId(runId: string) {
+  return /^run_[a-z0-9]+_[a-z0-9]+$/i.test(runId);
+}
+
+export async function appendTraceEvent(memoryDir: string | undefined, runId: string, event: any) {
+  if (!memoryDir || !validRunId(runId)) return;
+
+  const dir = tracesDir(memoryDir);
+  await mkdir(dir, { recursive: true });
+  const line = `${JSON.stringify({ ...event, runId: event?.runId || runId })}\n`;
+  await writeFile(tracePath(memoryDir, runId), line, { encoding: 'utf8', flag: 'a' });
+}
+
+export async function readTraceEvents(memoryDir: string | undefined, runId: string) {
+  if (!memoryDir || !validRunId(runId)) return [];
+
+  try {
+    const raw = await readFile(tracePath(memoryDir, runId), 'utf8');
+    const events = [];
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        events.push(JSON.parse(line));
+      } catch (err: any) {
+        log.warn(`[TraceStore] skip malformed trace line runId=${runId}: ${err.message}`);
+      }
+    }
+    return events;
+  } catch {
+    return [];
+  }
+}
+
+export async function listTraceRuns(memoryDir: string | undefined) {
+  if (!memoryDir) return [];
+
+  try {
+    const files = await readdir(tracesDir(memoryDir));
+    return files
+      .filter(file => file.endsWith('.jsonl'))
+      .map(file => file.slice(0, -'.jsonl'.length))
+      .filter(validRunId);
+  } catch {
+    return [];
+  }
+}
+
+export async function deleteTrace(memoryDir: string | undefined, runId: string) {
+  if (!memoryDir || !validRunId(runId)) return;
+
+  try {
+    await unlink(tracePath(memoryDir, runId));
+  } catch {
+    // ignore missing trace files
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:client": "cd client && npm run build",
     "build": "npm run typecheck && npm run build:client",
     "lint": "eslint .",
-    "stop": "kill -9 $(lsof -ti :3001) $(lsof -ti :5173) 2>/dev/null; echo 'stopped'",
+    "stop": "node scripts/stop.js",
     "test": "vitest run"
   },
   "dependencies": {

--- a/routes/agent-approval.ts
+++ b/routes/agent-approval.ts
@@ -22,8 +22,9 @@ export function createAgentApprovalRouter({ approvalStore }: AgentRouterContext)
     try {
       approvalStore.resolve(approvalId, decision);
       return res.json({ ok: true });
-    } catch (err: any) {
-      return res.status(404).json({ error: err.message });
+    } catch {
+      // Approval may have been cleared by rejectAll() after run ended
+      return res.json({ ok: true, stale: true });
     }
   });
 
@@ -45,8 +46,8 @@ export function createAgentApprovalRouter({ approvalStore }: AgentRouterContext)
     try {
       approvalStore.resolve(approvalId, response.trim());
       return res.json({ ok: true });
-    } catch (err: any) {
-      return res.status(404).json({ error: err.message });
+    } catch {
+      return res.json({ ok: true, stale: true });
     }
   });
 

--- a/routes/agent-run-control.ts
+++ b/routes/agent-run-control.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import type { AgentRouterContext } from './agent-types.ts';
 import { removeCheckpoint, removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
+import { readTraceEvents } from '../helpers/trace-store.ts';
 import { log } from '../helpers/logger.ts';
 
-export function createAgentRunControlRouter({ agentRunStore, approvalStore, checkpointDir }: AgentRouterContext) {
+export function createAgentRunControlRouter({ agentRunStore, approvalStore, checkpointDir, memoryDir }: AgentRouterContext) {
   const router = Router();
 
   router.post('/api/agent/cancel', async (req, res) => {
@@ -45,11 +46,28 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
   });
 
   router.get('/api/agent/stream/:runId', (req, res) => {
+    (async () => {
     const { runId } = req.params;
     const run = agentRunStore.getRun(runId);
     if (!run) {
-      return res.status(404).json({ error: '运行不存在' });
+      const traceEvents = await readTraceEvents(memoryDir, runId);
+      if (traceEvents.length === 0) {
+        return res.status(404).json({ error: '运行不存在' });
+      }
+
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.flushHeaders();
+      res.socket?.setNoDelay(true);
+
+      for (const event of traceEvents) {
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
+      }
+      res.end();
+      return;
     }
+    await Promise.allSettled(run.traceWrites || []);
 
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
@@ -81,15 +99,23 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
       });
     }
 
-    const replayCount = run.events.length;
-    for (let i = 0; i < replayCount; i++) {
-      res.write(`data: ${JSON.stringify(run.events[i])}\n\n`);
+    const traceEvents = await readTraceEvents(memoryDir, runId);
+    const replayEvents = traceEvents.length > 0 ? traceEvents : run.events;
+    for (const event of replayEvents) {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
     }
 
     if (run.status !== 'running' || run.cancelAc.signal.aborted) {
       res.end();
     }
     return;
+    })().catch((err: any) => {
+      if (!res.headersSent) {
+        res.status(500).json({ error: err.message });
+      } else if (!res.writableEnded) {
+        res.end();
+      }
+    });
   });
 
   return router;

--- a/routes/agent-run-session.ts
+++ b/routes/agent-run-session.ts
@@ -12,6 +12,7 @@ export function createAgentRunSession({
   runId,
   startedAt,
   agentRunStore,
+  memoryDir,
 }: {
   req: any;
   res: any;
@@ -21,6 +22,7 @@ export function createAgentRunSession({
   runId: string;
   startedAt: number;
   agentRunStore: any;
+  memoryDir?: string;
 }) {
   let completedStepCount = 0;
   let observedStepCount = 0;
@@ -48,7 +50,7 @@ export function createAgentRunSession({
   );
 
   const rawSendEvent = buildSseWriter(res);
-  const baseSendEvent = createBaseEventSender(runId, agentRunStore);
+  const baseSendEvent = createBaseEventSender(runId, agentRunStore, memoryDir);
   const sendEvent = (payload: any) => {
     if (payload.type === 'step') {
       observedStepCount = Math.max(observedStepCount, payload.step || 0);

--- a/routes/agent-run-start.ts
+++ b/routes/agent-run-start.ts
@@ -64,6 +64,7 @@ export function createAgentRunStartRouter({
       runId,
       startedAt,
       agentRunStore,
+      memoryDir,
     });
 
     let memory = null;

--- a/routes/agent-traces.ts
+++ b/routes/agent-traces.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { readTraceEvents } from '../helpers/trace-store.ts';
+import type { AgentRouterContext } from './agent-types.ts';
+
+export function createAgentTraceRouter({ memoryDir, agentRunStore }: AgentRouterContext) {
+  const router = Router();
+
+  router.get('/api/agent/traces/:runId', async (req, res) => {
+    const { runId } = req.params;
+    const run = agentRunStore.getRun(runId);
+    await Promise.allSettled(run?.traceWrites || []);
+    const events = await readTraceEvents(memoryDir, runId);
+    if (events.length === 0) {
+      return res.status(404).json({ error: 'trace 不存在' });
+    }
+    return res.json({ runId, events });
+  });
+
+  return router;
+}

--- a/routes/agent.ts
+++ b/routes/agent.ts
@@ -15,6 +15,7 @@ import { createAgentApprovalRouter } from './agent-approval.ts';
 import { createAgentFetchRulesRouter } from './agent-fetch-rules.ts';
 import { createAgentMemoryRouter } from './agent-memory.ts';
 import { createAgentCheckpointRouter } from './agent-checkpoints.ts';
+import { createAgentTraceRouter } from './agent-traces.ts';
 import type { AgentRouterContext } from './agent-types.ts';
 
 export function createAgentRouter(context: AgentRouterContext) {
@@ -25,6 +26,7 @@ export function createAgentRouter(context: AgentRouterContext) {
   router.use(createAgentFetchRulesRouter(context));
   router.use(createAgentMemoryRouter(context));
   router.use(createAgentCheckpointRouter(context));
+  router.use(createAgentTraceRouter(context));
 
   return router;
 }

--- a/scripts/stop.js
+++ b/scripts/stop.js
@@ -1,0 +1,13 @@
+import { execSync } from 'child_process';
+
+const isWin = process.platform === 'win32';
+
+const cmd = isWin
+  ? 'powershell -Command "Get-NetTCPConnection -LocalPort 3001,5173 -ErrorAction SilentlyContinue | ForEach-Object { Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue }; Write-Output stopped"'
+  : "kill -9 $(lsof -ti :3001) $(lsof -ti :5173) 2>/dev/null; echo stopped";
+
+try {
+  execSync(cmd, { stdio: 'inherit' });
+} catch {
+  // ports already free
+}

--- a/server.ts
+++ b/server.ts
@@ -95,7 +95,7 @@ async function resumeFromCheckpoint(cp) {
   const { runId, task, model, headless, history, step, maxSteps: _maxSteps, startedAt } = cp;
   log.info(`[Resume] 恢复运行 run_id=${runId} step=${step} task=${task.slice(0, 60)}…`);
 
-  const sendEvent = createBaseEventSender(runId, agentRunStore);
+  const sendEvent = createBaseEventSender(runId, agentRunStore, MEMORY_DIR);
 
   const { systemPrompt } = await loadMemoryForPrompt(MEMORY_DIR);
 

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -101,3 +101,32 @@ describe('GET /api/agent/memory', () => {
     expect(res.body.projectKnowledge).toBeDefined();
   });
 });
+
+describe('GET /api/agent/traces/:runId', () => {
+  it('returns persisted trace events for an agent run', async () => {
+    const res = await request(app)
+      .post('/api/agent')
+      .send({ task: 'trace test', model: 'test-model', memory: false })
+      .buffer(true)
+      .parse((response, callback) => {
+        let body = '';
+        response.setEncoding('utf8');
+        response.on('data', chunk => {
+          body += chunk;
+        });
+        response.on('end', () => callback(null, body));
+      });
+
+    expect(res.status).toBe(200);
+    const responseText = typeof res.text === 'string' ? res.text : String(res.body || '');
+    const runIdMatch = responseText.match(/"runId":"([^"]+)"/);
+    expect(runIdMatch).toBeTruthy();
+    const runId = runIdMatch![1];
+
+    const traceRes = await request(app).get(`/api/agent/traces/${runId}`);
+    expect(traceRes.status).toBe(200);
+    expect(traceRes.body.runId).toBe(runId);
+    expect(traceRes.body.events.some((event: any) => event.type === 'status')).toBe(true);
+    expect(traceRes.body.events.some((event: any) => event.type === 'done')).toBe(true);
+  });
+});

--- a/test/trace-store.test.ts
+++ b/test/trace-store.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { appendTraceEvent, listTraceRuns, readTraceEvents } from '../helpers/trace-store.ts';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-trace-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('trace store', () => {
+  it('appends and reads jsonl trace events', async () => {
+    const runId = 'run_labc123_abcdef';
+    await appendTraceEvent(tmpDir, runId, { type: 'status', message: 'starting' });
+    await appendTraceEvent(tmpDir, runId, { type: 'done', answer: 'ok' });
+
+    const events = await readTraceEvents(tmpDir, runId);
+    expect(events).toEqual([
+      { type: 'status', message: 'starting', runId },
+      { type: 'done', answer: 'ok', runId },
+    ]);
+    expect(await listTraceRuns(tmpDir)).toEqual([runId]);
+  });
+
+  it('ignores invalid run ids', async () => {
+    await appendTraceEvent(tmpDir, '../bad', { type: 'status' });
+    expect(await readTraceEvents(tmpDir, '../bad')).toEqual([]);
+    expect(await listTraceRuns(tmpDir)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Windows agent approval dialogs**: Add native `MessageBox`/`InputBox`/`NotifyIcon` support via PowerShell, fixing invalid `DefaultButton2` param that caused auto-rejection before user could see the dialog
- **Chrome MCP reliability**: Fix Windows spawn failure (ENOENT on shell scripts), detect `isError` responses to trigger `autoConnect` fallback, recover from "browser already running" orphaned Chrome conflicts
- **Frontend refactor**: Extract `App.jsx` into separate components (`AgentPane`, `ChatPane`, `SessionSidebar`) and hooks (`useAgentRun`, `useChatSessions`, `usePersistentState`, `useResponsiveLayout`, `api/streams`)
- **Trace persistence**: Add `trace-store.ts` + `agent-traces.ts` route to persist agent run events to disk (`data/traces/{runId}.jsonl`), replacing in-memory-only event storage
- **Agent fixes**: Cancel now works in vote/race mode; remove duplicate answer from trace; fix rollback dedup dropping new events; increase history truncation limits 5x; 429 retry delay 30s→240s with 4 retries; include assistant messages in `conversationHistory`

## Test plan

- [ ] Run agent on Windows — verify approval/question dialogs appear and responses are respected
- [ ] Kill Chrome while MCP is connected — verify orphan recovery kills stale Chrome and reconnects
- [ ] Click cancel during vote/race mode — verify immediate cancellation
- [ ] Rollback to a step, verify re-executed step events are not deduplicated away
- [ ] Refresh page during agent run — verify trace reloads from disk via `GET /api/agent/traces/:runId`
- [ ] Run `npx vitest test/trace-store.test.ts` and `npx vitest test/agent-api.test.ts`