### PR TITLE
feat(models): 过滤非对话模型 + 模型选择器支持搜索

### DIFF
--- a/agent/core/ai-client.ts
+++ b/agent/core/ai-client.ts
@@ -30,6 +30,15 @@ import { createModelTools, toolToClaudeTool } from './tool-definitions.ts';
 
 export { createModelTools } from './tool-definitions.ts';
 
+// 过滤掉不适合做 agent 决策的模型：向量/重排、视觉/OCR、纯代码补全、内容安全护栏等。
+// 这类模型在供应商接口里和对话模型混在一起，全塞进前端下拉会很难选。
+const NON_CHAT_MODEL_RE =
+  /embed|rerank|retriever|bge-|arctic-embed|nvclip|fuyu|deplot|vila|neva|kosmos|ocr|paddle|-vision|vision-|-vl-|codegemma|starcoder|codellama|-coder|coder-|guard|safety|topic-control/i;
+
+function isChatCapableModel(id: string) {
+  return !NON_CHAT_MODEL_RE.test(id);
+}
+
 export async function loadModelConfig({ openai_client, anthropic_client }: any = {}) {
   const models = [];
 
@@ -38,7 +47,9 @@ export async function loadModelConfig({ openai_client, anthropic_client }: any =
     try {
       const list = await openai_client.models.list();
       for (const m of list.data || []) {
-        if (m?.id) models.push({ id: m.id, label: m.id, provider: 'nvidia' });
+        if (m?.id && isChatCapableModel(m.id)) {
+          models.push({ id: m.id, label: m.id, provider: 'nvidia' });
+        }
       }
     } catch (err) {
       log.warn(`[Models] 拉取 OpenAI 兼容模型列表失败: ${err?.message || err}`);

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -910,11 +910,137 @@ select,
   cursor: not-allowed;
 }
 
+/* ── chat 模式：可搜索下拉 ── */
+.model-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.model-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 34px;
+  padding: 0 8px;
+  max-width: 170px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  font-size: var(--f-sm);
+  color: var(--c-text);
+  cursor: pointer;
+  outline: none;
+}
+
+.model-dropdown-trigger:hover:not(:disabled) {
+  border-color: var(--c-primary);
+}
+
+.model-dropdown-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.model-dropdown-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-dropdown-panel {
+  position: absolute;
+  z-index: 50;
+  bottom: calc(100% + 4px);
+  left: 0;
+  width: 260px;
+  max-width: 80vw;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-md);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+.model-dropdown-search,
+.model-tags-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--c-border);
+  color: var(--c-text-muted);
+}
+
+.model-tags-search {
+  border: 1px solid var(--c-border-input);
+  border-radius: var(--r-sm);
+  margin-bottom: 8px;
+  background: var(--c-surface);
+}
+
+.model-dropdown-search input,
+.model-tags-search input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: var(--f-sm);
+  color: var(--c-text);
+  min-width: 0;
+}
+
+.model-dropdown-list {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+.model-dropdown-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 9px;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  font-size: var(--f-sm);
+  color: var(--c-text);
+  cursor: pointer;
+  text-align: left;
+}
+
+.model-dropdown-option:hover {
+  background: var(--c-surface-dim);
+}
+
+.model-dropdown-option.selected {
+  color: var(--c-primary);
+  font-weight: 600;
+}
+
+.model-dropdown-option-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-dropdown-empty,
+.model-tags-empty {
+  padding: 12px;
+  font-size: var(--f-sm);
+  color: var(--c-text-muted);
+  text-align: center;
+}
+
 .model-tags {
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
   align-items: center;
+  max-height: 160px;
+  overflow-y: auto;
 }
 
 .model-tag-wrapper {

--- a/client/src/components/ModelSelector.jsx
+++ b/client/src/components/ModelSelector.jsx
@@ -1,7 +1,92 @@
-import { ChevronDown, ChevronUp } from 'lucide-react';
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { ChevronDown, ChevronUp, Search, Check } from 'lucide-react';
+
+function filterModels(models, query) {
+  const q = query.trim().toLowerCase();
+  if (!q) return models;
+  return models.filter(m =>
+    m.id.toLowerCase().includes(q) || (m.label && m.label.toLowerCase().includes(q))
+  );
+}
+
+// chat 模式：可搜索的下拉。供应商接口可能返回上百个模型，原生 <select> 没法选，
+// 这里做成「点击展开 → 输入过滤 → 点选」的浮层。
+function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLocked }) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const wrapRef = useRef(null);
+  const inputRef = useRef(null);
+
+  const selected = availableModels.find(m => m.id === chatModel);
+  const selectedLabel = selected?.label || chatModel || '选择模型';
+  const filtered = useMemo(() => filterModels(availableModels, query), [availableModels, query]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocClick = e => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  const openPanel = () => {
+    setQuery('');
+    setOpen(o => !o);
+  };
+
+  return (
+    <div className="model-dropdown" ref={wrapRef}>
+      <button
+        type="button"
+        className="model-dropdown-trigger"
+        onClick={openPanel}
+        disabled={sessionLocked}
+        title="切换模型"
+      >
+        <span className="model-dropdown-label">{selectedLabel}</span>
+        <ChevronDown size={14} />
+      </button>
+      {open && (
+        <div className="model-dropdown-panel">
+          <div className="model-dropdown-search">
+            <Search size={13} />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="搜索模型…"
+              onKeyDown={e => { if (e.key === 'Escape') setOpen(false); }}
+            />
+          </div>
+          <div className="model-dropdown-list">
+            {filtered.length === 0 && <div className="model-dropdown-empty">无匹配模型</div>}
+            {filtered.map(item => (
+              <button
+                type="button"
+                key={item.id}
+                className={`model-dropdown-option ${item.id === chatModel ? 'selected' : ''}`}
+                onClick={() => { setChatModel(item.id); setOpen(false); }}
+                title={item.id}
+              >
+                <span className="model-dropdown-option-label">{item.label}</span>
+                {item.id === chatModel && <Check size={13} />}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 // 模型选择控件：
-// - chat 模式：标准下拉
+// - chat 模式：可搜索下拉
 // - agent 模式：多选 tag + 优先级排序 + race/vote 策略切换
 //
 // 只在 sessionStarted=false 时渲染。组件自己判断这个条件，让 App
@@ -18,15 +103,18 @@ export function ModelSelector({
   setAgentStrategy,
   sessionLocked,
 }) {
+  const [query, setQuery] = useState('');
+
   if (sessionStarted) return null;
 
   if (mode !== 'agent') {
     return (
-      <select className="model-select" value={chatModel} onChange={e => setChatModel(e.target.value)} title="切换模型">
-        {availableModels.map(item => (
-          <option key={item.id} value={item.id}>{item.label}</option>
-        ))}
-      </select>
+      <ChatModelDropdown
+        availableModels={availableModels}
+        chatModel={chatModel}
+        setChatModel={setChatModel}
+        sessionLocked={sessionLocked}
+      />
     );
   }
 
@@ -46,32 +134,57 @@ export function ModelSelector({
     });
   };
 
+  // 已选模型始终置顶且不受搜索影响，避免选中后被过滤掉看不到。
+  const q = query.trim().toLowerCase();
+  const selectedSet = new Set(selectedAgentModels);
+  const selectedItems = selectedAgentModels
+    .map(id => availableModels.find(m => m.id === id))
+    .filter(Boolean);
+  const unselectedItems = availableModels.filter(m => !selectedSet.has(m.id));
+  const filteredUnselected = q
+    ? unselectedItems.filter(m => m.id.toLowerCase().includes(q) || (m.label && m.label.toLowerCase().includes(q)))
+    : unselectedItems;
+  const visibleItems = [...selectedItems, ...filteredUnselected];
+
+  const renderTag = item => {
+    const isSelected = selectedSet.has(item.id);
+    const orderIdx = selectedAgentModels.indexOf(item.id);
+    return (
+      <span key={item.id} className={`model-tag-wrapper ${isSelected ? 'selected' : ''}`}>
+        <button
+          className={`model-tag ${isSelected ? 'selected' : ''}`}
+          onClick={() => toggleAgentModel(item.id)}
+          disabled={sessionLocked}
+          title={isSelected ? '取消选择' : '选择并发执行'}
+        >
+          {item.label}
+        </button>
+        {isSelected && selectedAgentModels.length > 1 && (
+          <span className="model-tag-order">
+            <button className="order-arrow" onClick={() => moveAgentModel(item.id, -1)} disabled={orderIdx <= 0 || sessionLocked} title="提高优先级"><ChevronUp size={10} /></button>
+            <span className="order-number">{orderIdx + 1}</span>
+            <button className="order-arrow" onClick={() => moveAgentModel(item.id, 1)} disabled={orderIdx >= selectedAgentModels.length - 1 || sessionLocked} title="降低优先级"><ChevronDown size={10} /></button>
+          </span>
+        )}
+      </span>
+    );
+  };
+
   return (
     <div className="model-tags-wrap">
+      <div className="model-tags-search">
+        <Search size={13} />
+        <input
+          type="text"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder="搜索模型…"
+          disabled={sessionLocked}
+        />
+      </div>
       <div className="model-tags">
-        {availableModels.map(item => {
-          const isSelected = selectedAgentModels.includes(item.id);
-          const orderIdx = selectedAgentModels.indexOf(item.id);
-          return (
-            <span key={item.id} className={`model-tag-wrapper ${isSelected ? 'selected' : ''}`}>
-              <button
-                className={`model-tag ${isSelected ? 'selected' : ''}`}
-                onClick={() => toggleAgentModel(item.id)}
-                disabled={sessionLocked}
-                title={isSelected ? '取消选择' : '选择并发执行'}
-              >
-                {item.label}
-              </button>
-              {isSelected && selectedAgentModels.length > 1 && (
-                <span className="model-tag-order">
-                  <button className="order-arrow" onClick={() => moveAgentModel(item.id, -1)} disabled={orderIdx <= 0 || sessionLocked} title="提高优先级"><ChevronUp size={10} /></button>
-                  <span className="order-number">{orderIdx + 1}</span>
-                  <button className="order-arrow" onClick={() => moveAgentModel(item.id, 1)} disabled={orderIdx >= selectedAgentModels.length - 1 || sessionLocked} title="降低优先级"><ChevronDown size={10} /></button>
-                </span>
-              )}
-            </span>
-          );
-        })}
+        {visibleItems.length === 0 && <span className="model-tags-empty">无匹配模型</span>}
+        {visibleItems.map(renderTag)}
       </div>
       {selectedAgentModels.length > 1 && (
         <div className="strategy-toggle">


### PR DESCRIPTION
## Summary
供应商接口（如英伟达官方）返回上百个模型，前端下拉难以选择。本 PR 从两端优化：

- **后端过滤**：`loadModelConfig` 新增 `isChatCapableModel`，剔除不适合 agent 决策的模型——向量/重排（embed/rerank/retriever/bge/arctic-embed）、视觉/OCR（fuyu/deplot/vila/neva/kosmos/-vision/-vl-）、纯代码补全（codegemma/starcoder/codellama/-coder）、内容安全护栏（guard/safety/topic-control）。英伟达实测 118 → 84，无误删对话模型。
- **chat 模式**：原生 `<select>` 改为**可搜索下拉**（点击展开 → 输入过滤 → 点选；Esc / 点击外部关闭），带选中勾选标记。
- **agent 模式**：tag 列表上方加搜索框；已选模型**始终置顶**且不受搜索影响（避免选中后被过滤丢失），列表区限高滚动。

## 说明
- 过滤是关键词正则，可能漏放/误放边缘模型；规则集中在 `NON_CHAT_MODEL_RE` 一处，便于后续调整
- 样式复用现有 CSS 变量，新增下拉浮层与搜索框

## Test plan
- [x] `npm run typecheck` 通过
- [x] `cd client && npm run build` 通过
- [x] `cd client && npm run lint` 0 error（仅剩 App.jsx 既有 warning）
- [x] 实跑 `loadModelConfig`：英伟达 118 → 84，无残留向量/视觉/代码补全/护栏模型
- [ ] 浏览器实测：chat 下拉展开/搜索/点选/点外关闭
- [ ] 浏览器实测：agent 搜索过滤 + 已选置顶 + 长列表滚动