### PR TITLE
feat(policy): run_safe 不在白名单时自动升级到 run_confirmed

### DIFF
--- a/agent/policy/classify.ts
+++ b/agent/policy/classify.ts
@@ -1,3 +1,5 @@
+import { canRunSafe } from '../tools/terminal/safe-policy.ts';
+
 function matchesDangerousCommand(command) {
   // Block truly dangerous commands: rm, reboot, sudo, etc.
   if (/\b(rm|rmdir|reboot|shutdown|launchctl|mkfs|diskutil|dd|sudo|chmod|chown)\b/i.test(command)) return true;
@@ -115,9 +117,24 @@ export function classifyAgentAction(action) {
   }
 
   if (tool === 'terminal' && type === 'run_safe') {
+    if (canRunSafe(action.command || '')) {
+      return {
+        level: 'safe',
+        reason: '只读终端命令',
+      };
+    }
+    // 命令本身在 run_safe 白名单之外（或含危险操作符），不直接报错让 LLM 多跑一轮，
+    // 改写为 run_confirmed 走审批流程 —— 危险命令检查仍在下方 run_confirmed 分支生效。
+    if (matchesDangerousCommand(action.command || '')) {
+      return {
+        level: 'blocked',
+        reason: `命令被策略阻止: ${action.command}`,
+      };
+    }
+    action.type = 'run_confirmed';
     return {
-      level: 'safe',
-      reason: '只读终端命令',
+      level: 'confirm',
+      reason: `即将执行终端命令: ${action.command}`,
     };
   }
 

--- a/agent/tools/terminal/run.ts
+++ b/agent/tools/terminal/run.ts
@@ -1,24 +1,12 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
-import { SAFE_COMMANDS, SAFE_ENV_PREFIXES } from './safe-policy';
+import { SAFE_COMMANDS, getFirstToken } from './safe-policy';
 
 function resolveCwd(value) {
   if (typeof value !== 'string' || !value.trim()) {
     return process.cwd();
   }
   return path.isAbsolute(value) ? value : path.resolve(process.cwd(), value);
-}
-
-function getFirstToken(command) {
-  const tokens = command.trim().split(/\s+/);
-  for (const token of tokens) {
-    const m = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
-    if (m && SAFE_ENV_PREFIXES.has(m[1])) {
-      continue;
-    }
-    return token;
-  }
-  return '';
 }
 
 function assertSafeCommand(command) {

--- a/agent/tools/terminal/safe-policy.ts
+++ b/agent/tools/terminal/safe-policy.ts
@@ -72,3 +72,41 @@ export const SAFE_ENV_PREFIXES = new Set([
   'LC_CTYPE',            // 字符分类 locale
   'TZ',                  // 时区
 ]);
+
+// 取命令首词，跳过 SAFE_ENV_PREFIXES 列出的环境变量前缀（如 GIT_CONFIG_GLOBAL=...）。
+export function getFirstToken(command) {
+  const tokens = String(command || '').trim().split(/\s+/);
+  for (const token of tokens) {
+    const m = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
+    if (m && SAFE_ENV_PREFIXES.has(m[1])) {
+      continue;
+    }
+    return token;
+  }
+  return '';
+}
+
+// 命令是否可以走 run_safe 路径（首词在白名单且没有危险 shell 操作符）。
+// classify 阶段用它判断是否需要把 run_safe 升级到 run_confirmed 走审批。
+export function canRunSafe(command) {
+  const cmd = String(command || '');
+  const firstToken = getFirstToken(cmd);
+  if (!SAFE_COMMANDS.has(firstToken)) {
+    return false;
+  }
+  // 与 run.ts 内的危险操作符黑名单保持一致
+  if (
+    /[|;]/.test(cmd) ||
+    /`/.test(cmd) ||
+    /\$\(/.test(cmd) ||
+    /\$\{/.test(cmd) ||
+    /[^&]&[^&]/.test(cmd) ||
+    /\s&(\s|$)/.test(cmd) ||
+    /&&|\|\|/.test(cmd) ||
+    /[<>]\(/.test(cmd) ||
+    /<<\s*\w/.test(cmd)
+  ) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- LLM 输出 `type=run_safe` 但命令不在白名单（如 `node`、`osascript`、含 `|` 等操作符）时之前会直接报错，再让 LLM 改成 `run_confirmed`，多浪费一轮调用 + 一个 step
- classify 阶段新增判断：白名单且无危险操作符 → 维持 `safe`；命中危险黑名单 → `blocked`；其他 → 改写为 `run_confirmed` 走正常审批流
- `safe-policy.ts` 提取 `canRunSafe(command)` 与 `getFirstToken`，供 classify 与 run 复用

## Test plan
- [ ] LLM 给出 `run_safe` + 白名单命令（如 `ls`） → 直接执行
- [ ] LLM 给出 `run_safe` + 非白名单命令（如 `node -v`、`echo a | wc`） → 自动转入 confirm 流程
- [ ] LLM 给出 `run_safe` + 危险命令（如 `rm -rf /`） → blocked