### PR TITLE
fix(models): 模型选择下拉改为向下弹出

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -972,7 +972,7 @@ select,
 .model-dropdown-panel {
   position: absolute;
   z-index: 50;
-  bottom: calc(100% + 4px);
+  top: calc(100% + 4px);
   left: 0;
   width: 260px;
   max-width: 80vw;


### PR DESCRIPTION
## 改动

模型选择下拉浮层 `.model-dropdown-panel` 原本用 `bottom: calc(100% + 4px)` 锚在触发按钮上方,会往上弹。改成 `top: calc(100% + 4px)` 让其向下弹出。

## 影响范围

纯 CSS 改动,仅影响下拉浮层的弹出方向。