### PR TITLE
fix(gemini): 保留 functionCall 的 thoughtSignature 修复多轮工具调用 400

### DIFF
--- a/agent/core/providers/gemini.ts
+++ b/agent/core/providers/gemini.ts
@@ -154,25 +154,30 @@ export function createGeminiProvider(client: GoogleGenAI): LLMProvider {
         if (systemInstruction) config.systemInstruction = systemInstruction;
 
         const stream = await client.models.generateContentStream({ model, contents, config } as any);
-        let modelParts: any[] = [];
+        // 直接累积模型这一轮输出的原始 parts。part 级别的 thoughtSignature 必须原样回写，
+        // 否则下一轮带 functionCall 历史的请求会被 Gemini 拒绝（400 missing thought_signature）。
+        // 注意：chunk.text / chunk.functionCalls 这两个便捷访问器会丢掉 thoughtSignature，
+        // 不能用它们重建 parts。
+        const modelParts: any[] = [];
         const functionCalls: any[] = [];
 
         for await (const chunk of stream) {
-          const text = (chunk as any).text;
-          if (text) {
-            writeSse(res, { content: text });
-            modelParts.push({ text });
+          const parts = (chunk as any).candidates?.[0]?.content?.parts;
+          if (Array.isArray(parts)) {
+            for (const part of parts) {
+              // 思维摘要（thought=true）不作为可见正文流式输出，但仍需原样保留以携带签名。
+              if (typeof part.text === 'string' && !part.thought) writeSse(res, { content: part.text });
+              if (part.functionCall) functionCalls.push(part.functionCall);
+              modelParts.push(part);
+            }
           }
-          const calls = (chunk as any).functionCalls;
-          if (Array.isArray(calls)) functionCalls.push(...calls);
           const meta = (chunk as any).usageMetadata;
           if (meta) usage = buildGeminiUsage(meta);
         }
 
         if (functionCalls.length === 0) break;
 
-        // 把模型这一轮的输出（文本 + functionCall parts）记入 contents
-        for (const call of functionCalls) modelParts.push({ functionCall: { name: call.name, args: call.args } });
+        // 模型这一轮的输出原样记入 contents（含 thoughtSignature），供下一轮请求校验。
         contents.push({ role: 'model', parts: modelParts });
 
         const responseParts = [];


### PR DESCRIPTION
## 问题

Gemini 模型在 chat 模式下连续调用工具（如 `web_search`）时,第二轮请求报错:

```
400 INVALID_ARGUMENT: Function call is missing a thought_signature in functionCall
parts. ... function call `default_api:web_search`, position 2.
```

## 根因

Gemini 返回 `functionCall` 时,会在 **part 级别**附带一个 `thoughtSignature`(与 `functionCall` 平级的兄弟字段)。多轮工具调用把模型输出写回对话历史后,下一轮请求必须原样带上该签名,否则被服务端拒绝。

`agent/core/providers/gemini.ts` 的 `chatStream` 原先用 `chunk.functionCalls` / `chunk.text` 两个便捷访问器重建 parts:

- `chunk.functionCalls` getter 内部是 `parts.filter(p => p.functionCall).map(p => p.functionCall)`,丢掉了 part 上的 `thoughtSignature`;
- 重建 part 时 `{ functionCall: { name, args } }` 也只复制了 `name`/`args`。

两处叠加导致签名彻底丢失。

## 修复

改为直接累积 chunk 的**原始 parts**(`candidates[0].content.parts`)整段回写到 `contents`,签名自然保留:

- 文本仍按 `part.text` 流式输出,并跳过 `thought===true` 的思维摘要(保持原有可见正文行为不变);
- `functionCall` part 连同其 `thoughtSignature` 原样存入历史;
- 不再使用会丢字段的便捷访问器重建 part。

这是代码库中唯一一处多轮回写 `functionCall` 的位置;agent 决策路径(`agentPlan`)是单次决策、历史以文本重建,不受影响。

## 验证

- `npm run typecheck` ✓
- `npm test` ✓(73 passed）