### PR TITLE
feat(models): 展示当前 LLM 供应商(只读)

### DIFF
--- a/agent/core/ai-client.ts
+++ b/agent/core/ai-client.ts
@@ -39,16 +39,32 @@ function isChatCapableModel(id: string) {
   return !NON_CHAT_MODEL_RE.test(id);
 }
 
+// 从 baseURL 域名推断供应商展示名，用于前端/日志展示当前连的是哪家。
+// 例：api.freemodel.dev → freemodel，integrate.api.nvidia.com → nvidia，留空 → nvidia。
+export function deriveProviderName(baseURL?: string) {
+  if (!baseURL) return 'nvidia';
+  try {
+    const host = new URL(baseURL).hostname;
+    const parts = host.split('.').filter(p => p && p !== 'api' && p !== 'www');
+    // 去掉末尾 TLD（com/dev/cn 等），取剩下的最后一段作为主体名
+    if (parts.length >= 2) parts.pop();
+    return parts[parts.length - 1] || host;
+  } catch {
+    return 'nvidia';
+  }
+}
+
 export async function loadModelConfig({ openai_client, anthropic_client }: any = {}) {
   const models = [];
 
   // OpenAI 兼容供应商：从 /v1/models 拉取
   if (openai_client) {
+    const providerName = deriveProviderName(process.env.NVIDIA_BASE_URL);
     try {
       const list = await openai_client.models.list();
       for (const m of list.data || []) {
         if (m?.id && isChatCapableModel(m.id)) {
-          models.push({ id: m.id, label: m.id, provider: 'nvidia' });
+          models.push({ id: m.id, label: m.id, provider: providerName });
         }
       }
     } catch (err) {
@@ -75,7 +91,7 @@ export async function loadModelConfig({ openai_client, anthropic_client }: any =
   if (anthropic_client && !openai_client) {
     return [{ id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', provider: 'anthropic' }];
   }
-  return [{ id: 'minimaxai/minimax-m2.7', label: 'MiniMax M2.7', provider: 'nvidia' }];
+  return [{ id: 'minimaxai/minimax-m2.7', label: 'MiniMax M2.7', provider: deriveProviderName(process.env.NVIDIA_BASE_URL) }];
 }
 
 export function loadAgentMultiModels() {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -910,6 +910,28 @@ select,
   cursor: not-allowed;
 }
 
+/* ── 只读供应商标签 ── */
+.model-select-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.provider-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: var(--r-pill);
+  background: var(--c-primary-bg);
+  color: var(--c-primary);
+  border: 1px solid var(--c-primary-light);
+  font-size: var(--f-xs);
+  font-weight: 600;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 /* ── chat 模式：可搜索下拉 ── */
 .model-dropdown {
   position: relative;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -195,6 +195,11 @@ export default function App() {
   const selectedChatModelLabel = availableModels.find(item => item.id === chatModel)?.label || chatModel;
   const sessionLocked = streaming || agentRunning;
 
+  // 当前供应商：取当前选中模型的 provider 字段（agent 模式看首个选中模型，否则看 chatModel）。
+  // provider 来自后端 /api/models，已反映真实 baseURL 推断出的供应商名。
+  const activeModelId = mode === 'agent' && selectedAgentModels.length > 0 ? selectedAgentModels[0] : chatModel;
+  const currentProvider = availableModels.find(item => item.id === activeModelId)?.provider || null;
+
   // 在移动端/窄屏时，会话侧栏和 Agent 面板会改变页面主色块区域。
   // 同步 <meta name="theme-color"> 是为了让浏览器地址栏颜色也跟着切换。
   useThemeColorSync({ mode, agentMobileTab, showSessions });
@@ -675,6 +680,7 @@ export default function App() {
       agentStrategy={agentStrategy}
       setAgentStrategy={setAgentStrategy}
       sessionLocked={sessionLocked}
+      currentProvider={currentProvider}
     />
   );
   const sendButton = (

--- a/client/src/components/ModelSelector.jsx
+++ b/client/src/components/ModelSelector.jsx
@@ -102,19 +102,27 @@ export function ModelSelector({
   agentStrategy,
   setAgentStrategy,
   sessionLocked,
+  currentProvider,
 }) {
   const [query, setQuery] = useState('');
 
   if (sessionStarted) return null;
 
+  const providerBadge = currentProvider
+    ? <span className="provider-badge" title={`当前供应商：${currentProvider}`}>{currentProvider}</span>
+    : null;
+
   if (mode !== 'agent') {
     return (
-      <ChatModelDropdown
-        availableModels={availableModels}
-        chatModel={chatModel}
-        setChatModel={setChatModel}
-        sessionLocked={sessionLocked}
-      />
+      <div className="model-select-row">
+        {providerBadge}
+        <ChatModelDropdown
+          availableModels={availableModels}
+          chatModel={chatModel}
+          setChatModel={setChatModel}
+          sessionLocked={sessionLocked}
+        />
+      </div>
     );
   }
 
@@ -173,6 +181,7 @@ export function ModelSelector({
   return (
     <div className="model-tags-wrap">
       <div className="model-tags-search">
+        {providerBadge}
         <Search size={13} />
         <input
           type="text"

--- a/server.ts
+++ b/server.ts
@@ -37,7 +37,7 @@ import { createApprovalStore } from './agent/core/approval-store.ts';
 import { initLlmLogger } from './agent/core/llm-logger.ts';
 import { createDesktopAgentRunner } from './agent/desktop/agent.ts';
 import { DEFAULT_VISION_MODEL } from './agent/tools/vision/execute.ts';
-import { createClients, loadModelConfig, loadAgentMultiModels, isClaudeModel } from './agent/core/ai-client.ts';
+import { createClients, loadModelConfig, loadAgentMultiModels, isClaudeModel, deriveProviderName } from './agent/core/ai-client.ts';
 import { initWebViewDataStore } from './agent/tools/browser/webview-session.ts';
 import { loadIdeMcpConfig } from './agent/tools/ide/mcp-client.ts';
 import { loadChromeMcpConfig } from './agent/tools/chrome/mcp-client.ts';
@@ -183,6 +183,7 @@ app.listen(Number(PORT), HOST, async () => {
   ${ideConfig.enabled ? row('IDE_PROJECT_PATH', ideConfig.projectPath) : ''}
   ${chromeConfig.enabled ? row('CHROME_MCP', `${chromeConfig.transport} @ ${chromeConfig.url || `${chromeConfig.host}:${chromeConfig.port}${chromeConfig.ssePath}`}`) : row('CHROME_MCP', 'disabled')}
   ${hLine}
+  ${openai_client ? row('Provider', `${deriveProviderName(process.env.NVIDIA_BASE_URL)} @ ${process.env.NVIDIA_BASE_URL || 'https://integrate.api.nvidia.com/v1'}`) : ''}
   ${row('NVIDIA_API_KEY', process.env.NVIDIA_API_KEY ? '✓ configured' : '✗ not set')}
   ${row('ANTHROPIC_API_KEY', process.env.ANTHROPIC_API_KEY ? '✓ configured' : '✗ not set')}
   ╚${dLine.slice(2)}╝


### PR DESCRIPTION
## Summary
页面上看不出当前连的是哪个供应商。本 PR 在前端和启动日志里只读展示当前供应商，并修掉一个现存问题：`loadModelConfig` 此前把每个 OpenAI 模型的 `provider` 硬编码为字面量 `'nvidia'`，不论实际 baseURL。

- **后端**：`ai-client.ts` 新增 `deriveProviderName(baseURL)`，从域名推断供应商名（`api.freemodel.dev → freemodel`、`integrate.api.nvidia.com → nvidia`、留空 → `nvidia`）。`loadModelConfig` 用派生名替代硬编码。
- **启动 banner**：`server.ts` 增加 `Provider` 行，显示当前供应商名 + baseURL。
- **前端**：`App.jsx` 从当前选中模型（agent 模式看首个，否则 chatModel）的 `provider` 字段派生 `currentProvider`；`ModelSelector.jsx` 加只读 `provider-badge` 标签，chat/agent 两种模式都显示；`App.css` 配套 pill 样式。

## 说明
- 只读展示，**不含切换功能**（按需求范围）。
- `provider` 值从 `'nvidia'` 变为派生名。唯一读取者 `isClaudeModel`（查 `'anthropic'`）和 `/v1/models owned_by`（仅展示）均不受影响。
- 默认 NVIDIA baseURL → 派生 `nvidia`，与今天一致。

## Test plan
- [x] `npm run typecheck` 通过
- [x] `cd client && npm run build` 通过
- [x] `cd client && npm run lint` 0 error（仅剩 App.jsx 既有 warning）
- [x] 实跑 `deriveProviderName`：freemodel/nvidia/deepseek/空值 均正确
- [ ] 浏览器实测：工具栏出现当前供应商只读标签，chat/agent 模式都在；切换 baseURL 后标签随之变化