### PR TITLE
fix: SSE cleanup, browser timeout, trace dedup, markdown ol rendering

### DIFF
--- a/agent/tools/browser/execute.ts
+++ b/agent/tools/browser/execute.ts
@@ -15,16 +15,20 @@ function withTimeout(promise, ms, message) {
   const timeout = new Promise((_, reject) => {
     timer = setTimeout(() => reject(new Error(message)), ms);
   });
-  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+  return Promise.race([promise, timeout]).finally(() => {
+    clearTimeout(timer);
+    // Give the underlying operation time to settle so WebView clears its pending state
+    return promise.catch(() => {});
+  });
 }
 
 export async function safeNavigate(view, url) {
-  for (let i = 0; i < NAV_MAX_RETRIES; i++) {
+  for (let i = 0; i < NAV_MAX_RETRIES + 5; i++) {
     try {
       return await view.navigate(url);
     } catch (err) {
-      if (/already pending/i.test(err.message) && i < NAV_MAX_RETRIES - 1) {
-        await delay(NAV_RETRY_MS);
+      if (/already pending/i.test(err.message)) {
+        await delay(1000);
         continue;
       }
       throw err;

--- a/agent/tools/browser/execute.ts
+++ b/agent/tools/browser/execute.ts
@@ -4,9 +4,18 @@ import { isChromeMcpEnabled } from '../chrome/mcp-client.ts';
 const ACTION_SETTLE_MS = 600;
 const NAV_RETRY_MS = 500;
 const NAV_MAX_RETRIES = 3;
+const FETCH_TIMEOUT_MS = 15000;
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function withTimeout(promise, ms, message) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 export async function safeNavigate(view, url) {
@@ -114,7 +123,7 @@ export async function executeBrowserAction(view, action) {
 async function _executeBrowserAction(view, action) {
   if (action.type === 'navigate') {
     try {
-      await safeNavigate(view, action.url);
+      await withTimeout(safeNavigate(view, action.url), FETCH_TIMEOUT_MS, `导航超时: ${action.url}`);
       await delay(ACTION_SETTLE_MS);
       try {
         const { title, url, body } = await detectBlockedPage(view);
@@ -205,7 +214,7 @@ async function _executeBrowserAction(view, action) {
     if (!action.url) throw new Error('http_fetch 缺少 url');
     const url = /^https?:\/\//i.test(action.url) ? action.url : `https://${action.url}`;
     try {
-      await safeNavigate(view, url);
+      await withTimeout(safeNavigate(view, url), FETCH_TIMEOUT_MS, `访问超时: ${url}`);
       await delay(1000);
     } catch (err) {
       return `http_fetch ${url}: 浏览器访问失败 (${(err.message || '').slice(0, 100)})。`;
@@ -252,7 +261,7 @@ async function _executeBrowserAction(view, action) {
     for (const u of urls.slice(0, 5)) {
       const url = /^https?:\/\//i.test(u) ? u : `https://${u}`;
       try {
-        await safeNavigate(view, url);
+        await withTimeout(safeNavigate(view, url), FETCH_TIMEOUT_MS, `访问超时: ${url}`);
         await delay(1000);
         const text = await safeEvaluate(view, "document.body?.innerText || ''");
         const cleaned = text.replace(/\s+/g, ' ').trim();

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1130,6 +1130,8 @@ textarea {
 .md-body p { margin: 0 0 8px; }
 .md-body p:last-child { margin-bottom: 0; }
 .md-body ul, .md-body ol { padding-left: 20px; margin: 6px 0; }
+.md-body ul { list-style: disc; }
+.md-body ol { list-style: decimal; }
 .md-body li { margin: 3px 0; }
 .md-body h1, .md-body h2, .md-body h3 { font-weight: 500; margin: 12px 0 6px; }
 .md-body h1 { font-size: 17px; }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -407,9 +407,10 @@ function renderMarkdown(text) {
     // unordered list
     if (/^[-*]\s/.test(line)) {
       const items = [];
-      while (i < lines.length && /^[-*]\s/.test(lines[i])) {
-        items.push(lines[i].replace(/^[-*]\s+/, ''));
-        i++;
+      while (i < lines.length) {
+        if (/^[-*]\s/.test(lines[i])) { items.push(lines[i].replace(/^[-*]\s+/, '')); i++; }
+        else if (!lines[i].trim()) { i++; }
+        else break;
       }
       blocks.push({ type: 'ul', items });
       continue;
@@ -418,9 +419,10 @@ function renderMarkdown(text) {
     // ordered list
     if (/^\d+\.\s/.test(line)) {
       const items = [];
-      while (i < lines.length && /^\d+\.\s/.test(lines[i])) {
-        items.push(lines[i].replace(/^\d+\.\s+/, ''));
-        i++;
+      while (i < lines.length) {
+        if (/^\d+\.\s/.test(lines[i])) { items.push(lines[i].replace(/^\d+\.\s+/, '')); i++; }
+        else if (!lines[i].trim()) { i++; }
+        else break;
       }
       blocks.push({ type: 'ol', items });
       continue;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1248,7 +1248,7 @@ function AgentPanel({ mode, running, trace, startedAt, modelList, collapsed, onT
             // (other stages like thinking/success/failed are collected inside ModelPlanGroup)
             if (event.type === 'model_plan' && event.stage !== 'start' && event.stage !== 'consensus') return null;
             if (event.type === 'model_plan' && event.stage === 'start') {
-              return <ModelPlanGroup key={`model-plan-step-${event.step || index}`} trace={trace} step={event.step} models={event.models} modelList={modelList} running={running} cardsExpanded={cardsExpanded} onManualToggle={() => setCardsExpanded(null)} onRollback={onRollback} rollbackLoading={rollbackLoading} />;
+              return <ModelPlanGroup key={`model-plan-step-${event.step || index}-${index}`} trace={trace} step={event.step} models={event.models} modelList={modelList} running={running} cardsExpanded={cardsExpanded} onManualToggle={() => setCardsExpanded(null)} onRollback={onRollback} rollbackLoading={rollbackLoading} />;
             }
             // For multi-model steps, skip separate action/result items (shown inside model cards)
             if (event.type === 'step' && (event.stage === 'action' || event.stage === 'result') && multiModelSteps.has(event.step)) {
@@ -1813,10 +1813,14 @@ export default function App() {
       fetchAgentTrace(savedRunId, { signal: controller.signal })
         .then(events => {
           if (events.length === 0 || controller.signal.aborted) return;
-          setAgentTrace(events);
+          const deduped = events.filter((e, i) => {
+            const key = `${e.type}:${e.step ?? ''}:${e.stage ?? ''}:${e.model ?? ''}`;
+            return !events.slice(0, i).some(p => `${p.type}:${p.step ?? ''}:${p.stage ?? ''}:${p.model ?? ''}` === key);
+          });
+          setAgentTrace(deduped);
           updateSession(activeSession.id, session => touchSession(session, {
             agentRunId: savedRunId,
-            agentTrace: events,
+            agentTrace: deduped,
           }));
         })
         .catch(() => {});

--- a/routes/agent-run-session.ts
+++ b/routes/agent-run-session.ts
@@ -28,12 +28,7 @@ export function createAgentRunSession({
   let observedStepCount = 0;
   const modelsUsed = new Set();
   const stepModels: Record<number, string> = {};
-
-  req.on('close', () => {
-    if (!res.writableEnded) {
-      log.debug(`[${formatLogTime()}] POST /api/agent client_disconnected model=${model} run_id=${runId}`);
-    }
-  });
+  let sseClosed = false;
 
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
@@ -41,8 +36,17 @@ export function createAgentRunSession({
   res.flushHeaders();
   res.socket?.setNoDelay(true);
   const heartbeat = setInterval(() => {
-    if (!res.writableEnded) res.write(': heartbeat\n\n');
+    if (!sseClosed && !res.writableEnded) {
+      try { res.write(': heartbeat\n\n'); } catch { sseClosed = true; clearInterval(heartbeat); }
+    }
   }, 15000);
+
+  req.on('close', () => {
+    if (sseClosed) return;
+    sseClosed = true;
+    clearInterval(heartbeat);
+    log.debug(`[${formatLogTime()}] POST /api/agent client_disconnected model=${model} run_id=${runId}`);
+  });
 
   log.info(
     `[${formatLogTime()}] POST /api/agent model=${model} headless=${agentHeadless} task=${safeJson(normalizedTask)} ` +
@@ -66,10 +70,9 @@ export function createAgentRunSession({
     }
     logAgentEvent(payload);
     baseSendEvent(payload);
-    if (payload.type === 'model_plan' || payload.type === 'session_checkpoint') {
-      log.debug(`[SSE] write type=${payload.type} step=${payload.step} stage=${payload.stage ?? '-'} model=${payload.model ?? '-'} writableEnded=${res.writableEnded} writableFinished=${res.writableFinished}`);
+    if (!sseClosed && !res.writableEnded) {
+      try { rawSendEvent(payload); } catch { sseClosed = true; }
     }
-    rawSendEvent(payload);
   };
 
   sendEvent({
@@ -118,7 +121,10 @@ export function createAgentRunSession({
     log.info(`\n${box}`);
     clearInterval(heartbeat);
     approvalStore.rejectAll();
-    res.end();
+    if (!sseClosed && !res.writableEnded) {
+      try { res.end(); } catch {}
+    }
+    sseClosed = true;
   }
 
   return { sendEvent, getTrackingState, close };

--- a/server.ts
+++ b/server.ts
@@ -95,11 +95,13 @@ async function resumeFromCheckpoint(cp) {
   const { runId, task, model, headless, history, step, maxSteps: _maxSteps, startedAt } = cp;
   log.info(`[Resume] 恢复运行 run_id=${runId} step=${step} task=${task.slice(0, 60)}…`);
 
-  const sendEvent = createBaseEventSender(runId, agentRunStore, MEMORY_DIR);
+  // 回放历史事件不需要写 trace 文件（已经存在），只写内存 run-store 供 SSE 重连用
+  const sendEvent = createBaseEventSender(runId, agentRunStore);
+  const sendEventWithTrace = createBaseEventSender(runId, agentRunStore, MEMORY_DIR);
 
   const { systemPrompt } = await loadMemoryForPrompt(MEMORY_DIR);
 
-  // Replay historical steps so frontend sees all previous steps
+  // Replay historical steps so frontend sees all previous steps (memory-only, no trace write)
   sendEvent({ type: 'status', status: 'starting', runId, message: '准备启动桌面 Agent' });
   for (const h of history) {
     sendEvent({ type: 'step', step: h.step, stage: 'action', rationale: h.rationale, action: h.action });
@@ -122,10 +124,10 @@ async function resumeFromCheckpoint(cp) {
       initialHistory: history,
       conversationHistory: cp.conversationHistory || [],
       memory: cp.memory !== false,
-      onEvent: sendEvent,
+      onEvent: sendEventWithTrace,
       cancelSignal: new AbortController().signal,
     });
-    sendEvent({ type: 'done', runId, answer: result.answer, steps: result.steps, meta: { elapsed_ms: Date.now() - startedAt, step_count: result.steps.length } });
+    sendEventWithTrace({ type: 'done', runId, answer: result.answer, steps: result.steps, meta: { elapsed_ms: Date.now() - startedAt, step_count: result.steps.length } });
     if (cp.memory !== false) {
       try {
         const mem = await loadMemory(MEMORY_DIR);
@@ -136,7 +138,7 @@ async function resumeFromCheckpoint(cp) {
     }
   } catch (err: any) {
     log.error(`[Resume] 失败 run_id=${runId}:`, err.message);
-    sendEvent({ type: 'error', runId, error: err.message });
+    sendEventWithTrace({ type: 'error', runId, error: err.message });
   } finally {
     await cleanupAgentRun(CHECKPOINT_DIR, runId, agentRunStore);
   }


### PR DESCRIPTION
## Summary

一系列稳定性修复，解决 SSE 断连资源泄漏、浏览器导航卡死、trace 文件重复、前端 markdown 有序列表渲染等问题。

### SSE 断连清理（`agent-run-session.ts`）
- 添加 `sseClosed` 标记，客户端断连或写入失败后不再往已关闭的 response 写数据
- `req.on('close')` 中清理 heartbeat 定时器并标记状态，避免定时器空转
- `close()` 安全收尾，检查状态后再 `res.end()`，防止重复关闭

### 浏览器导航超时（`browser/execute.ts`）
- `navigate`、`http_fetch`、`parallel_fetch` 的 `safeNavigate` 包 15s 超时，不再无限卡死
- 超时后等待底层 promise settle，让 WebView 清理 pending 状态
- `safeNavigate` 对 "already pending" 错误增加重试次数（8次×1s），防止超时后级联失败

### Trace 持久化去重（`server.ts` + `App.jsx`）
- `resumeFromCheckpoint` 回放历史事件时不再写入 trace 文件（只写内存 run-store），避免断点恢复后 trace 重复
- 前端 `fetchAgentTrace` 返回结果做 dedup 后再设给 React state
- `ModelPlanGroup` React key 加 index 后缀防 duplicate key 警告

### Markdown 有序列表渲染（`App.jsx` + `App.css`）
- 解析器跳过列表项之间的空行，避免每项变成独立的单条 `<ol>`（显示全为 1）
- CSS 显式设置 `list-style: decimal` / `list-style: disc` 确保编号正确

## Test plan

- [ ] 启动 agent 任务后关闭浏览器标签页，确认后端无 `Cannot write after end` 异常
- [ ] 访问一个挂起的 URL，确认 15s 后超时返回错误而非永久卡死
- [ ] 超时后 agent 继续下一步，确认不会连续报 "navigation already pending"
- [ ] 断点恢复后查看 trace 文件，确认历史步骤不重复
- [ ] 让 LLM 输出带空行的有序列表（`1. ...\n\n2. ...\n\n3. ...`），确认渲染为 1-6 而非全 1