### PR TITLE
fix(terminal): expand run_safe allowlist + strip safe env var prefixes

### DIFF
--- a/agent/tools/terminal/run.ts
+++ b/agent/tools/terminal/run.ts
@@ -1,57 +1,6 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
-
-const SAFE_COMMANDS = new Set([
-  // 文件查看 / 搜索（只读）
-  'pwd',
-  'ls',
-  'cat',
-  'head',
-  'tail',
-  'wc',
-  'stat',
-  'date',
-  'echo',
-  'rg',
-  'find',
-  'which',
-  'git',
-  'grep',
-  'diff',
-  'sort',
-  'uniq',
-  'awk',
-  'sed',
-  'cut',
-  'tr',
-  'xargs',
-  'tee',
-  'tree',
-  'du',
-  'df',
-  'jq',
-  // 文件操作（低破坏性）
-  'mkdir',
-  'touch',
-  'cp',
-  'mv',
-  'ln',
-  'tar',
-  'gzip',
-  'gunzip',
-  'zip',
-  'unzip',
-  // 系统信息（只读）
-  'env',
-  'printenv',
-  'id',
-  'whoami',
-  'hostname',
-  'uname',
-  'ps',
-  'pgrep',
-  'pidof',
-]);
+import { SAFE_COMMANDS, SAFE_ENV_PREFIXES } from './safe-policy';
 
 function resolveCwd(value) {
   if (typeof value !== 'string' || !value.trim()) {
@@ -61,8 +10,15 @@ function resolveCwd(value) {
 }
 
 function getFirstToken(command) {
-  const match = command.trim().match(/^([^\s]+)/);
-  return match ? match[1] : '';
+  const tokens = command.trim().split(/\s+/);
+  for (const token of tokens) {
+    const m = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+    if (m && SAFE_ENV_PREFIXES.has(m[1])) {
+      continue;
+    }
+    return token;
+  }
+  return '';
 }
 
 function assertSafeCommand(command) {

--- a/agent/tools/terminal/safe-policy.ts
+++ b/agent/tools/terminal/safe-policy.ts
@@ -1,0 +1,74 @@
+// run_safe 终端命令策略：只读 / 低破坏命令的白名单，以及允许在命令前剥离的环境变量前缀。
+// 修改前请确认条目对应的命令在 macOS 上没有副作用、不会加载额外二进制或脚本。
+
+export const SAFE_COMMANDS = new Set([
+  // 文件查看 / 搜索（只读）
+  'pwd',
+  'ls',
+  'cat',
+  'head',
+  'tail',
+  'wc',
+  'stat',
+  'date',
+  'echo',
+  'rg',
+  'find',
+  'which',
+  'git',
+  'grep',
+  'diff',
+  'sort',
+  'uniq',
+  'awk',
+  'sed',
+  'cut',
+  'tr',
+  'xargs',
+  'tee',
+  'tree',
+  'du',
+  'df',
+  'jq',
+  // 文件操作（低破坏性）
+  'mkdir',
+  'touch',
+  'cp',
+  'mv',
+  'ln',
+  'tar',
+  'gzip',
+  'gunzip',
+  'zip',
+  'unzip',
+  // 系统信息（只读）
+  'env',
+  'printenv',
+  'id',
+  'whoami',
+  'hostname',
+  'uname',
+  'ps',
+  'pgrep',
+  'pidof',
+  // 网络 / 系统观测（只读）
+  'lsof',
+  'netstat',
+  'ss',
+  'memory_pressure',
+  'vm_stat',
+  'system_profiler',
+  'plutil',
+]);
+
+// 允许在命令前出现并被剥离的环境变量前缀。
+// 这些变量都不会影响 shell 二进制查找或加载（不像 PATH / DYLD_* / LD_* / IFS / BASH_ENV / ENV / ZDOTDIR）。
+export const SAFE_ENV_PREFIXES = new Set([
+  'GIT_CONFIG_GLOBAL',   // 指定 .gitconfig 路径，常见 =/dev/null
+  'GIT_CONFIG_NOSYSTEM', // =1 时让 git 忽略 /etc/gitconfig
+  'HOME',                // 用户主目录，影响 ~ 展开
+  'LANG',                // 默认 locale
+  'LC_ALL',              // 强制覆盖所有 locale 类别
+  'LC_CTYPE',            // 字符分类 locale
+  'TZ',                  // 时区
+]);


### PR DESCRIPTION
## Summary

- 把 `SAFE_COMMANDS` 和环境变量策略抽到 `agent/tools/terminal/safe-policy.ts`，`run.ts` 只保留执行 + 检查
- `SAFE_COMMANDS` 新增 7 个只读观测命令：`lsof / netstat / ss / memory_pressure / vm_stat / system_profiler / plutil`
- `getFirstToken` 剥离 `KEY=VAL` 环境变量前缀，仅放行 `SAFE_ENV_PREFIXES` 白名单（`GIT_CONFIG_GLOBAL / GIT_CONFIG_NOSYSTEM / HOME / LANG / LC_ALL / LC_CTYPE / TZ`）

## Why

近一个月 LLM 调 `run_safe` 时被拒首词统计（Top 项）：

| 首词 | 次数 | 处理 |
|---|---|---|
| `lsof` | 132 | 加入白名单（`lsof -i :3000` 是合法只读用法） |
| `netstat` | 54 | 加入白名单 |
| `plutil` | 45 | 加入白名单 |
| `memory_pressure` | 39 | 加入白名单 |
| `GIT_CONFIG_GLOBAL=...` | 36 | 修前缀解析（之前因 `getFirstToken` 把前缀当命令名而被拒） |
| `vm_stat` | 33 | 加入白名单 |
| `ss` | 27 | 加入白名单 |
| `HOME=/tmp` | 12 | 修前缀解析 |
| `system_profiler` | 12 | 加入白名单 |

合计消除约 390 次/月的误拒，且**不放松危险类**：`cd / curl / nc / python3 / node / osascript / launchctl` 等仍按原策略拒绝。

## Why 这套环境变量白名单是安全的

`SAFE_ENV_PREFIXES` 里的变量都**不会让 shell 在执行时加载或查找额外二进制/脚本**。

- `PATH` / `DYLD_INSERT_LIBRARIES` / `DYLD_LIBRARY_PATH` / `LD_*` / `IFS` / `BASH_ENV` / `ENV` / `ZDOTDIR` 不在剥离白名单 → 整段 `KEY=VAL` 原样返回 → `SAFE_COMMANDS.has` 必然失败 → 拒绝。
- 即使有人尝试 `PATH=/tmp/evil lsof`，由于 `PATH=` 不在白名单内，`getFirstToken` 返回的是 `PATH=/tmp/evil`，仍然走不过检查。

## What didn't change

- 危险操作符黑名单（`| ; ` 反引号 ` $( ${ & && || <( <<heredoc`）完全没动 — 那块逻辑相对复杂，留待单独评估
- `run_confirmed` / `run_review` 路径不变
- 没有放开 `sysctl / top / defaults / launchctl` 等需要按子命令限制的命令（同样留作后续）

## Test plan

- [x] `npm run typecheck` 通过
- [ ] 手动验证 `lsof -i :3000` 通过白名单
- [ ] 手动验证 `GIT_CONFIG_GLOBAL=/dev/null git status` 通过白名单
- [ ] 手动验证 `PATH=/tmp/evil lsof` 仍被拒
- [ ] 手动验证 `DYLD_INSERT_LIBRARIES=x ls` 仍被拒
- [ ] 手动验证 `HOME=/tmp node x.js` 仍被拒（HOME 剥离后 `node` 不在白名单）