### PR TITLE
fix session model labels

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -66,6 +66,32 @@ function buildTaskWithAttachments(userText, attachments) {
   return userText ? `${userText}\n\n${block}` : block;
 }
 
+function uniqueModelIds(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [...new Set(value.filter(item => typeof item === 'string' && item.trim()))];
+}
+
+function getTraceModels(trace) {
+  if (!Array.isArray(trace)) {
+    return [];
+  }
+
+  for (let i = trace.length - 1; i >= 0; i -= 1) {
+    const models = uniqueModelIds(trace[i]?.meta?.models_used);
+    if (models.length > 0) {
+      return models;
+    }
+  }
+
+  return uniqueModelIds(trace.flatMap(event => {
+    if (event?.type !== 'model_plan') return [];
+    return event.model ? [event.model] : event.models;
+  }));
+}
+
 export default function App() {
   const {
     setChatState,
@@ -244,15 +270,29 @@ export default function App() {
         // 刷新重连时，如果当前会话看起来不是这次 Agent 任务对应的会话，
         // 就临时创建一个“占位会话”承接运行态，避免把其他历史会话的消息替换掉。
         const task = data.task || 'Agent 任务';
+        const activeRunModels = uniqueModelIds(data.meta?.agentModels);
+        const activeRunPrimaryModel = activeRunModels[0] || data.model || undefined;
         setChatState(prev => {
           const cur = prev.sessions.find(s => s.id === prev.activeSessionId);
           const firstUser = cur?.messages?.find(m => m.role === 'user');
-          if (firstUser && firstUser.content === task) return prev;
+          if (firstUser && firstUser.content === task) {
+            const sessions = prev.sessions.map(session => {
+              if (session.id !== prev.activeSessionId) return session;
+              return touchSession(session, {
+                ...(activeRunPrimaryModel ? { model: activeRunPrimaryModel } : {}),
+                ...(activeRunModels.length > 0 ? { modelsUsed: activeRunModels } : {}),
+                agentRunId: data.runId,
+              });
+            });
+            return normalizeChatState({ ...prev, sessions });
+          }
           const cleanSession = createSession({
             messages: [
               { role: 'user', content: task, ts: data.startedAt || Date.now() },
               { role: 'assistant', content: 'Desktop Agent 正在执行任务，请稍候…', ts: Date.now() },
             ],
+            model: activeRunPrimaryModel,
+            modelsUsed: activeRunModels,
             agentRunId: data.runId,
           });
           return normalizeChatState({
@@ -286,6 +326,14 @@ export default function App() {
               if (event.type === 'run_meta') {
                 setAgentStartedAt(event.startedAt || null);
                 if (event.task) reconnectTaskRef.current = event.task;
+                const metaModels = uniqueModelIds(event.agentModels);
+                if (metaModels.length > 0) {
+                  updateActiveSession(session => touchSession(session, {
+                    model: metaModels[0],
+                    modelsUsed: metaModels,
+                    agentRunId: event.runId || data.runId,
+                  }));
+                }
                 continue;
               }
 
@@ -329,6 +377,7 @@ export default function App() {
 
               if (event.type === 'done') {
                 setAgentRunning(false);
+                const modelsUsed = uniqueModelIds(event.meta?.models_used);
                 updateActiveSession(session => {
                   const msgs = [...session.messages];
                   const idx = (() => { for (let i = msgs.length - 1; i >= 0; i--) { if (msgs[i].role === 'assistant' && msgs[i].content.includes('正在执行任务')) return i; } return -1; })();
@@ -338,7 +387,11 @@ export default function App() {
                     msgs.push({ role: 'user', content: reconnectTaskRef.current || data.task || 'Agent 任务', ts: data.startedAt || Date.now() });
                     msgs.push({ role: 'assistant', content: event.answer || 'Agent 已完成任务。', ts: Date.now() });
                   }
-                  return touchSession(session, { messages: msgs, agentRunId: data.runId });
+                  return touchSession(session, {
+                    messages: msgs,
+                    ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
+                    agentRunId: data.runId,
+                  });
                 });
               }
 
@@ -395,6 +448,7 @@ export default function App() {
       const content = terminal.type === 'done'
         ? (terminal.answer || 'Agent 已完成任务。')
         : `⚠️ Desktop Agent 失败：${terminal.error || '未知错误'}`;
+      const modelsUsed = getTraceModels(events);
 
       setChatState(prev => {
         let changed = false;
@@ -416,7 +470,11 @@ export default function App() {
             return session;
           }
           changed = true;
-          return touchSession(session, { messages: msgs, agentRunId: rid });
+          return touchSession(session, {
+            messages: msgs,
+            ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
+            agentRunId: rid,
+          });
         });
         if (!changed) return prev;
         return normalizeChatState({ ...prev, sessions });
@@ -459,9 +517,11 @@ export default function App() {
             return !events.slice(0, i).some(p => `${p.type}:${p.step ?? ''}:${p.stage ?? ''}:${p.model ?? ''}` === key);
           });
           setAgentTrace(deduped);
+          const modelsUsed = getTraceModels(deduped);
           updateSession(activeSession.id, session => touchSession(session, {
             agentRunId: savedRunId,
             agentTrace: deduped,
+            ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
           }));
         })
         .catch(() => {});

--- a/client/src/components/session/SessionList.jsx
+++ b/client/src/components/session/SessionList.jsx
@@ -2,6 +2,50 @@ import { Brain, Trash2 } from 'lucide-react';
 import { getSessionTitle } from '../../hooks/useChatSessions.js';
 import { MemoryPanel } from './MemoryPanel.jsx';
 
+function uniqueModelIds(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [...new Set(value.filter(item => typeof item === 'string' && item.trim()))];
+}
+
+function getTraceModels(trace) {
+  if (!Array.isArray(trace)) {
+    return [];
+  }
+
+  for (let i = trace.length - 1; i >= 0; i -= 1) {
+    const event = trace[i];
+    const models = uniqueModelIds(event?.meta?.models_used);
+    if (models.length > 0) {
+      return models;
+    }
+  }
+
+  const planned = trace.flatMap(event => {
+    if (event?.type !== 'model_plan') return [];
+    return event.model ? [event.model] : event.models;
+  });
+  return uniqueModelIds(planned);
+}
+
+function formatSessionModels(session, modelList) {
+  const models = uniqueModelIds(session.modelsUsed);
+  const traceModels = models.length > 0 ? models : getTraceModels(session.agentTrace);
+  const displayModels = traceModels.length > 0
+    ? traceModels
+    : uniqueModelIds(session.model ? [session.model] : []);
+
+  if (displayModels.length === 0) {
+    return '未知模型';
+  }
+
+  const labels = displayModels.map(model => modelList.find(item => item.id === model)?.label || model);
+  const visible = labels.slice(0, 2).join(' + ');
+  return labels.length > 2 ? `${visible} +${labels.length - 2}` : visible;
+}
+
 export function SessionList({ sessions, activeSessionId, modelList, onDelete, onClearAll, onSelect, locked, showMemoryPanel, onToggleMemory }) {
   return (
     <aside className="session-panel">
@@ -18,7 +62,7 @@ export function SessionList({ sessions, activeSessionId, modelList, onDelete, on
         <div className="session-list">
           {sessions.map(session => {
             const active = session.id === activeSessionId;
-            const modelLabel = modelList.find(item => item.id === session.model)?.label || session.model;
+            const modelLabel = formatSessionModels(session, modelList);
 
             return (
               <div key={session.id} className={`session-card ${active ? 'active' : ''}`}>

--- a/client/src/hooks/useAgentTransport.js
+++ b/client/src/hooks/useAgentTransport.js
@@ -3,6 +3,19 @@ import { showAgentNotification } from '../notifications.js';
 import { touchSession } from './useChatSessions.js';
 import { PHONE_BREAKPOINT } from '../utils/constants.js';
 
+function uniqueModelIds(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [...new Set(value.filter(item => typeof item === 'string' && item.trim()))];
+}
+
+function getEventModels(event, fallbackModels) {
+  const modelsUsed = uniqueModelIds(event?.meta?.models_used);
+  return modelsUsed.length > 0 ? modelsUsed : fallbackModels;
+}
+
 // Agent 流程的执行链路：
 // - sendAgentTask: 发起一次 Agent 任务（含 retry from checkpoint）
 // - stopAgent: 取消运行中的 Agent
@@ -64,6 +77,13 @@ export function useAgentTransport({
   const sendAgentTask = async (text, extraBody) => {
     const sessionId = activeSession.id;
     const isRetry = !!extraBody?.fromCheckpoint;
+    const availableModelIds = new Set(availableModels.map(model => model.id));
+    const selectedModelCandidates = uniqueModelIds(selectedAgentModels);
+    const selectedModels = availableModels.length > 0
+      ? selectedModelCandidates.filter(model => availableModelIds.has(model))
+      : selectedModelCandidates;
+    const runModels = selectedModels.length > 0 ? selectedModels : [chatModel];
+    const primaryModel = runModels[0] || chatModel;
     lastAgentTaskRef.current = text;
     const history = isRetry ? messages : [...messages, { role: 'user', content: text, ts: Date.now() }];
 
@@ -71,6 +91,8 @@ export function useAgentTransport({
       updateSession(sessionId, session =>
         touchSession(session, {
           messages: [...history, { role: 'assistant', content: 'Desktop Agent 正在执行任务，请稍候…', ts: Date.now() }],
+          model: primaryModel,
+          modelsUsed: runModels,
           agentTrace: [],
           agentRunId: null,
         })
@@ -86,7 +108,7 @@ export function useAgentTransport({
         const msgs = [...session.messages];
         const stepInfo = cpStep ? `从第 ${cpStep} 步` : '';
         msgs.push({ role: 'assistant', content: `Desktop Agent 正在${stepInfo}重新执行任务：${text}`, ts: Date.now() });
-        return touchSession(session, { messages: msgs });
+        return touchSession(session, { messages: msgs, model: primaryModel, modelsUsed: runModels });
       });
     }
     setAgentStartedAt(Date.now());
@@ -101,11 +123,9 @@ export function useAgentTransport({
         task: text,
         // Agent 至少要有一个主模型。多模型时第一个模型作为主请求参数，
         // 完整模型集合再通过 models 传给后端做并发规划。
-        model: selectedAgentModels.length > 0 ? selectedAgentModels[0] : chatModel,
-        models: selectedAgentModels.length > 0
-          ? selectedAgentModels.filter(m => availableModels.some(available => available.id === m))
-          : [chatModel],
-        strategy: selectedAgentModels.length > 1 ? agentStrategy : 'race',
+        model: primaryModel,
+        models: runModels,
+        strategy: runModels.length > 1 ? agentStrategy : 'race',
         memory: agentMemory,
         signal: controller.signal,
         messages: isRetry ? [] : messages.slice(-10).map(m => ({ role: m.role, content: m.content })),
@@ -193,7 +213,14 @@ export function useAgentTransport({
                     ts: Date.now(),
                   };
                 }
-                return touchSession(session, { messages: nextMessages, agentTrace: prev, agentRunId: agentRunIdRef.current });
+                const modelsUsed = getEventModels(event, runModels);
+                return touchSession(session, {
+                  messages: nextMessages,
+                  model: modelsUsed[0] || primaryModel,
+                  modelsUsed,
+                  agentTrace: prev,
+                  agentRunId: agentRunIdRef.current,
+                });
               });
               return prev;
             });
@@ -218,7 +245,14 @@ export function useAgentTransport({
                     ts: Date.now(),
                   };
                 }
-                return touchSession(session, { messages: nextMessages, agentTrace: prev, agentRunId: agentRunIdRef.current });
+                const modelsUsed = getEventModels(event, runModels);
+                return touchSession(session, {
+                  messages: nextMessages,
+                  model: modelsUsed[0] || primaryModel,
+                  modelsUsed,
+                  agentTrace: prev,
+                  agentRunId: agentRunIdRef.current,
+                });
               });
               return prev;
             });
@@ -259,9 +293,24 @@ export function useAgentTransport({
               } else {
                 next[lastIdx] = { role: 'assistant', content: `⚠️ Desktop Agent 失败：${errorEvent.error || '连接中断'}`, ts: Date.now() };
               }
-              return touchSession(session, { messages: next, agentTrace: prev, agentRunId: agentRunIdRef.current });
+              const terminalEvent = doneEvent || errorEvent;
+              const modelsUsed = getEventModels(terminalEvent, runModels);
+              return touchSession(session, {
+                messages: next,
+                model: modelsUsed[0] || primaryModel,
+                modelsUsed,
+                agentTrace: prev,
+                agentRunId: agentRunIdRef.current,
+              });
             }
-            return touchSession(session, { agentTrace: prev, agentRunId: agentRunIdRef.current });
+            const terminalEvent = doneEvent || errorEvent;
+            const modelsUsed = getEventModels(terminalEvent, runModels);
+            return touchSession(session, {
+              model: modelsUsed[0] || primaryModel,
+              modelsUsed,
+              agentTrace: prev,
+              agentRunId: agentRunIdRef.current,
+            });
           });
         } else if (prev.length === 0 || !prev.some(e => e.type === 'done' || e.type === 'error')) {
           // No events received at all or SSE disconnected without done/error
@@ -271,9 +320,20 @@ export function useAgentTransport({
             if (lastIdx >= 0 && msgs[lastIdx].role === 'assistant' && msgs[lastIdx].content.includes('正在执行任务')) {
               const next = [...msgs];
               next[lastIdx] = { role: 'assistant', content: '⚠️ Desktop Agent 连接中断，未收到执行结果。', ts: Date.now() };
-              return touchSession(session, { messages: next, agentTrace: prev, agentRunId: agentRunIdRef.current });
+              return touchSession(session, {
+                messages: next,
+                model: primaryModel,
+                modelsUsed: runModels,
+                agentTrace: prev,
+                agentRunId: agentRunIdRef.current,
+              });
             }
-            return touchSession(session, { agentTrace: prev, agentRunId: agentRunIdRef.current });
+            return touchSession(session, {
+              model: primaryModel,
+              modelsUsed: runModels,
+              agentTrace: prev,
+              agentRunId: agentRunIdRef.current,
+            });
           });
         }
         return prev;

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -25,10 +25,19 @@ function normalizeMessages(value) {
     }));
 }
 
+function normalizeModelIds(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return [...new Set(value.filter(item => typeof item === 'string' && item.trim()))];
+}
+
 export function createSession({
   id = generateSessionId(),
   messages = [],
   model,
+  modelsUsed = [],
   agentTrace = [],
   agentRunId = null,
   createdAt = Date.now(),
@@ -38,6 +47,7 @@ export function createSession({
     id,
     messages: normalizeMessages(messages),
     model: model || DEFAULT_MODEL_ID,
+    modelsUsed: normalizeModelIds(modelsUsed),
     agentTrace: Array.isArray(agentTrace) ? agentTrace : [],
     agentRunId: typeof agentRunId === 'string' ? agentRunId : null,
     createdAt,
@@ -57,6 +67,7 @@ export function normalizeChatState(rawState) {
             id: typeof session.id === 'string' && session.id ? session.id : undefined,
             messages: session.messages,
             model: session.model,
+            modelsUsed: session.modelsUsed,
             agentTrace: session.agentTrace,
             agentRunId: session.agentRunId,
             createdAt: Number.isFinite(session.createdAt) ? session.createdAt : Date.now(),

--- a/routes/agent-run-control.ts
+++ b/routes/agent-run-control.ts
@@ -79,6 +79,7 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
       runId: run.runId,
       startedAt: run.startedAt,
       model: run.meta?.model,
+      agentModels: run.meta?.agentModels,
       task: run.meta?.task,
     })}\n\n`);
 

--- a/routes/agent-run-start.ts
+++ b/routes/agent-run-start.ts
@@ -51,6 +51,7 @@ export function createAgentRunStartRouter({
     const existingRunId = fromCheckpoint?.runId;
     const runRecord = agentRunStore.createRun({
       model,
+      agentModels,
       task: normalizedTask,
     }, startedAt, existingRunId);
     const runId = runRecord.runId;


### PR DESCRIPTION
## Summary
- Persist the actual Agent model set on chat sessions via `modelsUsed`.
- Show session-list model labels from `modelsUsed` first, then recovered Agent trace data, then the legacy single `model` field.
- Include Agent model metadata in run/reconnect events so refreshed sessions keep the correct display immediately.

## Root Cause
Agent sessions only kept the single `session.model` value, which could be stale or the chat default. Multi-model Agent runs and reconnect flows therefore showed the wrong model in the session list.

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build:client`
- `npm test`，第一次在沙箱内因 `listen EPERM` 失败，提升权限重跑后 11 files / 73 tests 全过。