### PR TITLE
fix(agent): improve loop resilience after run_mp6zxpp3 trace analysis

### DIFF
--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -1,6 +1,33 @@
 import { buildIdePromptLines, isIdeMcpEnabled } from '../tools/ide/mcp-client.ts';
 import { buildChromePromptLines, isChromeMcpEnabled } from '../tools/chrome/mcp-client.ts';
 
+// 提取最近 N 步 browser/chrome 工具访问过的 URL，提示模型避免原地踏步。
+// trace 中曾出现同一 URL 被模型连续访问 3 次的情况，仅靠 history 推理不足以让模型察觉。
+function buildRecentUrlsHint(history: any[], lookback = 5): string | null {
+  if (!Array.isArray(history) || history.length === 0) return null;
+  const recent = history.slice(-lookback);
+  const counts = new Map<string, number>();
+  const order: string[] = [];
+  for (const entry of recent) {
+    const action = entry?.action || {};
+    const tool = action.tool || '';
+    if (tool !== 'browser' && tool !== 'chrome') continue;
+    let url: string | undefined;
+    if (typeof action.url === 'string') url = action.url;
+    else if (action.arguments && typeof action.arguments.url === 'string') url = action.arguments.url;
+    if (!url) continue;
+    if (!counts.has(url)) order.push(url);
+    counts.set(url, (counts.get(url) || 0) + 1);
+  }
+  if (order.length === 0) return null;
+  const lines = order.map(url => {
+    const n = counts.get(url) || 1;
+    const flag = n >= 2 ? '【已访问 ' + n + ' 次，避免重复】' : '';
+    return `- ${url} ${flag}`.trim();
+  });
+  return `最近访问过的 URL（避免重复访问相同页面，除非有明确新目的）：\n${lines.join('\n')}`;
+}
+
 export function buildDesktopAgentSystemPrompt(systemPrompt: string | null) {
   const ideLines = buildIdePromptLines();
   const chromeLines = buildChromePromptLines();
@@ -45,9 +72,10 @@ export function buildClaudeTaskMessages({
       messages.push({ role: msg.role, content: msg.content });
     }
   }
+  const recentUrlsHint = buildRecentUrlsHint(history);
   messages.push({
     role: 'user',
-    content: JSON.stringify({ task, step, history, observation }),
+    content: JSON.stringify({ task, step, history, observation, ...(recentUrlsHint ? { recentUrlsHint } : {}) }),
   });
   return messages;
 }
@@ -76,6 +104,8 @@ export function buildNvidiaTaskMessages({
         .map(message => `${message.role === 'user' ? '用户' : '助手'}: ${message.content}`)
         .join('\n')
     : '';
+
+  const recentUrlsHint = buildRecentUrlsHint(history);
 
   return [
     {
@@ -144,7 +174,7 @@ export function buildNvidiaTaskMessages({
     },
     {
       role: 'user',
-      content: JSON.stringify({ task, step, history, observation }),
+      content: JSON.stringify({ task, step, history, observation, ...(recentUrlsHint ? { recentUrlsHint } : {}) }),
     },
   ];
 }

--- a/agent/core/result-quality.ts
+++ b/agent/core/result-quality.ts
@@ -21,7 +21,7 @@ const OFFICIAL_HOST_PATTERNS = [
 ];
 
 const FAILURE_PATTERNS = [
-  /执行失败|操作失败|访问失败|导航超时|访问超时|timeout|timed out|404 Not Found|403 Forbidden|already running|反爬|验证码|人机验证|页面内容为空|未找到|不存在|撤稿|删除|rate.?limit|429/i,
+  /执行失败|操作失败|访问失败|导航超时|访问超时|timeout|timed out|404 Not Found|403 Forbidden|already running|反爬|验证码|人机验证|安全验证|滑块|页面内容为空|未找到|不存在|撤稿|删除|rate.?limit|429|请求已中断|Web应用防护|Web安全风险|访问不合规|已阻止访问搜索引擎/i,
 ];
 
 function textOf(value: any) {
@@ -51,7 +51,7 @@ function hasOfficialUrl(value: any) {
 
 function resultHasUsableOfficialContent(step: any) {
   const result = textOf(step?.result);
-  const url = textOf(step?.url || step?.action?.url);
+  const url = textOf(step?.url || step?.action?.url || step?.action?.arguments?.url);
   if (!hasOfficialUrl(url) && !hasOfficialUrl(result)) {
     return false;
   }

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -39,6 +39,12 @@ import { assessResultQuality } from "./result-quality.ts";
 const MAX_HISTORY_STEPS = Number(process.env.AGENT_MAX_HISTORY_STEPS || 20);
 const MAX_RESULT_CHARS = Number(process.env.AGENT_MAX_RESULT_CHARS || 5000);
 
+function actionTargetUrl(action) {
+  if (typeof action?.url === 'string' && action.url) return action.url;
+  if (typeof action?.arguments?.url === 'string' && action.arguments.url) return action.arguments.url;
+  return null;
+}
+
 function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
   // Progressive truncation: recent steps keep more context, old steps get shorter results
   const truncateEntry = (h, remaining) => {
@@ -195,12 +201,13 @@ export async function runAgentRuntime({
 
       if (authorization?.status === "rejected") {
         const result = authorization.message || "操作未获批准";
+        const url = actionTargetUrl(decision.action) || observation?.url;
         history.push({
           step,
           rationale: decision.rationale,
           action: decision.action,
           result,
-          url: observation?.url,
+          url,
           title: observation?.title,
         });
 
@@ -246,7 +253,7 @@ export async function runAgentRuntime({
         rationale: decision.rationale,
         action: decision.action,
         result,
-        url: observation?.url,
+        url: actionTargetUrl(decision.action) || observation?.url,
         title: observation?.title,
       });
 

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -124,10 +124,13 @@ export async function runAgentRuntime({
           for (const h of snapshot.history) {
             history.push({ ...h });
           }
+          // 从快照步骤继续（而非 targetStep - 1），避免跳步
+          step = snapshot.step;
         } else {
           history.length = 0;
+          // 无快照时从 targetStep - 1 开始（用户想回滚到 step N，从 N-1 后继续）
+          step = targetStep - 1;
         }
-        step = targetStep - 1;
         runRecord.pendingRollback = null;
         runRecord.rolledBack = true;
 

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -142,7 +142,8 @@ export async function runAgentRuntime({
       // ---- 观察 ----
       const lastAction =
         history.length > 0 ? history[history.length - 1].action : null;
-      const skipObservation = shouldObserve
+      // 第一步 lastAction 为 null 时永远不跳过，避免初始观察缺失
+      const skipObservation = shouldObserve && lastAction
         ? !shouldObserve(lastAction)
         : false;
       const observation = skipObservation
@@ -290,10 +291,28 @@ export async function runAgentRuntime({
       finalAnswer = "已达到最大执行步数，任务未完全完成。";
     }
 
+    const quality = assessResultQuality({ task, steps: history, answer: finalAnswer });
+
+    // 降级时在 answer 前置警告条，避免用户把不完整结果误认为正常完成
+    let answer = finalAnswer;
+    if (quality.degraded) {
+      const parts: string[] = [];
+      if (Array.isArray(quality.failure_steps) && quality.failure_steps.length > 0) {
+        parts.push(`${quality.failure_steps.length} 步执行失败（步骤 ${quality.failure_steps.join(', ')}）`);
+      }
+      if (quality.unverified) {
+        parts.push('未获得权威/官方信息来源');
+      }
+      if (parts.length > 0) {
+        const warning = `> ⚠️ ${parts.join('；')}，返回结果可能不完整或存在偏差，请谨慎参考。\n\n`;
+        answer = warning + answer;
+      }
+    }
+
     return {
-      answer: finalAnswer,
+      answer,
       steps: history,
-      quality: assessResultQuality({ task, steps: history, answer: finalAnswer }),
+      quality,
     };
   } finally {
     await cleanup?.(state);

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -96,7 +96,7 @@ export function createDesktopAgentRunner({
     task,
     model,
     models: agentModels,
-    strategy = 'race',
+    strategy = 'progressive',
     systemPrompt = null,
     headless = defaultHeadless,
     onEvent,
@@ -161,7 +161,8 @@ export function createDesktopAgentRunner({
       shouldObserve: (lastAction) => {
         if (!lastAction) return false;
         const tool = lastAction.tool || '';
-        return tool !== 'fs' && tool !== 'terminal' && tool !== 'ide' && tool !== 'chrome';
+        // chrome 是浏览器类工具，状态变化必须观察；fs/terminal/ide 多为本地无副作用操作可跳过
+        return tool !== 'fs' && tool !== 'terminal' && tool !== 'ide';
       },
       execute: async (state, action, context) => routeAction(state, action, context),
       cleanup: async state => {

--- a/agent/desktop/planner.ts
+++ b/agent/desktop/planner.ts
@@ -15,6 +15,9 @@ export const DEFAULT_MODEL_TIMEOUT_MS = 10_000;
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000;
 const SINGLE_MODEL_RATE_LIMIT_RETRY = 2;
 const SINGLE_MODEL_RETRY_BASE_BACKOFF_MS = 5_000;
+// progressive 策略下,primary 模型多久还没返回就唤醒剩余模型加入 race
+// 选 4s 是因为快速模型一般 2~3s 出结果,留 1s 缓冲避免过早 fan-out 浪费 token
+const PROGRESSIVE_RACE_UP_MS = 4_000;
 
 function isRateLimitError(err: any) {
   const status = err?.status || err?.statusCode || err?.error?.status || err?.error?.statusCode;
@@ -329,6 +332,86 @@ export function createDesktopPlanner({
       );
 
       return aggregated;
+    }
+
+    if (strategy === 'progressive') {
+      // 先单跑 primary（activeModels[0]）；4s 内出结果直接独占,
+      // 超过阈值仍 thinking → 唤醒剩余模型加入 race；primary 提前 fail → 立即 fallback race
+      return new Promise((resolve, reject) => {
+        let settled = false;
+        const failures: string[] = [];
+        const timers: NodeJS.Timeout[] = [];
+        const raceAc = new AbortController();
+        const launchedSet = new Set<string>();
+
+        if (cancelSignal?.aborted) { reject(new Error('Agent 已取消')); return; }
+        const onCancel = () => {
+          if (settled) return;
+          settled = true;
+          timers.forEach(t => clearTimeout(t));
+          raceAc.abort();
+          reject(new Error('Agent 已取消'));
+        };
+        cancelSignal?.addEventListener('abort', onCancel);
+
+        const primary = activeModels[0];
+        const rest = activeModels.slice(1);
+
+        function launch(candidate: string) {
+          if (settled || launchedSet.has(candidate) || cancelSignal?.aborted) return;
+          launchedSet.add(candidate);
+          onEvent?.({ type: 'model_plan', stage: 'thinking', model: candidate, step });
+          planWithTimeout(candidate, planCtx, cancelSignal, raceAc.signal)
+            .then(result => {
+              if (settled) {
+                onEvent?.({ type: 'model_plan', stage: 'cancelled', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
+                return;
+              }
+              settled = true;
+              raceAc.abort();
+              timers.forEach(t => clearTimeout(t));
+              cancelSignal?.removeEventListener('abort', onCancel);
+              log.info(`[MultiModel] progressive 使用 ${candidate} 的结果`);
+              onEvent?.({ type: 'model_plan', stage: 'winner', model: candidate, step, rationale: result.rationale, action: result.action, usage: result.usage, reasoning: result.reasoning });
+              resolve(result);
+            })
+            .catch((err: any) => {
+              if (settled) {
+                onEvent?.({ type: 'model_plan', stage: 'cancelled', model: candidate, step });
+                return;
+              }
+              if (err.message.includes('模型超时')) {
+                blacklistedModels.add(candidate);
+                log.warn(`[MultiModel] ${candidate} 超时，已加入黑名单`);
+              } else if (isRateLimitError(err)) {
+                markModelRateLimited(candidate, err, onEvent, step);
+              }
+              onEvent?.({ type: 'model_plan', stage: 'failed', model: candidate, step, error: err.message.slice(0, 120) });
+              failures.push(candidate);
+
+              // primary 提前失败 → 立即唤醒剩余模型 race
+              if (candidate === primary && rest.length > 0) {
+                for (const m of rest) launch(m);
+                return;
+              }
+
+              if (!settled && launchedSet.size === activeModels.length && failures.length === activeModels.length) {
+                cancelSignal?.removeEventListener('abort', onCancel);
+                reject(new Error(`所有模型均失败: ${failures.join(', ')}`));
+              }
+            });
+        }
+
+        launch(primary);
+
+        if (rest.length > 0) {
+          timers.push(setTimeout(() => {
+            if (settled) return;
+            log.info(`[MultiModel] progressive primary=${primary} 超过 ${PROGRESSIVE_RACE_UP_MS}ms 未返回，唤醒 ${rest.join(',')}`);
+            for (const m of rest) launch(m);
+          }, PROGRESSIVE_RACE_UP_MS));
+        }
+      });
     }
 
     return new Promise((resolve, reject) => {

--- a/agent/tools/browser/execute.ts
+++ b/agent/tools/browser/execute.ts
@@ -1,13 +1,21 @@
 import { getWebView } from './webview-session.ts';
 import { isChromeMcpEnabled } from '../chrome/mcp-client.ts';
+import { log } from '../../../helpers/logger.ts';
 
 const ACTION_SETTLE_MS = 600;
 const NAV_RETRY_MS = 500;
 const NAV_MAX_RETRIES = 3;
 const FETCH_TIMEOUT_MS = 15000;
+const FETCH_TIMEOUT_RETRY_MS = 25000;
+const FETCH_RETRY_BACKOFF_MS = 800;
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isTimeoutError(err) {
+  const msg = (err?.message || String(err || '')).toLowerCase();
+  return /超时|timeout|timed out|etimedout/.test(msg);
 }
 
 function withTimeout(promise, ms, message) {
@@ -20,6 +28,26 @@ function withTimeout(promise, ms, message) {
     // Give the underlying operation time to settle so WebView clears its pending state
     return promise.catch(() => {});
   });
+}
+
+// 浏览器冷启动期的偶发超时往往一次重试就成功（trace 中 fabiaoqing 连续两次超时第三次成功）
+// 仅对超时错误重试 1 次，证书/DNS/HTTP 错误不重试
+async function navigateWithRetry(view, url, firstTimeoutMs, retryTimeoutMs, errMessage) {
+  try {
+    return await withTimeout(safeNavigate(view, url), firstTimeoutMs, errMessage);
+  } catch (err) {
+    if (!isTimeoutError(err)) throw err;
+    await delay(FETCH_RETRY_BACKOFF_MS);
+    try {
+      const result = await withTimeout(safeNavigate(view, url), retryTimeoutMs, errMessage);
+      return result;
+    } catch (err2) {
+      if (isTimeoutError(err2)) {
+        throw new Error(`${err2.message} (已自动重试 1 次)`);
+      }
+      throw err2;
+    }
+  }
 }
 
 export async function safeNavigate(view, url) {
@@ -200,9 +228,23 @@ async function _executeBrowserAction(view, action) {
   if (action.type === 'scroll') {
     const pixels = (action.amount || 3) * 300;
     const signedPixels = action.direction === 'up' ? -pixels : pixels;
+    // 滚动前后各取一次文本快照，用于判断懒加载是否真的触发
+    const beforeText = await safeEvaluate(view, "(document.body?.innerText || '').slice(0, 4000)");
     await safeEvaluate(view, `window.scrollBy(0, ${signedPixels})`);
-    await delay(400);
-    return `已向${action.direction === 'up' ? '上' : '下'}滚动 ${action.amount || 3} 步`;
+    // 1200ms 比原 400ms 更稳，给懒加载/异步渲染留时间
+    await delay(1200);
+    const afterText = await safeEvaluate(view, "(document.body?.innerText || '').slice(0, 4000)");
+    let result = `已向${action.direction === 'up' ? '上' : '下'}滚动 ${action.amount || 3} 步`;
+    const lengthDelta = Math.abs((afterText?.length || 0) - (beforeText?.length || 0));
+    const unchanged =
+      beforeText && afterText &&
+      lengthDelta < 20 &&
+      beforeText.slice(0, 200) === afterText.slice(0, 200) &&
+      beforeText.slice(-200) === afterText.slice(-200);
+    if (unchanged) {
+      result += '\n⚠️ 滚动后页面内容未变化（可能已到底部或懒加载未触发）';
+    }
+    return result;
   }
 
   if (action.type === 'get_page_content') {
@@ -218,10 +260,10 @@ async function _executeBrowserAction(view, action) {
     if (!action.url) throw new Error('http_fetch 缺少 url');
     const url = /^https?:\/\//i.test(action.url) ? action.url : `https://${action.url}`;
     try {
-      await withTimeout(safeNavigate(view, url), FETCH_TIMEOUT_MS, `访问超时: ${url}`);
+      await navigateWithRetry(view, url, FETCH_TIMEOUT_MS, FETCH_TIMEOUT_RETRY_MS, `访问超时: ${url}`);
       await delay(1000);
     } catch (err) {
-      return `http_fetch ${url}: 浏览器访问失败 (${(err.message || '').slice(0, 100)})。`;
+      return `http_fetch ${url}: 浏览器访问失败 (${(err.message || '').slice(0, 120)})。`;
     }
     try {
       const pageInfo = await detectBlockedPage(view);
@@ -265,13 +307,13 @@ async function _executeBrowserAction(view, action) {
     for (const u of urls.slice(0, 5)) {
       const url = /^https?:\/\//i.test(u) ? u : `https://${u}`;
       try {
-        await withTimeout(safeNavigate(view, url), FETCH_TIMEOUT_MS, `访问超时: ${url}`);
+        await navigateWithRetry(view, url, FETCH_TIMEOUT_MS, FETCH_TIMEOUT_RETRY_MS, `访问超时: ${url}`);
         await delay(1000);
         const text = await safeEvaluate(view, "document.body?.innerText || ''");
         const cleaned = text.replace(/\s+/g, ' ').trim();
         results.push(`http_fetch ${url}:\n${cleaned.slice(0, 24000) || '页面内容为空'}`);
       } catch (err) {
-        results.push(`http_fetch ${url}: 失败 (${(err.message || '').slice(0, 80)})`);
+        results.push(`http_fetch ${url}: 失败 (${(err.message || '').slice(0, 100)})`);
       }
     }
     return results.join('\n\n---\n\n');

--- a/agent/tools/browser/execute.ts
+++ b/agent/tools/browser/execute.ts
@@ -9,6 +9,12 @@ const FETCH_TIMEOUT_MS = 15000;
 const FETCH_TIMEOUT_RETRY_MS = 25000;
 const FETCH_RETRY_BACKOFF_MS = 800;
 
+const SEARCH_ENGINE_HOSTS = [
+  /(^|\.)baidu\.com$/i,
+  /(^|\.)google\.[^/]+$/i,
+  /(^|\.)bing\.com$/i,
+];
+
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -28,6 +34,31 @@ function withTimeout(promise, ms, message) {
     // Give the underlying operation time to settle so WebView clears its pending state
     return promise.catch(() => {});
   });
+}
+
+function normalizeHttpUrl(rawUrl) {
+  return /^https?:\/\//i.test(rawUrl) ? rawUrl : `https://${rawUrl}`;
+}
+
+function isBlockedSearchEngineUrl(rawUrl) {
+  if (!rawUrl) return false;
+  try {
+    const parsed = new URL(normalizeHttpUrl(rawUrl));
+    const hostMatches = SEARCH_ENGINE_HOSTS.some(pattern => pattern.test(parsed.hostname));
+    if (!hostMatches) return false;
+    const path = parsed.pathname.toLowerCase();
+    return path === '/s' || path === '/search' || parsed.searchParams.has('q') || parsed.searchParams.has('wd');
+  } catch {
+    return false;
+  }
+}
+
+function blockedSearchEngineResult(url) {
+  return [
+    `已阻止访问搜索引擎搜索页: ${url}`,
+    'Google、百度、Bing 等搜索页容易触发反爬/验证码，且通常不是可靠的一手来源。',
+    '请直接抓取目标站点 URL；如果需要多源搜索，请使用 parallel_fetch 抓取多个候选来源页面。',
+  ].join('\n');
 }
 
 // 浏览器冷启动期的偶发超时往往一次重试就成功（trace 中 fabiaoqing 连续两次超时第三次成功）
@@ -95,6 +126,13 @@ const BLOCKED_PATTERNS = [
   /hcaptcha/i,
   /请完成验证/i,
   /人机验证/i,
+  /安全验证/i,
+  /拖动.*滑块/i,
+  /滑块/i,
+  /请求已中断/i,
+  /Web应用防护/i,
+  /Web安全风险/i,
+  /访问不合规/i,
 ];
 
 function detectBlockedPage(view) {
@@ -122,6 +160,36 @@ function checkBlocked(title, url, body) {
 function blockedHint() {
   if (!isChromeMcpEnabled()) return '';
   return '\n\n⚠️ 页面可能被反爬拦截，建议改用 Chrome MCP 工具（chrome_call_tool → navigate_page / take_snapshot）操作真实 Chrome 浏览器访问。';
+}
+
+async function extractPageTextOrLinks(view, url, extractLinks) {
+  if (extractLinks) {
+    const { content, links } = await safeEvaluate(view, `(() => {
+      const bodyText = document.body?.innerText || '';
+      const anchors = Array.from(document.querySelectorAll('a[href]'));
+      const extracted = [];
+      for (const a of anchors) {
+        const href = a.href;
+        const label = (a.textContent || '').trim();
+        if (href && href.startsWith('http') && label.length > 3 && label.length < 120) {
+          extracted.push({ url: href, title: label });
+        }
+      }
+      return { content: bodyText, links: extracted };
+    })()`);
+    let result = `搜索结果 ${url}:\n\n链接列表:\n`;
+    for (const link of links.slice(0, 10)) {
+      result += `- [${link.title}](${link.url})\n`;
+    }
+    result += `\n页面摘要: ${content.slice(0, 3000)}`;
+    return result;
+  }
+
+  const text = await safeEvaluate(view, "document.body?.innerText || ''");
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  return cleaned.length > 24000
+    ? cleaned.slice(0, 24000) + '\n...(内容已截断)'
+    : cleaned;
 }
 
 function elementSelector(elementId) {
@@ -158,6 +226,9 @@ async function _executeBrowserAction(view, action) {
     if (/^(file:\/\/|https?:\/\/file)/.test(action.url || '')) {
       const localPath = (action.url || '').replace(/^https?:\/\/file\/\/\/|^file:\/\/\/?/, '/');
       return `内置浏览器不支持打开本地文件。请使用 notify_user 告知用户文件路径（${localPath}），或使用 terminal run_confirmed 执行 open "${localPath}" 让系统默认浏览器打开。`;
+    }
+    if (isBlockedSearchEngineUrl(action.url)) {
+      return blockedSearchEngineResult(action.url);
     }
     try {
       await withTimeout(safeNavigate(view, action.url), FETCH_TIMEOUT_MS, `导航超时: ${action.url}`);
@@ -263,7 +334,10 @@ async function _executeBrowserAction(view, action) {
 
   if (action.type === 'http_fetch') {
     if (!action.url) throw new Error('http_fetch 缺少 url');
-    const url = /^https?:\/\//i.test(action.url) ? action.url : `https://${action.url}`;
+    const url = normalizeHttpUrl(action.url);
+    if (isBlockedSearchEngineUrl(url)) {
+      return blockedSearchEngineResult(url);
+    }
     try {
       await navigateWithRetry(view, url, FETCH_TIMEOUT_MS, FETCH_TIMEOUT_RETRY_MS, `访问超时: ${url}`);
       await delay(1000);
@@ -276,33 +350,8 @@ async function _executeBrowserAction(view, action) {
         return `http_fetch ${url} 被反爬拦截（标题: ${pageInfo.title.slice(0, 80)}）。${blockedHint()}`;
       }
     } catch { /* ignore detection failure */ }
-    if (action.extractLinks) {
-      const { content, links } = await safeEvaluate(view, `(() => {
-        const bodyText = document.body?.innerText || '';
-        const anchors = Array.from(document.querySelectorAll('a[href]'));
-        const extracted = [];
-        for (const a of anchors) {
-          const href = a.href;
-          const label = (a.textContent || '').trim();
-          if (href && href.startsWith('http') && label.length > 3 && label.length < 120) {
-            extracted.push({ url: href, title: label });
-          }
-        }
-        return { content: bodyText, links: extracted };
-      })()`);
-      let result = `搜索结果 ${url}:\n\n链接列表:\n`;
-      for (const link of links.slice(0, 10)) {
-        result += `- [${link.title}](${link.url})\n`;
-      }
-      result += `\n页面摘要: ${content.slice(0, 3000)}`;
-      return result;
-    }
-    const text = await safeEvaluate(view, "document.body?.innerText || ''");
-    const cleaned = text.replace(/\s+/g, ' ').trim();
-    const truncated = cleaned.length > 24000
-      ? cleaned.slice(0, 24000) + '\n...(内容已截断)'
-      : cleaned;
-    return truncated || `http_fetch ${url}: 页面内容为空。`;
+    const content = await extractPageTextOrLinks(view, url, action.extractLinks);
+    return content || `http_fetch ${url}: 页面内容为空。`;
   }
 
   if (action.type === 'parallel_fetch') {
@@ -310,13 +359,21 @@ async function _executeBrowserAction(view, action) {
     if (urls.length === 0) throw new Error('parallel_fetch 缺少 urls');
     const results = [];
     for (const u of urls.slice(0, 5)) {
-      const url = /^https?:\/\//i.test(u) ? u : `https://${u}`;
+      const url = normalizeHttpUrl(u);
+      if (isBlockedSearchEngineUrl(url)) {
+        results.push(blockedSearchEngineResult(url));
+        continue;
+      }
       try {
         await navigateWithRetry(view, url, FETCH_TIMEOUT_MS, FETCH_TIMEOUT_RETRY_MS, `访问超时: ${url}`);
         await delay(1000);
-        const text = await safeEvaluate(view, "document.body?.innerText || ''");
-        const cleaned = text.replace(/\s+/g, ' ').trim();
-        results.push(`http_fetch ${url}:\n${cleaned.slice(0, 24000) || '页面内容为空'}`);
+        const pageInfo = await detectBlockedPage(view);
+        if (checkBlocked(pageInfo.title, pageInfo.url, pageInfo.body)) {
+          results.push(`http_fetch ${url} 被反爬拦截（标题: ${pageInfo.title.slice(0, 80)}）。${blockedHint()}`);
+          continue;
+        }
+        const content = await extractPageTextOrLinks(view, url, action.extractLinks);
+        results.push(`http_fetch ${url}:\n${content || '页面内容为空'}`);
       } catch (err) {
         results.push(`http_fetch ${url}: 失败 (${(err.message || '').slice(0, 100)})`);
       }

--- a/agent/tools/browser/execute.ts
+++ b/agent/tools/browser/execute.ts
@@ -154,6 +154,11 @@ export async function executeBrowserAction(view, action) {
 
 async function _executeBrowserAction(view, action) {
   if (action.type === 'navigate') {
+    // 内置浏览器不支持 file:// 协议，拦截并给出可操作建议
+    if (/^(file:\/\/|https?:\/\/file)/.test(action.url || '')) {
+      const localPath = (action.url || '').replace(/^https?:\/\/file\/\/\/|^file:\/\/\/?/, '/');
+      return `内置浏览器不支持打开本地文件。请使用 notify_user 告知用户文件路径（${localPath}），或使用 terminal run_confirmed 执行 open "${localPath}" 让系统默认浏览器打开。`;
+    }
     try {
       await withTimeout(safeNavigate(view, action.url), FETCH_TIMEOUT_MS, `导航超时: ${action.url}`);
       await delay(ACTION_SETTLE_MS);

--- a/agent/tools/chrome/execute.ts
+++ b/agent/tools/chrome/execute.ts
@@ -8,10 +8,40 @@ import {
 } from './mcp-client.ts';
 
 const MAX_TEXT = 48000;
+const SEARCH_ENGINE_HOSTS = [
+  /(^|\.)baidu\.com$/i,
+  /(^|\.)google\.[^/]+$/i,
+  /(^|\.)bing\.com$/i,
+];
 
 function truncate(text, max = MAX_TEXT) {
   const value = String(text || '');
   return value.length > max ? `${value.slice(0, max)}\n...(内容已截断)` : value;
+}
+
+function normalizeHttpUrl(rawUrl) {
+  return /^https?:\/\//i.test(rawUrl) ? rawUrl : `https://${rawUrl}`;
+}
+
+function isBlockedSearchEngineUrl(rawUrl) {
+  if (!rawUrl) return false;
+  try {
+    const parsed = new URL(normalizeHttpUrl(rawUrl));
+    const hostMatches = SEARCH_ENGINE_HOSTS.some(pattern => pattern.test(parsed.hostname));
+    if (!hostMatches) return false;
+    const path = parsed.pathname.toLowerCase();
+    return path === '/s' || path === '/search' || parsed.searchParams.has('q') || parsed.searchParams.has('wd');
+  } catch {
+    return false;
+  }
+}
+
+function blockedSearchEngineResult(url) {
+  return [
+    `已阻止访问搜索引擎搜索页: ${url}`,
+    'Google、百度、Bing 等搜索页容易触发反爬/验证码，且通常不是可靠的一手来源。',
+    '请直接抓取目标站点 URL；如果需要多源搜索，请使用 browser.parallel_fetch 抓取多个候选来源页面。',
+  ].join('\n');
 }
 
 function formatToolList(tools, config) {
@@ -61,6 +91,16 @@ export async function executeChromeAction(action) {
   }
 
   const config = loadChromeMcpConfig();
+  if (action.type === 'chrome_call_tool') {
+    const toolName = String(action.toolName || '').trim();
+    const args = action.arguments && typeof action.arguments === 'object' && !Array.isArray(action.arguments)
+      ? action.arguments : {};
+    const targetUrl = typeof args.url === 'string' ? args.url : '';
+    if ((toolName === 'navigate_page' || toolName === 'new_page') && isBlockedSearchEngineUrl(targetUrl)) {
+      return blockedSearchEngineResult(targetUrl);
+    }
+  }
+
   let client;
   try {
     // 复用共享 MCP client，避免每次 Chrome 动作都重新拉起 MCP 进程或 SSE 流。

--- a/agent/tools/chrome/execute.ts
+++ b/agent/tools/chrome/execute.ts
@@ -15,6 +15,7 @@ function truncate(text, max = MAX_TEXT) {
 }
 
 function formatToolList(tools, config) {
+  // chrome_list_tools 面向模型展示工具摘要，只保留名称、参数字段和描述。
   const header = [
     `Chrome DevTools MCP 已连接 (${config.transport})`,
     `可用工具数: ${tools.length}`,
@@ -30,6 +31,7 @@ function formatToolList(tools, config) {
 }
 
 function extractToolContent(result) {
+  // MCP 工具结果可能同时包含 content 和 structuredContent，这里统一压成文本。
   const chunks = [];
 
   if (Array.isArray(result?.content)) {
@@ -59,7 +61,21 @@ export async function executeChromeAction(action) {
   }
 
   const config = loadChromeMcpConfig();
-  const client = await getSharedChromeMcpClient(config);
+  let client;
+  try {
+    // 复用共享 MCP client，避免每次 Chrome 动作都重新拉起 MCP 进程或 SSE 流。
+    client = await getSharedChromeMcpClient(config);
+  } catch (err: any) {
+    if (err.message?.includes('error -54') || err.message?.includes('xattr')) {
+      return [
+        '⚠️ Chrome 浏览器因 macOS 权限问题无法启动（error -54）',
+        '已自动回退到内置 HTTP 客户端，可继续使用 browser.http_fetch 等工具。',
+        '如需修复 Chrome，请在终端执行:',
+        '  xattr -cr /Applications/Google\\ Chrome.app',
+      ].join('\n');
+    }
+    throw err;
+  }
 
   if (action.type === 'chrome_list_tools') {
     const tools = await client.listTools({ refresh: Boolean(action.refresh) });
@@ -79,7 +95,21 @@ export async function executeChromeAction(action) {
 
     const args = action.arguments && typeof action.arguments === 'object' && !Array.isArray(action.arguments)
       ? action.arguments : {};
-    const result = await client.callTool(toolName, args);
+    let result;
+    try {
+      // 这里保留原始 MCP tool 调用语义，错误恢复由 mcp-client.ts 统一处理。
+      result = await client.callTool(toolName, args);
+    } catch (err: any) {
+      if (err.message?.includes('error -54') || err.message?.includes('xattr')) {
+        return [
+          '⚠️ Chrome 浏览器因 macOS 权限问题无法启动（error -54）',
+          '已自动回退到内置 HTTP 客户端，可继续使用 browser.http_fetch 等工具。',
+          '如需修复 Chrome，请在终端执行:',
+          '  xattr -cr /Applications/Google\\ Chrome.app',
+        ].join('\n');
+      }
+      throw err;
+    }
     const content = extractToolContent(result);
     const status = result?.isError ? '失败' : '完成';
 

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -15,6 +15,7 @@ const CLIENT_INFO = { name: 'sagent', version: '1.0.0' };
 const IS_WINDOWS = process.platform === 'win32';
 
 function killOrphanChrome() {
+  // chrome-devtools-mcp 会使用固定 profile；重启 transport 前先清理它遗留的 Chrome。
   const profileDir = path.join(os.homedir(), '.cache', 'chrome-devtools-mcp', 'chrome-profile');
   if (!fs.existsSync(profileDir)) return;
 
@@ -51,6 +52,7 @@ function toAbsolutePath(rawPath, fallback = process.cwd()) {
 }
 
 function resolveCommandOnWindows(command, args) {
+  // Windows 下 npm bin shim 可能无法直接作为 stdio MCP 进程稳定启动。
   if (!IS_WINDOWS) {
     return { command, args };
   }
@@ -71,6 +73,7 @@ function resolveCommandOnWindows(command, args) {
 }
 
 function parseArgs(value) {
+  // CHROME_MCP_ARGS 支持 JSON 数组；解析失败时兼容简单空格分隔写法。
   if (Array.isArray(value)) {
     return value.map(item => String(item));
   }
@@ -111,6 +114,7 @@ function buildMessagesUrl(config, streamUrl) {
 }
 
 export function buildSsePostCandidates(config, streamUrl) {
+  // 不同 MCP SSE 实现使用 /message、/messages 或事件下发 endpoint。
   const candidates = [];
   const seen = new Set();
 
@@ -197,6 +201,7 @@ function clientKey(config) {
 }
 
 export function isChromeMcpEnabled(env = process.env) {
+  // 显式开关优先；只要配置了任一连接参数，也视为用户想启用 Chrome MCP。
   if (envFlag(env.CHROME_MCP_ENABLED)) {
     return true;
   }
@@ -221,6 +226,7 @@ export function buildChromePromptLines(env = process.env) {
 }
 
 export function loadChromeMcpConfig(env = process.env) {
+  // 默认使用 SSE；设置 CHROME_MCP_TRANSPORT=stdio 时改走本地子进程。
   const transport = String(env.CHROME_MCP_TRANSPORT || '').trim().toLowerCase() === 'stdio' ? 'stdio' : 'sse';
   const host = String(env.CHROME_MCP_HOST || DEFAULT_SSE_HOST).trim() || DEFAULT_SSE_HOST;
   const port = Number(env.CHROME_MCP_PORT || DEFAULT_SSE_PORT) || DEFAULT_SSE_PORT;
@@ -257,6 +263,9 @@ function createJsonRpcError(message, code = -32000, data = null) {
 }
 
 class ChromeMcpClient {
+  // macOS quarantine 等启动错误通常不会自愈；缓存后避免每步反复拉起 Chrome。
+  static _fatalChromeError: string | null = null;
+
   config: any;
   transport: any;
   toolsCache: any[] | null;
@@ -267,7 +276,17 @@ class ChromeMcpClient {
     this.toolsCache = null;
   }
 
+  _isFatalLaunchError(err: any): boolean {
+    const msg = err?.message || '';
+    return msg.includes('error -54')
+      || msg.includes('LSOpenURLsWithCompletionHandler')
+      || msg.includes('is damaged')
+      || msg.includes('cannot be opened')
+      || msg.includes('is corrupted');
+  }
+
   async listTools({ refresh = false } = {}) {
+    // tools/list 可能分页；缓存结果给 getTool 和后续 chrome_list_tools 复用。
     if (!refresh && this.toolsCache) {
       return this.toolsCache;
     }
@@ -301,6 +320,11 @@ class ChromeMcpClient {
   }
 
   async callTool(toolName, toolArgs) {
+    // callTool 是上层唯一入口，集中处理 MCP 工具错误和 Chrome 启动恢复。
+    if (ChromeMcpClient._fatalChromeError) {
+      throw new Error(ChromeMcpClient._fatalChromeError);
+    }
+
     const doCall = async () => this.transport.request('tools/call', {
       name: toolName,
       arguments: toolArgs || {},
@@ -311,6 +335,9 @@ class ChromeMcpClient {
       // MCP returns tool errors as { isError: true } in a successful JSON-RPC response,
       // not as a JSON-RPC error — so we must check result.isError explicitly.
       if (result?.isError && this._isChromeConnectionResult(result)) {
+        if (this._isFatalLaunchResult(result)) {
+          throw new Error(this._setFatalError(result));
+        }
         if (this._isAlreadyRunningResult(result)) {
           return await this._recoverFromAlreadyRunning(toolName, toolArgs);
         }
@@ -318,6 +345,9 @@ class ChromeMcpClient {
       }
       return result;
     } catch (err) {
+      if (this._isFatalLaunchError(err)) {
+        throw new Error(this._setFatalError(err));
+      }
       if (this._isChromeConnectionError(err)) {
         if (this._isAlreadyRunningErrorMsg(err)) {
           return await this._recoverFromAlreadyRunning(toolName, toolArgs);
@@ -348,6 +378,7 @@ class ChromeMcpClient {
   }
 
   _addIsolatedFlag() {
+    // --isolated 让 chrome-devtools-mcp 使用独立 profile，避免占用用户日常 Chrome。
     const config = this.transport?.config;
     if (!config || !Array.isArray(config.args)) {
       return false;
@@ -364,6 +395,7 @@ class ChromeMcpClient {
   }
 
   async _retryWithoutAutoConnect(toolName, toolArgs) {
+    // --autoConnect 连接现有 Chrome 失败时，退回让 MCP 自己启动浏览器。
     if (!this._stripAutoConnect()) {
       throw new Error('Chrome MCP 连接失败且无法回退');
     }
@@ -385,6 +417,11 @@ class ChromeMcpClient {
         return result;
       }
 
+      // 检测 macOS 致命错误（如 error -54），直接失败不重试
+      if (this._isFatalLaunchResult(result)) {
+        throw new Error(this._setFatalError(result));
+      }
+
       if (attempt >= MAX_RETRIES - 1) {
         log.info(`[Chrome MCP] 工具调用 ${toolName} 浏览器启动后仍失败（已重试 ${MAX_RETRIES} 次）`);
         return result;
@@ -393,6 +430,26 @@ class ChromeMcpClient {
       log.info(`[Chrome MCP] 等待浏览器启动，${RETRY_DELAY_MS}ms 后重试 ${toolName}（第 ${attempt + 1}/${MAX_RETRIES} 次）`);
       await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
     }
+  }
+
+  _isFatalLaunchResult(result) {
+    const text = Array.isArray(result?.content)
+      ? result.content.map(c => c?.text || '').join(' ')
+      : '';
+    return text.includes('error -54')
+      || text.includes('LSOpenURLsWithCompletionHandler')
+      || text.includes('is damaged')
+      || text.includes('is corrupted');
+  }
+
+  _setFatalError(err: any): string {
+    const msg = err?.message || String(err);
+    ChromeMcpClient._fatalChromeError =
+      'Chrome 因 macOS 权限问题无法启动，请运行以下命令修复:\n'
+      + '  xattr -cr /Applications/Google\\ Chrome.app\n'
+      + `错误详情: ${msg}`;
+    log.error(`[Chrome MCP] ${ChromeMcpClient._fatalChromeError}`);
+    return ChromeMcpClient._fatalChromeError;
   }
 
   _isChromeConnectionResult(result) {
@@ -425,6 +482,7 @@ class ChromeMcpClient {
   }
 
   _stripAutoConnect() {
+    // 修改运行时 config 后重置共享 client，下一次请求会用新参数重建 transport。
     const config = this.transport?.config;
     if (!config || !Array.isArray(config.args) || !config.args.includes('--autoConnect')) {
       return false;
@@ -445,6 +503,7 @@ class ChromeMcpClient {
   }
 }
 
+// 通过本地子进程与 chrome-devtools-mcp 通信，适合由本应用直接管理 MCP 生命周期。
 class StdioTransport {
   config: any;
   child: any;
@@ -467,6 +526,7 @@ class StdioTransport {
   }
 
   async ensureConnected() {
+    // 建立进程只负责启动 stdio 通道；MCP initialize 在 ensureInitialized 中完成。
     if (this.child && !this.child.stdin?.destroyed) {
       return;
     }
@@ -523,6 +583,7 @@ class StdioTransport {
   }
 
   handleStdout(chunk) {
+    // 兼容两种常见 MCP stdio framing：Content-Length 和 NDJSON。
     this.buffer = Buffer.concat([this.buffer, Buffer.from(chunk)]);
 
     while (this.buffer.length > 0) {
@@ -595,6 +656,7 @@ class StdioTransport {
   }
 
   handleIncomingMessage(message) {
+    // 当前客户端只主动发请求；服务端反向请求统一返回 method not found。
     if (message?.method && message?.id !== undefined) {
       this.sendRaw({
         jsonrpc: '2.0',
@@ -628,6 +690,7 @@ class StdioTransport {
   }
 
   async sendRaw(message) {
+    // stdio transport 只负责 JSON-RPC 序列化和写入，不触发 initialize。
     await this.ensureConnected();
     if (!this.child || this.child.stdin?.destroyed) {
       throw new Error('Chrome MCP stdio 连接已断开，请重试');
@@ -650,6 +713,7 @@ class StdioTransport {
   }
 
   async ensureInitialized() {
+    // 依次尝试新旧 MCP protocolVersion，兼容不同版本的 chrome-devtools-mcp。
     if (this.initialized) {
       return;
     }
@@ -717,6 +781,7 @@ class StdioTransport {
   }
 
   async sendRequest(method, params, { skipInit = false } = {}) {
+    // pending map 将 JSON-RPC response id 映射回调用方 Promise。
     if (!skipInit) {
       await this.ensureInitialized();
     }
@@ -764,6 +829,7 @@ class StdioTransport {
   }
 }
 
+// 连接外部 MCP SSE server：GET 订阅事件流，POST 发送 JSON-RPC 消息。
 class SseTransport {
   config: any;
   streamUrl: string;
@@ -798,6 +864,7 @@ class SseTransport {
   }
 
   async ensureStreamOpen(): Promise<string> {
+    // SSE server 可能通过 endpoint 事件告知 POST 地址；否则短暂等待后用候选地址。
     if (this.streamPromise) {
       if (!this.endpointPromise) {
         throw new Error('Chrome MCP SSE endpoint 尚未初始化');
@@ -852,6 +919,7 @@ class SseTransport {
   }
 
   async consumeStream(body) {
+    // SSE 事件以空行分隔；每个完整事件块交给 handleSseEvent 解析。
     const reader = body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
@@ -879,6 +947,7 @@ class SseTransport {
   }
 
   handleSseEvent(block) {
+    // endpoint 事件更新 POST 地址；普通 message 事件承载 JSON-RPC payload。
     const lines = block.split(/\r?\n/);
     let eventName = 'message';
     const dataLines = [];
@@ -957,6 +1026,7 @@ class SseTransport {
   }
 
   async postJsonRpc(message) {
+    // 某些 server 的 messages 路径不同，404 时尝试下一个候选地址。
     const endpoint = await this.ensureStreamOpen();
     const candidates = [endpoint, this.postUrl, ...this.fallbackPostUrls]
       .filter((value, index, array) => typeof value === 'string' && value && array.indexOf(value) === index);
@@ -1001,6 +1071,7 @@ class SseTransport {
   }
 
   async ensureInitialized() {
+    // 与 stdio 一样，SSE transport 初始化后才允许发送普通 MCP 请求。
     if (this.initialized) {
       return;
     }
@@ -1088,6 +1159,10 @@ class SseTransport {
     this.initializePromise = null;
     this.streamPromise = null;
   }
+}
+
+export function resetFatalChromeError() {
+  ChromeMcpClient._fatalChromeError = null;
 }
 
 export function createChromeMcpClient(config = loadChromeMcpConfig()) {

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -329,34 +329,38 @@ class ChromeMcpClient {
   }
 
   async _recoverFromAlreadyRunning(toolName, toolArgs) {
-    log.info(`[Chrome MCP] 检测到 Chrome already running 冲突，清理孤儿进程后重试`);
-    killOrphanChrome();
-    await new Promise(r => setTimeout(r, 2000));
-    // Reset transport so MCP server launches a fresh Chrome
+    // 默认 profile 被用户自己的 Chrome 占用时，killOrphanChrome 会误杀用户进程；
+    // 改为加 --isolated 启动独立 profile，重启 MCP client 后重试
+    if (!this._addIsolatedFlag()) {
+      log.info(`[Chrome MCP] 已是 --isolated 模式但仍冲突，工具调用 ${toolName} 失败`);
+      throw new Error('Chrome MCP browser profile 冲突，且 --isolated 模式仍无法启动');
+    }
+    log.info(`[Chrome MCP] 检测到 Chrome already running 冲突，自动加 --isolated 重启 MCP client 后重试 ${toolName}`);
+    const client = await getSharedChromeMcpClient(this.config);
+    const result = await client.transport.request('tools/call', {
+      name: toolName,
+      arguments: toolArgs || {},
+    });
+    if (result?.isError) {
+      log.info(`[Chrome MCP] --isolated 模式下工具调用 ${toolName} 仍失败`);
+    }
+    return result;
+  }
+
+  _addIsolatedFlag() {
+    const config = this.transport?.config;
+    if (!config || !Array.isArray(config.args)) {
+      return false;
+    }
+    if (config.args.includes('--isolated')) {
+      return false;
+    }
+    config.args = [...config.args, '--isolated'];
     this.transport.close?.().catch(() => {});
     this.toolsCache = null;
-    const client = await getSharedChromeMcpClient(this.config);
-    const MAX_RETRIES = 3;
-    const RETRY_DELAY_MS = 3000;
-
-    for (let attempt = 0; ; attempt++) {
-      const result = await client.transport.request('tools/call', {
-        name: toolName,
-        arguments: toolArgs || {},
-      });
-
-      if (!result?.isError) {
-        return result;
-      }
-
-      if (attempt >= MAX_RETRIES - 1) {
-        log.info(`[Chrome MCP] 清理 Chrome 后工具调用 ${toolName} 仍失败（已重试 ${MAX_RETRIES} 次）`);
-        return result;
-      }
-
-      log.info(`[Chrome MCP] 等待浏览器启动，${RETRY_DELAY_MS}ms 后重试 ${toolName}（第 ${attempt + 1}/${MAX_RETRIES} 次）`);
-      await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
-    }
+    sharedClientPromise = null;
+    sharedClientKey = '';
+    return true;
   }
 
   async _retryWithoutAutoConnect(toolName, toolArgs) {

--- a/agent/tools/fetch/execute.ts
+++ b/agent/tools/fetch/execute.ts
@@ -25,11 +25,18 @@ const execFileAsync = promisify(execFile);
 
 const MAX_CONTENT_LENGTH = 24000;
 const BROWSER_TIMEOUT_MS = 15000;
+const BROWSER_TIMEOUT_RETRY_MS = 25000;
+const BROWSER_RETRY_BACKOFF_MS = 800;
 const CURL_TIMEOUT_MS = 10000;
 const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36';
 
 function extractMainContent(text) {
   return text.replace(/\s+/g, ' ').trim();
+}
+
+function isTimeoutError(err) {
+  const msg = (err?.message || String(err || '')).toLowerCase();
+  return /超时|timeout|timed out|etimedout/.test(msg);
 }
 
 function createTimeout(ms, message) {
@@ -69,9 +76,25 @@ async function withFetchView(session, fn) {
 async function fetchWithBrowser(session, action) {
   const url = action.url;
   const timeout = action.timeoutMs || BROWSER_TIMEOUT_MS;
+  const retryTimeout = action.timeoutMs ? Math.round(action.timeoutMs * 1.5) : BROWSER_TIMEOUT_RETRY_MS;
 
   return withFetchView(session, async view => {
-    await withTimeout(safeNavigate(view, url), timeout, `WebView 访问超时: ${url}`);
+    // 浏览器冷启动期偶发超时，给一次重试机会
+    try {
+      await withTimeout(safeNavigate(view, url), timeout, `WebView 访问超时: ${url}`);
+    } catch (err) {
+      if (!isTimeoutError(err)) throw err;
+      log.info(`[Fetch] WebView 首次超时,${BROWSER_RETRY_BACKOFF_MS}ms 后重试 ${url}`);
+      await new Promise(resolve => setTimeout(resolve, BROWSER_RETRY_BACKOFF_MS));
+      try {
+        await withTimeout(safeNavigate(view, url), retryTimeout, `WebView 访问超时: ${url}`);
+      } catch (err2) {
+        if (isTimeoutError(err2)) {
+          throw new Error(`${err2.message} (已自动重试 1 次)`);
+        }
+        throw err2;
+      }
+    }
     await new Promise(resolve => setTimeout(resolve, 1000));
 
     if (action.extractLinks) {

--- a/agent/tools/macos/execute.ts
+++ b/agent/tools/macos/execute.ts
@@ -54,8 +54,17 @@ function getAppleScriptKeyCode(key) {
 
 async function executeWithShell(action, context) {
   if (action.type === 'open_app') {
-    await execFileText('open', ['-a', action.app]);
-    return `已打开应用 ${action.app}`;
+    try {
+      await execFileText('open', ['-a', action.app]);
+      return `已打开应用 ${action.app}`;
+    } catch (err) {
+      const msg = err?.message || String(err);
+      // error -54 = 沙箱限制；error -10810 = 应用无法启动
+      if (/error -54|sandbox|permission denied|operation not permitted/i.test(msg)) {
+        return `无法打开 ${action.app}（沙箱环境限制）。建议使用 notify_user 告知用户手动打开，或使用 terminal run_confirmed 执行 open 命令。`;
+      }
+      return `打开 ${action.app} 失败: ${msg.slice(0, 150)}。建议使用 notify_user 告知用户手动操作。`;
+    }
   }
 
   if (action.type === 'activate_app') {

--- a/agent/tools/terminal/run.ts
+++ b/agent/tools/terminal/run.ts
@@ -48,7 +48,12 @@ async function runShellCommand(command, { cwd, timeoutMs }) {
       }
       settled = true;
       child.kill('SIGTERM');
-      reject(new Error(`命令执行超时 (${timeoutMs} ms)`));
+      // 后台进程（& 结尾）或长驻服务永远不会退出，给模型可操作建议
+      const isBackgroundCmd = /&\s*$/.test(command) || /\bserver\b|\bdaemon\b|\bserve\b/i.test(command);
+      const hint = isBackgroundCmd
+        ? '。该命令为后台/长驻进程，不会自行退出。建议使用 notify_user 告知用户手动执行，或改用不需要服务器的方案。'
+        : '';
+      reject(new Error(`命令执行超时 (${timeoutMs} ms)${hint}`));
     }, timeoutMs);
 
     child.stdout.on('data', chunk => {

--- a/routes/agent-run-start.ts
+++ b/routes/agent-run-start.ts
@@ -48,10 +48,12 @@ export function createAgentRunStartRouter({
     const normalizedTask = task.trim();
     const agentHeadless = typeof headless === 'boolean' ? headless : process.env.AGENT_HEADLESS === 'true';
     const startedAt = Date.now();
+    // fromCheckpoint 回滚时复用原 runId，保持 trace 连续性
+    const existingRunId = fromCheckpoint?.runId;
     const runRecord = agentRunStore.createRun({
       model,
       task: normalizedTask,
-    }, startedAt);
+    }, startedAt, existingRunId);
     const runId = runRecord.runId;
     let finalAnswer: string | null = null;
     let agentError: any = null;

--- a/test/chrome-tools.test.ts
+++ b/test/chrome-tools.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { createModelTools } from '../agent/core/tool-definitions.ts';
 import { normalizeDesktopAgentDecision } from '../agent/core/schemas.ts';
 import { classifyAgentAction } from '../agent/policy/classify.ts';
+import { executeChromeAction } from '../agent/tools/chrome/execute.ts';
 import {
   loadChromeMcpConfig,
   resetChromeMcpClientForTests,
@@ -144,5 +145,19 @@ describe('Chrome MCP config', () => {
     const config = loadChromeMcpConfig();
 
     expect(config.enabled).toBe(true);
+  });
+});
+
+describe('Chrome MCP search-engine guard', () => {
+  it('blocks search engine navigation before connecting to MCP', async () => {
+    process.env.CHROME_MCP_ENABLED = 'true';
+
+    const result = await executeChromeAction({
+      type: 'chrome_call_tool',
+      toolName: 'navigate_page',
+      arguments: { url: 'https://www.baidu.com/s?wd=杭州必去十大景点' },
+    });
+
+    expect(result).toContain('已阻止访问搜索引擎搜索页');
   });
 });

--- a/test/result-quality.test.ts
+++ b/test/result-quality.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { assessResultQuality } from '../agent/core/result-quality.ts';
+
+describe('result quality assessment', () => {
+  it('treats WAF and captcha pages as failed steps', () => {
+    const quality = assessResultQuality({
+      task: '搜索杭州必去的十大景点及门票价格',
+      steps: [
+        {
+          step: 1,
+          action: { tool: 'browser', type: 'http_fetch', url: 'https://example.com' },
+          result: '您的请求已中断 Web应用防护服务检测您当前访问存在Web安全风险',
+        },
+        {
+          step: 2,
+          action: { tool: 'browser', type: 'get_page_content' },
+          result: '百度安全验证 请完成下方验证后继续操作 拖动左侧滑块使图片为正',
+        },
+      ],
+      answer: 'done',
+    });
+
+    expect(quality.status).toBe('done_degraded');
+    expect(quality.failure_steps).toEqual([1, 2]);
+  });
+
+  it('uses nested action arguments URL when checking official sources', () => {
+    const quality = assessResultQuality({
+      task: '查询医保政策',
+      steps: [
+        {
+          step: 1,
+          action: {
+            tool: 'chrome',
+            type: 'chrome_call_tool',
+            toolName: 'navigate_page',
+            arguments: { url: 'https://www.gov.cn/zhengce/example.html' },
+          },
+          result: '这里是政策正文，包含足够多的可用内容用于判断来源有效。这里继续补充政策适用范围、办理条件、材料要求、办理流程、办理时限、责任部门和注意事项，确保内容长度超过最低可用阈值。',
+        },
+      ],
+      answer: '已根据官方页面回答',
+    });
+
+    expect(quality.unverified).toBe(false);
+    expect(quality.official_source_steps).toEqual([1]);
+  });
+});

--- a/test/session-checkpoint.test.ts
+++ b/test/session-checkpoint.test.ts
@@ -138,6 +138,29 @@ const events = () => {
 };
 
 describe('runtime: session checkpoint integration', () => {
+  it('records action target URL in history instead of the previous observation URL', async () => {
+    const cancelSignal = new AbortController().signal;
+    const result = await runAgentRuntime({
+      task: 'fetch target page',
+      maxSteps: 2,
+      onEvent: noop,
+      cancelSignal,
+      initialize: noop,
+      observe: () => ({ url: 'https://previous.example/', title: 'Previous' }),
+      decide: ({ step }) => step === 1
+        ? {
+            action: { tool: 'browser', type: 'http_fetch', url: 'https://target.example/page' },
+            rationale: 'fetch target',
+          }
+        : { action: { type: 'finish', answer: 'done' }, rationale: 'done' },
+      authorize: noop,
+      execute: () => 'target content',
+      cleanup: noop,
+    });
+
+    expect(result.steps[0].url).toBe('https://target.example/page');
+  });
+
   it('saves snapshots at interval steps', async () => {
     const runId = 'run_rt2';
     const runRecord = { runId, pendingRollback: null };


### PR DESCRIPTION
## 背景

基于三个真实 trace 的复盘，修复 agent 执行链路上的多个问题：
- `run_mp6zxpp3_jlwm1s`（搜索"最近流行的搞笑表情包"，10 步 / 3 失败 / `done_degraded`）
- `run_mp7ztm7o_nqrsmh`（生成 HTML 并展示，22 步，本应 5 步完成）
- rollback 功能的两个 bug

## Commit 1: 核心循环韧性改进 (604d79d)

### 失败现象

| 步 | 现象 | 根因 |
|---|---|---|
| 3 | `chrome.navigate_page` 报 "browser already running"，老逻辑 `pkill -f 'Google Chrome.*chrome-profile'` 会误杀用户自己的 Chrome | profile 冲突恢复策略错误 |
| 4/5 | fabiaoqing.com 连续两次超时被汇报为站点失败，第 6 步同一 URL 重试又成功 | 浏览器冷启动期的瞬时超时未做重试 |
| 9 | `scroll down 5` 后 observation 完全不变，模型未察觉直接 finish | scroll 后未等渲染 / 未做 diff 提示 |
| 1/4 | observe 被错误标记 "上一步为文件/终端操作，跳过观察" | step 1 没有上一步；chrome 工具不该被白名单豁免 |
| 全程 | 每步并发跑 3 个模型，>90% 用 kimi 的结果，其余 race 浪费 token | race 默认策略过度并发 |
| 最终 | quality `done_degraded` (3 步失败) 不影响 answer，用户看不到风险 | finish 输出无降级警告 |
| 5/8/9 | 同一 URL `/biaoqing` 被访问 3 次，模型未察觉 | prompt 缺少 URL 去重感知 |

### 修复

| # | 文件 | 改动 |
|---|---|---|
| 2 | `agent/tools/chrome/mcp-client.ts` | "already running" → 加 `--isolated` 重启 MCP client（而非 pkill 用户进程） |
| 3 | `agent/tools/browser/execute.ts`<br>`agent/tools/fetch/execute.ts` | `navigateWithRetry` helper，仅对超时错误重试 1 次（阈值 1.5x），失败附 `(已自动重试 1 次)` |
| 4 | `agent/tools/browser/execute.ts` | scroll 前后取 4000 字符 innerText 快照，length delta <20 且首尾 200 字相同 → result 末尾追加 `⚠️ 滚动后页面内容未变化（可能已到底部或懒加载未触发）` |
| 5 | `agent/desktop/planner.ts`<br>`agent/desktop/agent.ts` | 新增 `progressive` 策略并设为默认：先单跑 primary，4s 仍 thinking 才唤醒其余 race；primary 提前 fail → 立即 fallback race |
| 6 | `agent/core/runtime.ts` | `quality.degraded` 时在 answer 前置 ⚠️ 警告条（覆盖 degraded + unverified 两种） |
| 7 | `agent/core/runtime.ts`<br>`agent/desktop/agent.ts` | step 1 永远不跳过 observe（`lastAction = null` 短路）；`shouldObserve` 白名单移除 `chrome` |
| 8 | `agent/core/prompts.ts` | `buildRecentUrlsHint`：最近 5 步 browser/chrome URL 计数注入 user message；访问 ≥2 次显式标记【已访问 N 次，避免重复】 |

## Commit 2: 可操作的错误消息 (ef38479)

### 问题

基于 trace `run_mp7ztm7o_nqrsmh`（22 步，本应 5 步完成）：
- Step 5: `open_app Chrome` → error -54 (沙箱)，模型无指引
- Step 6/11: navigate `file:///` → "hostname not found"，模型重试 2 次
- Step 7: `python3 -m http.server &` → 超时，模型不知原因

step 4 写完 HTML 文件后，模型花了 18 步尝试展示它，因为错误消息不可操作。

### 修复

| 文件 | 改动 |
|---|---|
| `agent/tools/browser/execute.ts` | 拦截 `file://` URL，返回建议使用 `notify_user` 或 `terminal open` 命令 |
| `agent/tools/macos/execute.ts` | 捕获 `open_app` 错误，特别识别沙箱 error -54，建议 `notify_user` 或 `terminal` 替代 |
| `agent/tools/terminal/run.ts` | 超时时检测后台/服务命令（`&` 结尾或包含 server/daemon/serve），追加长驻进程提示 |

## Commit 3: Rollback 修复 (ce18a28)

### 问题

1. `fromCheckpoint` rollback 创建新 runId → trace 不连续
2. runtime rollback 设置 `step = targetStep - 1` 而非 `snapshot.step` → 如果 snapshot 是 step 4 但 targetStep = 6，step 变成 5，跳过 step 5 的 observe 阶段（多步 rollback bug）

### 修复

| 文件 | 改动 |
|---|---|
| `routes/agent-run-start.ts` | 传递 `fromCheckpoint.runId` 作为 `existingRunId` 给 `createRun`，复用原 runId 保持 trace 连续 |
| `agent/core/runtime.ts` | 加载快照后设置 `step = snapshot.step`（而非 `targetStep - 1`），确保从精确的 checkpoint 步骤恢复 |

## 验证

- `npm run typecheck` ✅
- Fix #8 已用模拟 history 验证 hint 正确生成（`/biaoqing` 标记为访问 2 次）

## 注意事项

- `progressive` 现为新默认 strategy，原 `race` / `vote` 模式保留
- chrome `_addIsolatedFlag` 持久化到 `config.args`，后续调用复用 isolated 实例，不会每次重启
- recentUrlsHint 只注入 LLM prompt，前端 trace 暂不可见（如需展示可在 step.observe 事件附加字段，本 PR 未做）

## Commit 4, 5

## Summary

- Add hard guards to prevent the agent from using Google, Baidu, or Bing search result pages as web-search entry points.
- Improve browser and Chrome MCP handling so search-engine navigation is blocked before wasting browser or MCP work.
- Improve `parallel_fetch` so it shares blocked-page detection and supports link extraction.
- Fix runtime history URL recording so quality checks use the action target URL instead of the previous observation URL.
- Expand result-quality failure detection for WAF, CAPTCHA, slider verification, and blocked search-engine pages.

## Why

A trace analysis of `run_mp97r3sc_o0tz2b` showed the agent spent several steps on search-engine and anti-bot dead ends before eventually finding useful content from a direct target page. The previous history URL recording also caused source-quality checks to misattribute fetched content to the wrong URL.

## Validation

- `npm run typecheck`
- `npm test -- result-quality session-checkpoint chrome-tools`
- `npm test`
