### PR TITLE
fix(client): agent trace 仅在底部时自动滚动

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1098,6 +1098,7 @@ function MemoryPanel({ onClose }) {
 // - 在移动端和桌面端之间复用同一套事件展示逻辑
 function AgentPanel({ mode, running, trace, startedAt, modelList, collapsed, onToggleCollapse, onStop, agentStopping, pendingApproval, onRollback, rollbackLoading }) {
   const traceBottomRef = useRef(null);
+  const traceStickyRef = useRef(true);
   const startTimeRef = useRef(null);
   const isMobile = typeof window !== 'undefined' && window.innerWidth < PHONE_BREAKPOINT;
   const pauseRef = useRef(null);
@@ -1163,8 +1164,24 @@ function AgentPanel({ mode, running, trace, startedAt, modelList, collapsed, onT
   }, [hasPendingQuestion]);
 
   useEffect(() => {
+    if (!traceStickyRef.current) return;
     traceBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [trace]);
+
+  // 用户在 trace 容器内手动滚动时维护 sticky 标志：距离底部 80px 内视为"在底部"。
+  // 容器是条件渲染的，trace 从空变非空时才挂上 scroll 监听。
+  const traceHasContent = trace.length > 0;
+  useEffect(() => {
+    if (!traceHasContent) return;
+    const scroller = traceBottomRef.current?.parentElement;
+    if (!scroller) return;
+    const onScroll = () => {
+      const distance = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+      traceStickyRef.current = distance <= 80;
+    };
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    return () => scroller.removeEventListener('scroll', onScroll);
+  }, [traceHasContent]);
 
   if (mode !== 'agent') {
     return null;


### PR DESCRIPTION
## Summary

用户向上翻看历史 trace 时，新事件不再把视图强制拉回底部。

## Changes

`client/src/App.jsx` `AgentPanel`：

- 新增 `traceStickyRef` (useRef，默认 true) 跟踪"用户当前是否在底部"
- 原有自动滚动 effect 加 sticky 守卫：`if (!traceStickyRef.current) return;`
- 新增 scroll 事件监听 effect：用户滚动时计算 `scrollHeight - scrollTop - clientHeight`，≤ 80px 视为"在底部" → sticky = true；否则 false
- scroll 监听在 trace 容器条件渲染存在时挂载，trace 清空时清理（依赖 `traceHasContent`）

## Behavior

| 场景 | 行为 |
|---|---|
| 用户在底部 → 新事件到来 | 继续自动滚到底（保持原行为）|
| 用户向上滚阅读历史 → 新事件到来 | 视图保持原位，不打断阅读 |
| 用户滚回底部 → 新事件到来 | 自动跟随恢复 |

阈值 80px 留点容差，避免几像素抖动导致 sticky 状态反复翻转。

## Test plan

- [x] `npm run typecheck` 通过
- [x] `eslint client/src/App.jsx` 无 warning
- [ ] 手动：运行长 trace 任务，向上滚到中间，等若干新事件，确认视图不被强制拖回底部
- [ ] 手动：滚到底，确认新事件仍自动跟随
- [ ] 手动：从中间滚回底部后，新事件恢复自动跟随