### PR TITLE
fix(models): 模型列表全部获取失败时中止启动，不再兜底默认模型

### DIFF
--- a/agent/core/providers/anthropic.ts
+++ b/agent/core/providers/anthropic.ts
@@ -84,13 +84,10 @@ export function createAnthropicProvider(client: any): LLMProvider {
 
     async listModels() {
       const models: ModelInfo[] = [];
-      try {
-        const list = await client.models.list();
-        for (const m of list.data || []) {
-          if (m?.id) models.push({ id: m.id, label: m.display_name || m.id, provider: 'anthropic' });
-        }
-      } catch (err: any) {
-        log.warn(`[Models] 拉取 Anthropic 模型列表失败: ${err?.message || err}`);
+      // 失败直接抛错，由 registry 聚合原因；全部供应商失败时中止启动。
+      const list = await client.models.list();
+      for (const m of list.data || []) {
+        if (m?.id) models.push({ id: m.id, label: m.display_name || m.id, provider: 'anthropic' });
       }
       return models;
     },

--- a/agent/core/providers/gemini.ts
+++ b/agent/core/providers/gemini.ts
@@ -76,24 +76,21 @@ export function createGeminiProvider(client: GoogleGenAI): LLMProvider {
 
     async listModels() {
       const models: ModelInfo[] = [];
-      try {
-        const pager = await client.models.list();
-        for await (const m of pager) {
-          // m.name 形如 'models/gemini-2.5-flash'；剥离前缀作为 id。
-          const rawName: string = (m as any).name || '';
-          const id = rawName.replace(/^models\//, '');
-          if (!id) continue;
-          // 仅保留能做对话决策的模型。注意 tts / image 类模型也声明了 generateContent，
-          // 无法靠 supportedActions 区分，必须按 id 过滤。
-          const actions: string[] = (m as any).supportedActions || (m as any).supportedGenerationMethods || [];
-          const supportsGenerate = !actions.length || actions.includes('generateContent');
-          if (!supportsGenerate) continue;
-          if (!isChatCapableModel(id)) continue;
-          if (/imagen|veo|embedding|aqa|tts|-image|image-|gemma-(?:2|3n)/i.test(id)) continue;
-          models.push({ id, label: (m as any).displayName || id, provider: 'gemini' });
-        }
-      } catch (err: any) {
-        log.warn(`[Models] 拉取 Gemini 模型列表失败: ${err?.message || err}`);
+      // 失败直接抛错，由 registry 聚合原因；全部供应商失败时中止启动。
+      const pager = await client.models.list();
+      for await (const m of pager) {
+        // m.name 形如 'models/gemini-2.5-flash'；剥离前缀作为 id。
+        const rawName: string = (m as any).name || '';
+        const id = rawName.replace(/^models\//, '');
+        if (!id) continue;
+        // 仅保留能做对话决策的模型。注意 tts / image 类模型也声明了 generateContent，
+        // 无法靠 supportedActions 区分，必须按 id 过滤。
+        const actions: string[] = (m as any).supportedActions || (m as any).supportedGenerationMethods || [];
+        const supportsGenerate = !actions.length || actions.includes('generateContent');
+        if (!supportsGenerate) continue;
+        if (!isChatCapableModel(id)) continue;
+        if (/imagen|veo|embedding|aqa|tts|-image|image-|gemma-(?:2|3n)/i.test(id)) continue;
+        models.push({ id, label: (m as any).displayName || id, provider: 'gemini' });
       }
       return models;
     },

--- a/agent/core/providers/openai-compat.ts
+++ b/agent/core/providers/openai-compat.ts
@@ -67,15 +67,12 @@ export function createOpenAICompatProvider(client: any): LLMProvider {
     async listModels() {
       const models: ModelInfo[] = [];
       const providerName = deriveProviderName(process.env.NVIDIA_BASE_URL);
-      try {
-        const list = await client.models.list();
-        for (const m of list.data || []) {
-          if (m?.id && isChatCapableModel(m.id)) {
-            models.push({ id: m.id, label: m.id, provider: providerName });
-          }
+      // 失败直接抛错，由 registry 聚合原因；全部供应商失败时中止启动。
+      const list = await client.models.list();
+      for (const m of list.data || []) {
+        if (m?.id && isChatCapableModel(m.id)) {
+          models.push({ id: m.id, label: m.id, provider: providerName });
         }
-      } catch (err: any) {
-        log.warn(`[Models] 拉取 OpenAI 兼容模型列表失败: ${err?.message || err}`);
       }
       return models;
     },

--- a/agent/core/providers/registry.ts
+++ b/agent/core/providers/registry.ts
@@ -3,7 +3,7 @@
  *
  * 装配所有已配置的 LLMProvider，对外提供：
  *   - resolve(model, modelConfig): 把模型路由到认领它的 provider（兜底 openai-compat）
- *   - loadModelConfig(): 合并所有 provider 的模型列表（含兜底默认值）
+ *   - loadModelConfig(): 合并所有 provider 的模型列表；全部获取失败则抛错中止启动
  *   - providers: provider 列表（server resume / banner 等处遍历用）
  *
  * 加第四家供应商：写 createXxxProvider() 实现 LLMProvider 接口，在下方
@@ -14,7 +14,6 @@
 import { createAnthropicProvider } from './anthropic.ts';
 import { createOpenAICompatProvider } from './openai-compat.ts';
 import { createGeminiProvider } from './gemini.ts';
-import { deriveProviderName } from '../ai-client.ts';
 import { log } from '../../../helpers/logger.ts';
 import type { LLMProvider, ModelInfo } from './types.ts';
 
@@ -52,17 +51,31 @@ export function createProviderRegistry({
   }
 
   async function loadModelConfig(): Promise<ModelInfo[]> {
-    const lists = await Promise.all(providers.map(p => p.listModels().catch(() => [] as ModelInfo[])));
-    const merged = lists.flat();
-    if (merged.length > 0) return merged;
+    const results = await Promise.allSettled(providers.map(p => p.listModels()));
+    const merged: ModelInfo[] = [];
+    const failures: string[] = [];
+    results.forEach((r, i) => {
+      const name = providers[i].name;
+      if (r.status === 'fulfilled') {
+        if (r.value.length > 0) merged.push(...r.value);
+        else failures.push(`${name}: 接口可达但返回 0 个可用模型`);
+      } else {
+        failures.push(`${name}: ${r.reason?.message || String(r.reason)}`);
+      }
+    });
 
-    // 接口拉取全部失败时的兜底，保证服务仍能启动
-    log.warn('[Models] 未能从任何供应商接口获取模型，使用兜底默认值');
-    const fallbacks: ModelInfo[] = [];
-    if (gemini_client) fallbacks.push({ id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', provider: 'gemini' });
-    if (anthropic_client) fallbacks.push({ id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6', provider: 'anthropic' });
-    if (openai_client) fallbacks.push({ id: 'minimaxai/minimax-m2.7', label: 'MiniMax M2.7', provider: deriveProviderName(process.env.NVIDIA_BASE_URL) });
-    return fallbacks;
+    if (merged.length > 0) {
+      // 至少一家成功即可启动；失败的供应商记录原因便于排查，但不阻塞。
+      if (failures.length > 0) {
+        log.warn(`[Models] 部分供应商获取模型失败（已忽略）:\n  - ${failures.join('\n  - ')}`);
+      }
+      return merged;
+    }
+
+    // 全部失败：不再兜底默认模型，直接抛错让启动失败并给出原因。
+    throw new Error(
+      `未能从任何供应商获取模型列表，启动中止。请检查 API Key / 网络 / BASE_URL。各供应商失败原因:\n  - ${failures.join('\n  - ')}`,
+    );
   }
 
   return { providers, resolve, loadModelConfig };

--- a/agent/core/providers/types.ts
+++ b/agent/core/providers/types.ts
@@ -79,7 +79,8 @@ export interface LLMProvider {
   // 是否「认领」某模型。registry 先用它精确匹配，匹配不到再兜底到 openai-compat。
   ownsModel(model: string, modelConfig?: ModelInfo[] | null): boolean;
 
-  // 从供应商 /v1/models 拉取并归一成 ModelInfo[]；失败应自行兜底（抛错由 registry 吞掉）。
+  // 从供应商 /v1/models 拉取并归一成 ModelInfo[]；失败直接抛错，由 registry 聚合各家原因，
+  // 全部失败时中止启动（不再兜底默认模型）。
   listModels(): Promise<ModelInfo[]>;
 
   // agent 决策：调用 LLM → 解析 → 归一成 { rationale, action, usage, reasoning }。

--- a/server.ts
+++ b/server.ts
@@ -59,7 +59,11 @@ app.use(express.json({ limit: '25mb' }));
 
 const { openai_client, anthropic_client, gemini_client } = createClients();
 const registry = createProviderRegistry({ openai_client, anthropic_client, gemini_client });
-const modelConfig = await registry.loadModelConfig();
+// 启动时同步拉取模型列表；全部供应商失败则中止启动并打印原因，不再兜底默认模型。
+const modelConfig = await registry.loadModelConfig().catch((err: any) => {
+  log.error(`[启动失败] ${err.message}`);
+  process.exit(1);
+});
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MEMORY_DIR = path.resolve(__dirname, process.env.MEMORY_DIR || 'data');


### PR DESCRIPTION
## 背景

各 provider 的 `listModels()` 原先自行 `try/catch` 兜底返回 `[]`，`registry` 在全部失败时还会塞入硬编码默认模型。结果：API Key / 网络 / `BASE_URL` 配错时服务照常启动，用户拿到的是**无法实际调用的「假」模型列表**，问题被掩盖到运行期才暴露。

## 改动（fail-fast）

- 三家 provider（anthropic / gemini / openai-compat）的 `listModels()` 去掉 `try/catch`，失败直接抛错
- `registry.loadModelConfig()` 改用 `Promise.allSettled` 聚合各家结果：
  - **至少一家成功**即可启动，失败的供应商记录原因（`warn`）但不阻塞
  - **全部失败**则抛错，附带每家的失败原因，不再兜底默认模型
- `server.ts` 启动时捕获该错误，打印原因并 `process.exit(1)`

## 影响

- 配置正确时行为不变（任一家成功即正常启动）
- 配置错误时从「静默启动 + 假模型」变为「启动失败 + 明确原因」，更早暴露问题

## 验证

- `npm run typecheck` 通过