### PR TITLE
fix(runtime): parallel_fetch 多页结果不再被历史截断削到只剩第一页

### DIFF
--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -15,9 +15,10 @@
  * 历史截断 / Progressive history truncation：
  *   compressHistory() 发给 LLM 前截断历史，防止上下文超限：
  *   - 保留最近 AGENT_MAX_HISTORY_STEPS（默认 20）步
- *   - 渐进截断 result：最近 3 步保留最多 1000 字符，4-10 步 500 字符，11+ 步 200 字符
+ *   - 渐进截断 result：最近 3 步保留最多 MAX_RESULT_CHARS 字符，4-10 步 2500 字符，11+ 步 1000 字符
+ *   - parallel_fetch 把 N 个页面拼成单步 result，按 URL 数放大该步预算（封顶 MAX_PARALLEL_RESULT_CHARS），避免多页结果被截到只剩第一页
  *   - 超出步数压缩为一行摘要
- *   - 可通过 .env 的 AGENT_MAX_HISTORY_STEPS / AGENT_MAX_RESULT_CHARS 配置
+ *   - 可通过 .env 的 AGENT_MAX_HISTORY_STEPS / AGENT_MAX_RESULT_CHARS / AGENT_MAX_PARALLEL_RESULT_CHARS 配置
  *
  * 调用场景：
  *   - agent/desktop/agent.js 的 runDesktopAgent() 是唯一的调用方，
@@ -37,7 +38,9 @@ import {
 import { assessResultQuality } from "./result-quality.ts";
 
 const MAX_HISTORY_STEPS = Number(process.env.AGENT_MAX_HISTORY_STEPS || 20);
-const MAX_RESULT_CHARS = Number(process.env.AGENT_MAX_RESULT_CHARS || 5000);
+const MAX_RESULT_CHARS = Number(process.env.AGENT_MAX_RESULT_CHARS || 8000);
+// parallel_fetch 把多个页面拼成单步 result，按 URL 数放大该步预算，封顶此值，避免被截到只剩第一页
+const MAX_PARALLEL_RESULT_CHARS = Number(process.env.AGENT_MAX_PARALLEL_RESULT_CHARS || 32000);
 
 function actionTargetUrl(action) {
   if (typeof action?.url === 'string' && action.url) return action.url;
@@ -49,9 +52,15 @@ function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
   // Progressive truncation: recent steps keep more context, old steps get shorter results
   const truncateEntry = (h, remaining) => {
     // Last 3 steps: full (up to MAX_RESULT_CHARS)
-    // Steps 4-10: 500 chars
-    // Steps 11+: 200 chars
-    const limit = remaining <= 3 ? MAX_RESULT_CHARS : remaining <= 10 ? 2500 : 1000;
+    // Steps 4-10: 2500 chars
+    // Steps 11+: 1000 chars
+    let limit = remaining <= 3 ? MAX_RESULT_CHARS : remaining <= 10 ? 2500 : 1000;
+    // parallel_fetch 把 N 个页面拼成单步 result，按 URL 数放大该步预算（封顶），
+    // 否则多页抓取会被截到只剩第一页
+    const urlCount = Array.isArray(h.action?.urls) ? h.action.urls.length : 0;
+    if (h.action?.type === 'parallel_fetch' && urlCount > 1) {
+      limit = Math.min(limit * urlCount, MAX_PARALLEL_RESULT_CHARS);
+    }
     const str = h.result == null ? '' : String(h.result);
     if (str.length <= limit) return h;
     return { ...h, result: str.slice(0, limit) + '…[truncated]' };


### PR DESCRIPTION
## 背景

排查任务 `run_mpruejvs_gr2cw2`（并行抓取 4 只基金页面做对比）时发现：模型最终只输出了第一只基金（270023）的完整数据，其余 3 只显示"需进一步查看"，并误报"parallel_fetch 返回内容被截断"。

## 根因

`parallel_fetch` 把 N 个页面抓取结果用 `---` 拼成**单步** result（本例 4 页共 22498 字符，4 段数据均完整、fetch 层无截断）。但 `compressHistory()`（`agent/core/runtime.ts`）发给 LLM 前对每步 result 统一按 `MAX_RESULT_CHARS = 5000` 截断——单页(段1=5545)就已超 5000，后 3 页根本没进入模型上下文。模型无从得知是 history 压缩层削的，故误归因为"被截断"。

fetch 层 24000 的预算在这里用不上，且抓得越多被丢得越多。

## 改动（`agent/core/runtime.ts`）

- `MAX_RESULT_CHARS` 5000 → 8000
- `parallel_fetch` 步骤按 URL 数放大该步截断预算，封顶新常量 `MAX_PARALLEL_RESULT_CHARS = 32000`：`limit = min(limit * urlCount, 32000)`
- 三个阈值均可经 `.env` 覆盖（`AGENT_MAX_RESULT_CHARS` / `AGENT_MAX_PARALLEL_RESULT_CHARS` / `AGENT_MAX_HISTORY_STEPS`）
- 同步修正文件头部与函数内已与代码脱节的过时注释（原写 1000/500/200，实际为 5000/2500/1000）

对该 case：`8000 × 4 = 32000`（命中封顶）≥ 22498，4 段全部进入上下文，模型可输出全部 4 只基金。

## 权衡

多页抓取这一步的 prompt 体积会增大（封顶约 1.5–2 万 token）。对"抓 4–5 页做对比"是合适的；若后续出现单任务连续多次 parallel_fetch，可下调封顶或让旧的 parallel_fetch 步骤随步龄衰减。

## 测试

- [x] `npm run typecheck` 通过
- [ ] 复跑同类多页抓取任务，确认 4 只基金数据齐全