### PR TITLE
feat(policy): run_safe 不在白名单时自动升级到 run_confirmed

### DIFF
--- a/agent/policy/classify.ts
+++ b/agent/policy/classify.ts
@@ -1,3 +1,5 @@
+import { canRunSafe } from '../tools/terminal/safe-policy.ts';
+
 function matchesDangerousCommand(command) {
   // Block truly dangerous commands: rm, reboot, sudo, etc.
   if (/\b(rm|rmdir|reboot|shutdown|launchctl|mkfs|diskutil|dd|sudo|chmod|chown)\b/i.test(command)) return true;
@@ -115,9 +117,24 @@ export function classifyAgentAction(action) {
   }
 
   if (tool === 'terminal' && type === 'run_safe') {
+    if (canRunSafe(action.command || '')) {
+      return {
+        level: 'safe',
+        reason: '只读终端命令',
+      };
+    }
+    // 命令本身在 run_safe 白名单之外（或含危险操作符），不直接报错让 LLM 多跑一轮，
+    // 改写为 run_confirmed 走审批流程 —— 危险命令检查仍在下方 run_confirmed 分支生效。
+    if (matchesDangerousCommand(action.command || '')) {
+      return {
+        level: 'blocked',
+        reason: `命令被策略阻止: ${action.command}`,
+      };
+    }
+    action.type = 'run_confirmed';
     return {
-      level: 'safe',
-      reason: '只读终端命令',
+      level: 'confirm',
+      reason: `即将执行终端命令: ${action.command}`,
     };
   }
 

--- a/agent/tools/terminal/run.ts
+++ b/agent/tools/terminal/run.ts
@@ -1,24 +1,12 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
-import { SAFE_COMMANDS, SAFE_ENV_PREFIXES } from './safe-policy';
+import { SAFE_COMMANDS, getFirstToken } from './safe-policy';
 
 function resolveCwd(value) {
   if (typeof value !== 'string' || !value.trim()) {
     return process.cwd();
   }
   return path.isAbsolute(value) ? value : path.resolve(process.cwd(), value);
-}
-
-function getFirstToken(command) {
-  const tokens = command.trim().split(/\s+/);
-  for (const token of tokens) {
-    const m = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
-    if (m && SAFE_ENV_PREFIXES.has(m[1])) {
-      continue;
-    }
-    return token;
-  }
-  return '';
 }
 
 function assertSafeCommand(command) {

--- a/agent/tools/terminal/safe-policy.ts
+++ b/agent/tools/terminal/safe-policy.ts
@@ -72,3 +72,41 @@ export const SAFE_ENV_PREFIXES = new Set([
   'LC_CTYPE',            // 字符分类 locale
   'TZ',                  // 时区
 ]);
+
+// 取命令首词，跳过 SAFE_ENV_PREFIXES 列出的环境变量前缀（如 GIT_CONFIG_GLOBAL=...）。
+export function getFirstToken(command) {
+  const tokens = String(command || '').trim().split(/\s+/);
+  for (const token of tokens) {
+    const m = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+    if (m && SAFE_ENV_PREFIXES.has(m[1])) {
+      continue;
+    }
+    return token;
+  }
+  return '';
+}
+
+// 命令是否可以走 run_safe 路径（首词在白名单且没有危险 shell 操作符）。
+// classify 阶段用它判断是否需要把 run_safe 升级到 run_confirmed 走审批。
+export function canRunSafe(command) {
+  const cmd = String(command || '');
+  const firstToken = getFirstToken(cmd);
+  if (!SAFE_COMMANDS.has(firstToken)) {
+    return false;
+  }
+  // 与 run.ts 内的危险操作符黑名单保持一致
+  if (
+    /[|;]/.test(cmd) ||
+    /`/.test(cmd) ||
+    /\$\(/.test(cmd) ||
+    /\$\{/.test(cmd) ||
+    /[^&]&[^&]/.test(cmd) ||
+    /\s&(\s|$)/.test(cmd) ||
+    /&&|\|\|/.test(cmd) ||
+    /[<>]\(/.test(cmd) ||
+    /<<\s*\w/.test(cmd)
+  ) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary

LLM 输出 `type=run_safe` 但命令不在白名单（`node` / `osascript` / `python3` / 带 `|` 的命令等）时，过去会直接报错让 LLM 改写、多跑一轮。现在 classify 阶段直接把它升级成 `run_confirmed`，走正常审批流程。

## Why

近一周 trace 中典型模式（出现多次）：

```
step1: type=run_safe, command="node -e ..." → 失败: run_safe 不允许执行该命令: node
step2: type=run_confirmed, 同命令          → 弹审批 → 执行成功
```

每条这样的命令都浪费一次 LLM 调用 + 一个 step（外加用户多看一条失败提示）。

## What changed

`agent/policy/classify.ts` 的 `run_safe` 分支：

```ts
if (canRunSafe(command)) {           // 白名单内 & 无危险操作符 → 原行为
  return { level: 'safe', ... };
}
if (matchesDangerousCommand(command)) { // rm/sudo/dd/... → blocked
  return { level: 'blocked', ... };
}
action.type = 'run_confirmed';        // 其他 → 升级 + 走审批
return { level: 'confirm', reason: \`即将执行终端命令: ...\` };
```

`action` 引用贯穿 `decide → authorize → execute`，所以 mutation 一次，下游审批弹窗 / event / 实际执行都看到的是 `run_confirmed`。

为复用判断逻辑，把 run.ts 的 `getFirstToken` + 白名单 + 操作符黑名单合并成一个 `canRunSafe(command): boolean` 放到 `safe-policy.ts`。run.ts 改为 import 共用。

## Safety

- `canRunSafe` 的判定与原 `run.ts:assertSafeCommand` 完全等价
- 命中 `matchesDangerousCommand` 的命令仍然 `blocked`（rm / reboot / sudo / dd / mkfs / diskutil / chown / chmod / pipe-to-bash 等）
- 其他命令进入审批弹窗，由**用户**做最终判断 —— 安全边界不变，只是少了"LLM 试一下，被拒，再换 type"这一轮

## Test plan

- [x] \`npm run typecheck\` 通过
- [ ] 手动：让 agent 跑 \`node -e "console.log(process.version)"\` —— 期望直接弹审批，不再先失败一轮
- [ ] 手动：让 agent 跑 \`netstat -an | grep 3000\` —— 期望弹审批（带 \`|\` 走升级路径）
- [ ] 手动：让 agent 试图跑 \`rm -rf /tmp/x\` —— 期望直接 blocked，不弹审批
- [ ] 手动：让 agent 跑 \`ls\` —— 期望仍然 safe，不弹审批

## Branch base

Based on \`fix/run-safe-allowlist\` (PR #193) 因为依赖那个 PR 新建的 \`safe-policy.ts\`。#193 合并后这个 PR 会自动 rebase 到 main。