### PR TITLE
feat(models): 模型列表动态拉取 + baseURL 可配置 + 字符串响应修复

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,15 @@
 # ─── API Keys ──────────────────────────────────────────────
 NVIDIA_API_KEY=nvapi-...
+# OpenAI 兼容接口地址，留空则默认 NVIDIA（https://integrate.api.nvidia.com/v1）
+# NVIDIA_BASE_URL=https://
 
 # ─── Server ───────────────────────────────────────────────
 PORT=3001
 # HOST=0.0.0.0
 
 # ─── Models ───────────────────────────────────────────────
-# 逗号分隔，不填则根据 API Key 自动选择默认模型
-#   NVIDIA: z-ai/glm-5.1, deepseek-ai/deepseek-v4-pro
-MODELS=deepseek-ai/deepseek-v4-flash
+# 模型列表在启动时从供应商接口（/v1/models）自动拉取，无需手动配置。
+# MODELS 已废弃（保留仅为兼容），不再生效。
 
 
 # ─── Agent ────────────────────────────────────────────────

--- a/agent/core/ai-client.ts
+++ b/agent/core/ai-client.ts
@@ -5,8 +5,8 @@
  * 职责 / Responsibilities:
  *   1. 管理 OpenAI (NVIDIA) 和 Anthropic (Claude) 两套 SDK 客户端
  *      Manage OpenAI (NVIDIA) and Anthropic (Claude) SDK clients
- *   2. 从环境变量加载模型配置（MODELS, AGENT_MULTI_MODELS）
- *      Load model configuration from env vars (MODELS, AGENT_MULTI_MODELS)
+ *   2. 从供应商接口（/v1/models）加载可用模型列表
+ *      Load available models from provider APIs (/v1/models)
  *   3. 提供 Claude 专用的 claudeAgentPlan() — 通过 Anthropic SDK 原生 tool_use 调用
  *      Claude-specific planning via Anthropic SDK native tool_use
  *   4. 提供 summarizeText() — 用于记忆压缩的 LLM 文本摘要
@@ -24,24 +24,44 @@
 import OpenAI from 'openai';
 import Anthropic from '@anthropic-ai/sdk';
 import { logLlmRequest, logLlmResponse } from './llm-logger.ts';
+import { log } from '../../helpers/logger.ts';
 import { retryAsync } from '../../helpers/retry.ts';
 import { createModelTools, toolToClaudeTool } from './tool-definitions.ts';
 
 export { createModelTools } from './tool-definitions.ts';
 
-export function loadModelConfig() {
-  const envModels = process.env.MODELS;
-  if (typeof envModels === 'string' && envModels.trim()) {
-    const ids = envModels.split(',').map(s => s.trim()).filter(Boolean);
-    const hasAnthropicKey = Boolean(process.env.ANTHROPIC_API_KEY);
-    const onlyAnthropic = hasAnthropicKey && !process.env.NVIDIA_API_KEY;
-    return ids.map(id => ({
-      id,
-      label: id,
-      provider: id.startsWith('claude-') || onlyAnthropic ? 'anthropic' : 'nvidia',
-    }));
+export async function loadModelConfig({ openai_client, anthropic_client }: any = {}) {
+  const models = [];
+
+  // OpenAI 兼容供应商：从 /v1/models 拉取
+  if (openai_client) {
+    try {
+      const list = await openai_client.models.list();
+      for (const m of list.data || []) {
+        if (m?.id) models.push({ id: m.id, label: m.id, provider: 'nvidia' });
+      }
+    } catch (err) {
+      log.warn(`[Models] 拉取 OpenAI 兼容模型列表失败: ${err?.message || err}`);
+    }
   }
-  if (process.env.ANTHROPIC_API_KEY && !process.env.NVIDIA_API_KEY) {
+
+  // Anthropic：从 /v1/models 拉取
+  if (anthropic_client) {
+    try {
+      const list = await anthropic_client.models.list();
+      for (const m of list.data || []) {
+        if (m?.id) models.push({ id: m.id, label: m.display_name || m.id, provider: 'anthropic' });
+      }
+    } catch (err) {
+      log.warn(`[Models] 拉取 Anthropic 模型列表失败: ${err?.message || err}`);
+    }
+  }
+
+  if (models.length > 0) return models;
+
+  // 接口拉取失败时的兜底，保证服务仍能启动
+  log.warn('[Models] 未能从供应商接口获取任何模型，使用兜底默认值');
+  if (anthropic_client && !openai_client) {
     return [{ id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', provider: 'anthropic' }];
   }
   return [{ id: 'minimaxai/minimax-m2.7', label: 'MiniMax M2.7', provider: 'nvidia' }];
@@ -67,7 +87,7 @@ export function createClients() {
   const anthropicKey = process.env.ANTHROPIC_API_KEY;
 
   const openai_client = nvidiaKey
-    ? new OpenAI({ apiKey: nvidiaKey, baseURL: 'https://integrate.api.nvidia.com/v1', maxRetries: 0 })
+    ? new OpenAI({ apiKey: nvidiaKey, baseURL: process.env.NVIDIA_BASE_URL || 'https://integrate.api.nvidia.com/v1', maxRetries: 0 })
     : null;
 
   const anthropic_client = anthropicKey

--- a/agent/core/nvidia-response-parsers.ts
+++ b/agent/core/nvidia-response-parsers.ts
@@ -319,9 +319,20 @@ export function createModelResponseParser(model) {
   const extractReasoning = config.extractReasoning || false;
 
   return function parseResponse(response) {
-    const message = response.choices[0]?.message;
+    // 个别 OpenAI 兼容供应商的部分模型返回的响应体
+    // Content-Type 不是 application/json，SDK 未能解析成对象，整个 body 原样作为字符串返回。
+    // 这里兜底把字符串还原成对象，避免 response.choices 读到 undefined 而崩溃。
+    if (typeof response === 'string') {
+      try {
+        response = JSON.parse(response);
+      } catch {
+        return { parseFailed: true, rawContent: response, usage: null, reasoning: null };
+      }
+    }
+
+    const message = response?.choices?.[0]?.message;
     const content = getMessageText(message?.content);
-    const usage = response.usage || null;
+    const usage = response?.usage || null;
     const reasoning = extractReasoning
       ? (message?.reasoning || message?.reasoning_content || null)
       : null;

--- a/agent/core/summarizer.ts
+++ b/agent/core/summarizer.ts
@@ -46,7 +46,7 @@ ${text}`;
         temperature: 0.1,
         max_tokens: 800,
       }));
-      result = resp.choices[0]?.message?.content || text.slice(0, 300);
+      result = resp?.choices?.[0]?.message?.content || text.slice(0, 300);
     } else {
       result = text.slice(0, 300);
     }

--- a/server.ts
+++ b/server.ts
@@ -57,7 +57,7 @@ app.use(cors());
 app.use(express.json({ limit: '25mb' }));
 
 const { openai_client, anthropic_client } = createClients();
-const modelConfig = loadModelConfig();
+const modelConfig = await loadModelConfig({ openai_client, anthropic_client });
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MEMORY_DIR = path.resolve(__dirname, process.env.MEMORY_DIR || 'data');


### PR DESCRIPTION
## Summary
- **baseURL 可配置**：新增 `NVIDIA_BASE_URL` 环境变量，支持自定义 OpenAI 兼容接口地址，留空则默认 NVIDIA 官方地址
- **模型列表动态化**：`loadModelConfig` 改为 async，启动时从供应商 `/v1/models` 接口拉取可用模型（OpenAI 兼容 + Anthropic 两条链路），不再依赖写死的 `MODELS`；接口失败有兜底默认值保证服务可启动
- **修复字符串响应崩溃**：部分供应商的某些模型返回的 HTTP body Content-Type 非 `application/json`，OpenAI SDK 不解析成对象、整个响应原样作为字符串返回，导致 `response.choices[0]` 抛 `undefined is not an object`。在解析层入口兜底 `JSON.parse` 还原，并对 `.choices?.[0]` 加可选链（`nvidia-response-parsers.ts` + `summarizer.ts`）

## 说明
- 前端无需改动：`/api/models` 接口契约不变，`App.jsx` 本就动态拉取并渲染
- `.env.example` 已更新：标注 `MODELS` 废弃、新增 `NVIDIA_BASE_URL` 注释
- `.env`（含 key）在 .gitignore 中，未纳入本 PR

## Test plan
- [x] `npm run typecheck` 通过
- [x] 实跑 `loadModelConfig` 成功从供应商接口拉到真实模型列表
- [x] 用真实崩溃响应（字符串体）验证解析器：不再报错，正确解析出 action 与子任务
- [ ] 重启服务确认启动 banner 的 Models 行显示接口拉取结果
- [ ] 前端下拉模型列表正常显示并可切换