### PR TITLE
feat(search): 新增 web_search 工具（DuckDuckGo lite，无 key）

### DIFF
--- a/agent/chat/chat-tool-executor.ts
+++ b/agent/chat/chat-tool-executor.ts
@@ -13,6 +13,7 @@
  */
 
 import { executeFsAction } from '../tools/fs/execute.ts';
+import { executeSearchAction } from '../tools/search/execute.ts';
 import { executeTerminalAction } from '../tools/terminal/run.ts';
 
 export async function executeChatTool(name, input) {
@@ -29,6 +30,9 @@ export async function executeChatTool(name, input) {
   }
   if (name === 'run_safe') {
     return truncate(await executeTerminalAction({ tool: 'terminal', type: 'run_safe', ...input }), MAX_RESULT);
+  }
+  if (name === 'web_search') {
+    return truncate(await executeSearchAction({ tool: 'search', type: 'web_search', ...input }), MAX_RESULT);
   }
   throw new Error(`Chat 模式不支持工具: ${name}`);
 }

--- a/agent/chat/chat-tools.ts
+++ b/agent/chat/chat-tools.ts
@@ -6,7 +6,7 @@
 
 import { createModelTools } from '../core/tool-definitions.ts';
 
-const CHAT_TOOL_NAMES = new Set(['search_files', 'read_file', 'list_dir', 'run_safe']);
+const CHAT_TOOL_NAMES = new Set(['search_files', 'read_file', 'list_dir', 'run_safe', 'web_search']);
 
 export function createChatTools() {
   return createModelTools().filter(t => CHAT_TOOL_NAMES.has(t.name));

--- a/agent/core/action-types.ts
+++ b/agent/core/action-types.ts
@@ -19,6 +19,8 @@ export const ACTION_TYPE_TO_TOOL = {
   get_page_content: 'browser',
   http_fetch: 'browser',
   parallel_fetch: 'browser',
+  // search
+  web_search: 'search',
   // fs
   list_dir: 'fs',
   read_file: 'fs',

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -40,7 +40,7 @@ export function buildDesktopAgentSystemPrompt(systemPrompt: string | null) {
     '3. 文件写入、终端确认命令、桌面键鼠输入可能需要用户批准，被拒绝后请尝试替代方案。',
     '4. cd/pushd/popd 等目录切换命令使用 run_review，需要用户审批。',
     '5. answer 用简体中文，简洁直接。',
-    '6. 禁止使用 Google、百度、Bing 等搜索引擎网站搜索信息，这些网站会触发反爬机制导致任务失败。需要获取网页内容时使用 navigate 或 http_fetch 打开目标页面。',
+    '6. 需要全网搜索关键词时，优先使用 web_search（DuckDuckGo，返回标题/URL/摘要），再用 http_fetch 抓具体页面。禁止直接 navigate 到 Google/Bing/百度搜索结果页，这些页面会触发反爬。',
     '7. 需要用户输入或确认偏好时使用 ask_user，不要自行假设。',
     '8. 执行中发现重要信息或潜在问题时使用 notify_user 主动告知用户。',
     '9. 涉及医保、社保、签证、贷款、股票、基金、汇率、法律、法规、政策、许可、合规等高风险或合规性信息时，必须优先从官方来源核验；如果未能核验，finish 答案必须明确说明“未能完成官方核验”，不要把记忆或常识包装成已确认结论。',
@@ -136,6 +136,7 @@ export function buildNvidiaTaskMessages({
         '{"rationale":"抓取网页内容","action":{"tool":"browser","type":"http_fetch","url":"https://example.com"}}',
         '{"rationale":"搜索并提取链接","action":{"tool":"browser","type":"http_fetch","url":"https://example.com/search?q=关键词","extractLinks":true}}',
         '{"rational":"并发抓取多个页面","action":{"tool":"browser","type":"parallel_fetch","urls":["https://example.com/a","https://example.com/b"]}}',
+        '{"rationale":"网络搜索关键词","action":{"tool":"search","type":"web_search","query":"2026 北京最低工资标准"}}',
         ...(ideEnabled
           ? [
               '{"rationale":"查看 IDE 可用工具","action":{"tool":"ide","type":"ide_list_tools"}}',
@@ -158,7 +159,7 @@ export function buildNvidiaTaskMessages({
         '3. 文件写入、终端确认命令、桌面键鼠输入可能需要用户批准，被拒绝后请尝试替代方案。',
         '4. cd/pushd/popd 等目录切换命令使用 run_review，会触发用户审批。',
         '5. answer 用简体中文，简洁直接。',
-        '6. 禁止使用 Google、百度、Bing 等搜索引擎网站搜索信息，这些网站会触发反爬机制导致任务失败。需要获取网页内容时使用 http_fetch 或 navigate 打开目标页面。',
+        '6. 需要全网搜索关键词时，优先使用 web_search（DuckDuckGo，返回标题/URL/摘要），再用 http_fetch 抓具体页面。禁止直接 navigate 到 Google/Bing/百度搜索结果页。',
         '7. http_fetch 和 navigate 都通过浏览器执行，可以处理需要 JS 渲染的页面。',
         '8. 需要同时获取多个页面时，使用 parallel_fetch 并发抓取（最多5个URL）。',
         '9. 需要用户输入或确认偏好时使用 ask_user。',

--- a/agent/core/schemas.ts
+++ b/agent/core/schemas.ts
@@ -124,6 +124,22 @@ function normalizeBrowserAction(type, action) {
   throw new Error(`不支持的浏览器动作: ${type}`);
 }
 
+function normalizeSearchAction(type, action) {
+  if (type === 'web_search') {
+    const query = typeof action.query === 'string' ? action.query.trim() : '';
+    if (!query) throw new Error('web_search 缺少 query');
+    return {
+      tool: 'search',
+      type,
+      query,
+      maxResults: Number.isFinite(Number(action.maxResults))
+        ? Math.min(Math.max(Number(action.maxResults), 1), 10)
+        : 5,
+    };
+  }
+  throw new Error(`不支持的搜索动作: ${type}`);
+}
+
 function normalizeFsAction(type, action) {
   if (type === 'list_dir') {
     return {
@@ -333,6 +349,8 @@ export function normalizeDesktopAgentDecision(payload) {
     normalizedAction = normalizeBrowserAction(type, action);
   } else if (tool === 'fs') {
     normalizedAction = normalizeFsAction(type, action);
+  } else if (tool === 'search') {
+    normalizedAction = normalizeSearchAction(type, action);
   } else if (tool === 'terminal') {
     normalizedAction = normalizeTerminalAction(type, action);
   } else if (tool === 'macos') {

--- a/agent/core/tool-definitions.ts
+++ b/agent/core/tool-definitions.ts
@@ -136,6 +136,18 @@ export function createModelTools() {
       },
     },
     {
+      name: 'web_search',
+      description: '用 DuckDuckGo 搜索网络（无需 API key），返回标题/URL/摘要列表。优先用它定位资料，再用 http_fetch 抓取具体页面。比直接打开 Google/Bing 更稳，不会触发反爬。',
+      input_schema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: '搜索关键词（自然语言）' },
+          maxResults: { type: 'number', description: '返回结果数（1-10，默认 5）' },
+        },
+        required: ['query'],
+      },
+    },
+    {
       name: 'search_files',
       description: '在文件中搜索文本内容（类似 grep），支持 glob 过滤',
       input_schema: {

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -32,6 +32,7 @@ import { runAgentRuntime } from '../core/runtime.ts';
 import { createAgentAuthorizer } from '../policy/approvals.ts';
 import { executeBrowserAction } from '../tools/browser/execute.ts';
 import { executeFsAction } from '../tools/fs/execute.ts';
+import { executeSearchAction } from '../tools/search/execute.ts';
 import { createDomainRules } from '../tools/fetch/domain-rules.ts';
 import { executeIdeAction } from '../tools/ide/execute.ts';
 import { executeChromeAction } from '../tools/chrome/execute.ts';
@@ -81,6 +82,7 @@ export function createDesktopAgentRunner({
         return executeBrowserAction(session.view, action);
       },
       fs: async (_state, action) => executeFsAction(action),
+      search: async (_state, action) => executeSearchAction(action),
       ide: async (_state, action) => executeIdeAction(action),
       chrome: async (_state, action) => executeChromeAction(action),
       terminal: async (_state, action) => executeTerminalAction(action),

--- a/agent/policy/classify.ts
+++ b/agent/policy/classify.ts
@@ -112,6 +112,13 @@ export function classifyAgentAction(action) {
     };
   }
 
+  if (tool === 'search' && type === 'web_search') {
+    return {
+      level: 'safe',
+      reason: '只读网络搜索（DuckDuckGo）',
+    };
+  }
+
   if (tool === 'fs' && ['list_dir', 'read_file', 'search_files'].includes(type)) {
     return {
       level: 'safe',

--- a/agent/tools/search/execute.ts
+++ b/agent/tools/search/execute.ts
@@ -1,0 +1,149 @@
+/**
+ * Search Tool — 通过 DuckDuckGo lite HTML 端点做无 key 搜索
+ *
+ * 不走浏览器（避免反爬验证页），直接 HTTP GET 拉取 https://lite.duckduckgo.com/lite/
+ * 解析其中 .result-link / .result-snippet 节点，
+ * 返回 title + url + snippet 的纯文本列表给 LLM。
+ *
+ * 不需要 API key、无明显限流。失败时返回错误说明，由上层 router 转换为 observation。
+ */
+
+const ENDPOINT = 'https://lite.duckduckgo.com/lite/';
+const REQUEST_TIMEOUT_MS = 12000;
+const DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36';
+
+function decodeEntities(text) {
+  return String(text || '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, '/')
+    .replace(/&#(\d+);/g, (_, code) => {
+      const n = Number(code);
+      return Number.isFinite(n) ? String.fromCharCode(n) : '';
+    });
+}
+
+function stripTags(html) {
+  return decodeEntities(String(html || '').replace(/<[^>]+>/g, '')).replace(/\s+/g, ' ').trim();
+}
+
+// DuckDuckGo 把真实链接包装成 //duckduckgo.com/l/?uddg=ENCODED&rut=...，需要解包。
+function unwrapDdgRedirect(href) {
+  if (!href) return '';
+  let url = href;
+  if (url.startsWith('//')) url = 'https:' + url;
+  try {
+    const parsed = new URL(url, ENDPOINT);
+    if (/(^|\.)duckduckgo\.com$/i.test(parsed.hostname) && parsed.pathname === '/l/') {
+      const uddg = parsed.searchParams.get('uddg');
+      if (uddg) return decodeURIComponent(uddg);
+    }
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+// lite 端点的每条结果由三行 <tr> 组成：标题链接、snippet、显示用 URL。
+// 解析方式：先按 class='result-link' 找标题 <a>，然后向后查同结果块内的 result-snippet。
+function parseResults(html, maxResults) {
+  const results: Array<{ title: string; url: string; snippet: string }> = [];
+  // 属性顺序不可控（href 可能在 class 前后），用 [^>]* 兜底；分别用 href / class 两条信息回锁。
+  const anchorRe = /<a\b([^>]*)>([\s\S]*?)<\/a>/g;
+  const hrefRe = /href=['"]([^'"]+)['"]/i;
+  const classRe = /class=['"]([^'"]*)['"]/i;
+  const snippetRe = /<td[^>]+class=['"]result-snippet['"][^>]*>([\s\S]*?)<\/td>/g;
+
+  const links: Array<{ url: string; title: string; index: number }> = [];
+  let m;
+  while ((m = anchorRe.exec(html)) !== null) {
+    const attrs = m[1];
+    const cls = classRe.exec(attrs)?.[1] || '';
+    if (!/\bresult-link\b/.test(cls)) continue;
+    const href = hrefRe.exec(attrs)?.[1] || '';
+    if (!href) continue;
+    links.push({ url: unwrapDdgRedirect(href), title: stripTags(m[2]), index: m.index });
+  }
+  const snippets: Array<{ text: string; index: number }> = [];
+  while ((m = snippetRe.exec(html)) !== null) {
+    snippets.push({ text: stripTags(m[1]), index: m.index });
+  }
+
+  // 对每个 link，找紧随其后的第一个 snippet（同一结果块）。
+  for (const link of links) {
+    if (results.length >= maxResults) break;
+    if (!link.url || !link.title) continue;
+    const followingSnippet = snippets.find(s => s.index > link.index);
+    const nextLink = links.find(l => l.index > link.index);
+    let snippet = '';
+    if (followingSnippet && (!nextLink || followingSnippet.index < nextLink.index)) {
+      snippet = followingSnippet.text;
+    }
+    results.push({ title: link.title, url: link.url, snippet });
+  }
+  return results;
+}
+
+function formatResults(query, results) {
+  if (results.length === 0) {
+    return `web_search 未找到 "${query}" 的结果。可能是查询过于冷门或 DuckDuckGo 临时无返回，可换关键词或改用 http_fetch 直接抓目标站点。`;
+  }
+  const lines = results.map((item, index) => {
+    const head = `${index + 1}. ${item.title}`;
+    const url = `   URL: ${item.url}`;
+    const snip = item.snippet ? `   摘要: ${item.snippet}` : '';
+    return [head, url, snip].filter(Boolean).join('\n');
+  });
+  return `web_search 结果（query="${query}", count=${results.length}）:\n${lines.join('\n\n')}`;
+}
+
+async function fetchHtml(query) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const url = ENDPOINT + '?' + new URLSearchParams({ q: query, kl: 'wt-wt' }).toString();
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'User-Agent': DEFAULT_USER_AGENT,
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Language': 'en-US,en;q=0.9,zh;q=0.8',
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`);
+    }
+    return await response.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function executeSearchAction(action) {
+  const query = typeof action?.query === 'string' ? action.query.trim() : '';
+  if (!query) {
+    return 'web_search 失败：query 为空';
+  }
+  const maxResults = Number.isFinite(Number(action?.maxResults))
+    ? Math.min(Math.max(Number(action.maxResults), 1), 10)
+    : 5;
+
+  try {
+    const html = await fetchHtml(query);
+    if (html.includes('anomaly-modal') || html.includes('challenge-form')) {
+      return 'web_search 失败：DuckDuckGo 触发反爬验证。请稍后重试或改用 http_fetch 直接抓取目标站点。';
+    }
+    const results = parseResults(html, maxResults);
+    return formatResults(query, results);
+  } catch (err: any) {
+    const msg = err?.message || String(err);
+    return `web_search 失败：${msg}。建议改用 http_fetch 直接抓取目标站点，或检查网络。`;
+  }
+}


### PR DESCRIPTION
Closes #10

## Summary
- 新增 `agent/tools/search/execute.ts`：调用 `https://lite.duckduckgo.com/lite/`（GET，无 API key，无明显限流），解析 `result-link` / `result-snippet` 节点并解包 `/l/?uddg=…` 重定向，返回 `title / url / snippet` 列表给 LLM。
- 把 `web_search` 接入完整工具链路：`tool-definitions` / `action-types` / `schemas` / `desktop/agent` router / `policy/classify`（标记为 safe）。
- `prompts.ts` 加示例，并把"禁用所有搜索引擎"规则改写为"优先使用 web_search，禁止直接 navigate 到 Google/Bing/百度搜索结果页"。
- Chat 模式（`chat-tools` / `chat-tool-executor`）同步暴露 `web_search`。

## Why
之前 Agent / Chat 模式都没有原生搜索能力，必须靠 navigate 到 Google/Bing 搜索结果页（频繁触发反爬验证）或让模型瞎拼 URL，成本高且不稳定。DuckDuckGo lite 端点无需 key、纯 HTML、解析量小（~50 行），是性价比最高的入口。

## Test plan
- [x] `npm run typecheck` 通过
- [x] `npm run lint` 通过
- [x] 中文查询实搜：`"2026 上海最低工资标准"` 返回 4 条结构化结果（含官方人社局通知）
- [x] 英文查询实搜：`"TypeScript release notes"` 返回 3 条结构化结果
- [ ] Agent 端到端：在前端发起一条需要搜索的任务（如"最近 OpenAI 有什么新闻"），确认模型会调用 `web_search` 并基于结果继续 `http_fetch`
- [ ] Chat 模式：开启 Chat 工具调用，确认 `web_search` 出现在可用工具列表中
- [ ] 反爬兜底：若 DuckDuckGo 临时返回 anomaly 页，确认错误信息正确回流到 observation

## Notes
- DuckDuckGo HTML 端点（`html.duckduckgo.com/html/` 的 POST）会触发 anomaly challenge，所以选用了 lite 端点的 GET 方式。
- 单个查询最多返回 10 条；默认 5 条；snippet 抓取最近的 `result-snippet td`。