### PR TITLE
feat(session): 会话列表支持时间显示、按时间分组折叠与搜索

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -536,6 +536,118 @@ select,
   gap: 4px;
 }
 
+.session-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.session-search-icon {
+  position: absolute;
+  left: 9px;
+  color: var(--c-text-hint);
+  pointer-events: none;
+}
+
+.session-search-input {
+  width: 100%;
+  height: 32px;
+  padding: 0 28px;
+  border: 1px solid var(--c-border-input);
+  border-radius: var(--r-sm);
+  background: var(--c-surface);
+  color: var(--c-text);
+  font-size: var(--f-sm);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.session-search-input::placeholder {
+  color: var(--c-text-hint);
+}
+
+.session-search-input:focus {
+  border-color: var(--c-primary-light);
+}
+
+.session-search-clear {
+  position: absolute;
+  right: 6px;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: var(--c-text-hint);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.15s;
+}
+
+.session-search-clear:hover {
+  background: var(--c-surface-dim);
+  color: var(--c-text-secondary);
+}
+
+.session-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.session-group + .session-group {
+  margin-top: 6px;
+}
+
+.session-group-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 4px 6px;
+  border: none;
+  background: transparent;
+  color: var(--c-text-muted);
+  font-size: var(--f-xs);
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: var(--r-sm);
+  transition: background 0.15s;
+}
+
+.session-group-header:hover {
+  background: var(--c-surface-dim);
+}
+
+.session-group-chevron {
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+.session-group-header.collapsed .session-group-chevron {
+  transform: rotate(-90deg);
+}
+
+.session-group-label {
+  flex: 1;
+  text-align: left;
+}
+
+.session-group-count {
+  flex-shrink: 0;
+  color: var(--c-text-hint);
+  font-weight: 500;
+}
+
+.session-empty {
+  padding: 24px 8px;
+  text-align: center;
+  color: var(--c-text-hint);
+  font-size: var(--f-sm);
+}
+
 .session-memory-btn {
   height: 30px;
   padding: 0 8px;
@@ -603,6 +715,14 @@ select,
 .session-card-meta {
   font-size: var(--f-xs);
   color: var(--c-text-hint);
+}
+
+.session-card-time {
+  font-size: var(--f-xs);
+  color: var(--c-text-hint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .session-delete-btn {
@@ -3588,11 +3708,13 @@ textarea:focus-visible,
   .send-btn:active:not(:disabled),
   .session-main:active:not(:disabled),
   .session-delete-btn:active:not(:disabled),
-  .session-clear-all-btn:active:not(:disabled) {
+  .session-clear-all-btn:active:not(:disabled),
+  .session-group-header:active {
     filter: brightness(0.96);
   }
 
   .session-main,
+  .session-group-header,
   .suggestion-card,
   .agent-mobile-tab,
   .model-tag,

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -518,7 +518,10 @@ export default function App() {
           });
           setAgentTrace(deduped);
           const modelsUsed = getTraceModels(deduped);
-          updateSession(activeSession.id, session => touchSession(session, {
+          // 重建 trace 只是恢复客户端镜像，不算用户活动：保留原 updatedAt，
+          // 否则每次切到/刷新一个 agent 会话都会把它的最近活动时间刷成当前时间。
+          updateSession(activeSession.id, session => ({
+            ...session,
             agentRunId: savedRunId,
             agentTrace: deduped,
             ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),

--- a/client/src/components/session/SessionList.jsx
+++ b/client/src/components/session/SessionList.jsx
@@ -2,19 +2,11 @@ import { useMemo, useState } from 'react';
 import { Brain, ChevronDown, Search, Trash2, X } from 'lucide-react';
 import { getSessionTitle } from '../../hooks/useChatSessions.js';
 import { usePersistentState, jsonStorage } from '../../hooks/usePersistentState.js';
-import { calendarDaysAgo, formatRelativeTime, formatShortTime, formatFullTime } from '../../utils/format.js';
+import { formatRelativeTime, formatShortTime, formatFullTime } from '../../utils/format.js';
+import { buildGroups, lastActivityTs } from './session-grouping.js';
 import { MemoryPanel } from './MemoryPanel.jsx';
 
 const COLLAPSED_GROUPS_KEY = 'nvidia_chat_collapsed_groups';
-
-// 按“最近活动时间”落入的分组（从新到旧）；match 接收 calendarDaysAgo 的自然日差。
-const GROUP_DEFS = [
-  { key: 'today', label: '今天', match: d => d === 0 },
-  { key: 'yesterday', label: '昨天', match: d => d === 1 },
-  { key: 'week', label: '近 7 天', match: d => d >= 2 && d < 7 },
-  { key: 'month', label: '近 30 天', match: d => d >= 7 && d < 30 },
-  { key: 'earlier', label: '更早', match: d => d >= 30 },
-];
 
 function uniqueModelIds(value) {
   if (!Array.isArray(value)) {
@@ -58,41 +50,6 @@ function formatSessionModels(session, modelList) {
   const labels = displayModels.map(model => modelList.find(item => item.id === model)?.label || model);
   const visible = labels.slice(0, 2).join(' + ');
   return labels.length > 2 ? `${visible} +${labels.length - 2}` : visible;
-}
-
-// 会话的最近活动时间：优先取最后一条带时间戳的消息（用户消息均带 ts，
-// 不会被 App.jsx 的 trace 重建逻辑污染），回退到 updatedAt / createdAt。
-function lastActivityTs(session) {
-  const msgs = session.messages || [];
-  for (let i = msgs.length - 1; i >= 0; i -= 1) {
-    if (Number.isFinite(msgs[i].ts)) return msgs[i].ts;
-  }
-  return session.updatedAt || session.createdAt || null;
-}
-
-// 标题 + 全部消息内容做大小写不敏感匹配。
-function sessionMatchesQuery(session, query) {
-  if (getSessionTitle(session.messages).toLowerCase().includes(query)) {
-    return true;
-  }
-  return session.messages.some(
-    msg => typeof msg.content === 'string' && msg.content.toLowerCase().includes(query)
-  );
-}
-
-// 过滤 + 按最近活动时间分组，组内按 updatedAt 倒序，空组剔除。
-function buildGroups(sessions, query) {
-  const q = query.trim().toLowerCase();
-  const matched = q ? sessions.filter(session => sessionMatchesQuery(session, q)) : sessions;
-  const sorted = [...matched].sort((a, b) => (lastActivityTs(b) || 0) - (lastActivityTs(a) || 0));
-
-  return GROUP_DEFS
-    .map(def => ({
-      key: def.key,
-      label: def.label,
-      sessions: sorted.filter(session => def.match(calendarDaysAgo(lastActivityTs(session) || Date.now()))),
-    }))
-    .filter(group => group.sessions.length > 0);
 }
 
 function SessionCard({ session, active, modelLabel, locked, canDelete, onSelect, onDelete }) {

--- a/client/src/components/session/SessionList.jsx
+++ b/client/src/components/session/SessionList.jsx
@@ -60,6 +60,16 @@ function formatSessionModels(session, modelList) {
   return labels.length > 2 ? `${visible} +${labels.length - 2}` : visible;
 }
 
+// 会话的最近活动时间：优先取最后一条带时间戳的消息（用户消息均带 ts，
+// 不会被 App.jsx 的 trace 重建逻辑污染），回退到 updatedAt / createdAt。
+function lastActivityTs(session) {
+  const msgs = session.messages || [];
+  for (let i = msgs.length - 1; i >= 0; i -= 1) {
+    if (Number.isFinite(msgs[i].ts)) return msgs[i].ts;
+  }
+  return session.updatedAt || session.createdAt || null;
+}
+
 // 标题 + 全部消息内容做大小写不敏感匹配。
 function sessionMatchesQuery(session, query) {
   if (getSessionTitle(session.messages).toLowerCase().includes(query)) {
@@ -74,19 +84,19 @@ function sessionMatchesQuery(session, query) {
 function buildGroups(sessions, query) {
   const q = query.trim().toLowerCase();
   const matched = q ? sessions.filter(session => sessionMatchesQuery(session, q)) : sessions;
-  const sorted = [...matched].sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+  const sorted = [...matched].sort((a, b) => (lastActivityTs(b) || 0) - (lastActivityTs(a) || 0));
 
   return GROUP_DEFS
     .map(def => ({
       key: def.key,
       label: def.label,
-      sessions: sorted.filter(session => def.match(calendarDaysAgo(session.updatedAt || session.createdAt || Date.now()))),
+      sessions: sorted.filter(session => def.match(calendarDaysAgo(lastActivityTs(session) || Date.now()))),
     }))
     .filter(group => group.sessions.length > 0);
 }
 
 function SessionCard({ session, active, modelLabel, locked, canDelete, onSelect, onDelete }) {
-  const ts = session.updatedAt || session.createdAt;
+  const ts = lastActivityTs(session);
 
   return (
     <div className={`session-card ${active ? 'active' : ''}`}>

--- a/client/src/components/session/SessionList.jsx
+++ b/client/src/components/session/SessionList.jsx
@@ -1,6 +1,20 @@
-import { Brain, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Brain, ChevronDown, Search, Trash2, X } from 'lucide-react';
 import { getSessionTitle } from '../../hooks/useChatSessions.js';
+import { usePersistentState, jsonStorage } from '../../hooks/usePersistentState.js';
+import { calendarDaysAgo, formatRelativeTime, formatShortTime, formatFullTime } from '../../utils/format.js';
 import { MemoryPanel } from './MemoryPanel.jsx';
+
+const COLLAPSED_GROUPS_KEY = 'nvidia_chat_collapsed_groups';
+
+// 按“最近活动时间”落入的分组（从新到旧）；match 接收 calendarDaysAgo 的自然日差。
+const GROUP_DEFS = [
+  { key: 'today', label: '今天', match: d => d === 0 },
+  { key: 'yesterday', label: '昨天', match: d => d === 1 },
+  { key: 'week', label: '近 7 天', match: d => d >= 2 && d < 7 },
+  { key: 'month', label: '近 30 天', match: d => d >= 7 && d < 30 },
+  { key: 'earlier', label: '更早', match: d => d >= 30 },
+];
 
 function uniqueModelIds(value) {
   if (!Array.isArray(value)) {
@@ -46,7 +60,75 @@ function formatSessionModels(session, modelList) {
   return labels.length > 2 ? `${visible} +${labels.length - 2}` : visible;
 }
 
+// 标题 + 全部消息内容做大小写不敏感匹配。
+function sessionMatchesQuery(session, query) {
+  if (getSessionTitle(session.messages).toLowerCase().includes(query)) {
+    return true;
+  }
+  return session.messages.some(
+    msg => typeof msg.content === 'string' && msg.content.toLowerCase().includes(query)
+  );
+}
+
+// 过滤 + 按最近活动时间分组，组内按 updatedAt 倒序，空组剔除。
+function buildGroups(sessions, query) {
+  const q = query.trim().toLowerCase();
+  const matched = q ? sessions.filter(session => sessionMatchesQuery(session, q)) : sessions;
+  const sorted = [...matched].sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+
+  return GROUP_DEFS
+    .map(def => ({
+      key: def.key,
+      label: def.label,
+      sessions: sorted.filter(session => def.match(calendarDaysAgo(session.updatedAt || session.createdAt || Date.now()))),
+    }))
+    .filter(group => group.sessions.length > 0);
+}
+
+function SessionCard({ session, active, modelLabel, locked, canDelete, onSelect, onDelete }) {
+  const ts = session.updatedAt || session.createdAt;
+
+  return (
+    <div className={`session-card ${active ? 'active' : ''}`}>
+      <button className="session-main" onClick={() => onSelect(session.id)} disabled={locked || active}>
+        <span className="session-card-title">{getSessionTitle(session.messages)}</span>
+        <span className="session-card-meta">{modelLabel} · {session.messages.length} 条</span>
+        {ts ? (
+          <span className="session-card-time" title={formatFullTime(ts)}>
+            {formatRelativeTime(ts)} · {formatShortTime(ts)}
+          </span>
+        ) : null}
+      </button>
+
+      {canDelete && (
+        <button
+          className="session-delete-btn"
+          onClick={() => onDelete(session.id)}
+          disabled={locked}
+          title="删除会话"
+        >
+          <Trash2 size={12} />
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function SessionList({ sessions, activeSessionId, modelList, onDelete, onClearAll, onSelect, locked, showMemoryPanel, onToggleMemory }) {
+  const [query, setQuery] = useState('');
+  const [collapsedGroups, setCollapsedGroups] = usePersistentState(COLLAPSED_GROUPS_KEY, [], jsonStorage);
+
+  const groups = useMemo(() => buildGroups(sessions, query), [sessions, query]);
+  const searching = query.trim().length > 0;
+
+  // 搜索时强制展开所有命中分组，避免折叠把结果藏起来。
+  const isCollapsed = key => !searching && Array.isArray(collapsedGroups) && collapsedGroups.includes(key);
+  const toggleGroup = key =>
+    setCollapsedGroups(prev => {
+      const list = Array.isArray(prev) ? prev : [];
+      return list.includes(key) ? list.filter(k => k !== key) : [...list, key];
+    });
+
   return (
     <aside className="session-panel">
       <div className="session-panel-header">
@@ -59,36 +141,63 @@ export function SessionList({ sessions, activeSessionId, modelList, onDelete, on
       {showMemoryPanel ? (
         <MemoryPanel onClose={onToggleMemory} />
       ) : (
-        <div className="session-list">
-          {sessions.map(session => {
-            const active = session.id === activeSessionId;
-            const modelLabel = formatSessionModels(session, modelList);
+        <>
+          <div className="session-search">
+            <Search size={14} className="session-search-icon" />
+            <input
+              className="session-search-input"
+              type="text"
+              placeholder="搜索会话…"
+              value={query}
+              onChange={event => setQuery(event.target.value)}
+            />
+            {query && (
+              <button className="session-search-clear" onClick={() => setQuery('')} title="清除">
+                <X size={13} />
+              </button>
+            )}
+          </div>
 
-            return (
-              <div key={session.id} className={`session-card ${active ? 'active' : ''}`}>
-                <button className="session-main" onClick={() => onSelect(session.id)} disabled={locked || active}>
-                  <span className="session-card-title">{getSessionTitle(session.messages)}</span>
-                  <span className="session-card-meta">{modelLabel} · {session.messages.length} 条</span>
-                </button>
+          <div className="session-list">
+            {groups.length === 0 ? (
+              <div className="session-empty">{searching ? '未找到匹配的会话' : '暂无会话'}</div>
+            ) : (
+              groups.map(group => {
+                const collapsed = isCollapsed(group.key);
 
-                {sessions.length > 1 && (
-                  <button
-                    className="session-delete-btn"
-                    onClick={() => onDelete(session.id)}
-                    disabled={locked}
-                    title="删除会话"
-                  >
-                    <Trash2 size={12} />
-                  </button>
-                )}
-              </div>
-            );
-          })}
+                return (
+                  <div key={group.key} className="session-group">
+                    <button
+                      className={`session-group-header ${collapsed ? 'collapsed' : ''}`}
+                      onClick={() => toggleGroup(group.key)}
+                    >
+                      <ChevronDown size={14} className="session-group-chevron" />
+                      <span className="session-group-label">{group.label}</span>
+                      <span className="session-group-count">{group.sessions.length}</span>
+                    </button>
 
-          {sessions.length > 1 && (
-            <button className="session-clear-all-btn" onClick={onClearAll} disabled={locked}>清空全部</button>
-          )}
-        </div>
+                    {!collapsed && group.sessions.map(session => (
+                      <SessionCard
+                        key={session.id}
+                        session={session}
+                        active={session.id === activeSessionId}
+                        modelLabel={formatSessionModels(session, modelList)}
+                        locked={locked}
+                        canDelete={sessions.length > 1}
+                        onSelect={onSelect}
+                        onDelete={onDelete}
+                      />
+                    ))}
+                  </div>
+                );
+              })
+            )}
+
+            {sessions.length > 1 && (
+              <button className="session-clear-all-btn" onClick={onClearAll} disabled={locked}>清空全部</button>
+            )}
+          </div>
+        </>
       )}
     </aside>
   );

--- a/client/src/components/session/session-grouping.js
+++ b/client/src/components/session/session-grouping.js
@@ -1,0 +1,43 @@
+import { calendarDaysAgo } from '../../utils/format.js';
+
+// 按“最近活动时间”落入的分组（从新到旧）；match 接收 calendarDaysAgo 的自然日差。
+export const GROUP_DEFS = [
+  { key: 'today', label: '今天', match: d => d === 0 },
+  { key: 'yesterday', label: '昨天', match: d => d === 1 },
+  { key: 'week', label: '近 7 天', match: d => d >= 2 && d < 7 },
+  { key: 'month', label: '近 30 天', match: d => d >= 7 && d < 30 },
+  { key: 'earlier', label: '更早', match: d => d >= 30 },
+];
+
+// 会话的最近活动时间：优先取最后一条带时间戳的消息（用户消息均带 ts，
+// 不会被 App.jsx 的 trace 重建逻辑污染），回退到 updatedAt / createdAt。
+export function lastActivityTs(session) {
+  const msgs = session.messages || [];
+  for (let i = msgs.length - 1; i >= 0; i -= 1) {
+    if (Number.isFinite(msgs[i].ts)) return msgs[i].ts;
+  }
+  return session.updatedAt || session.createdAt || null;
+}
+
+// 按消息内容做大小写不敏感匹配（标题取自首条用户消息，已包含在消息内容中）。
+// query 需为已 trim + lowercase 的非空串。
+export function sessionMatchesQuery(session, query) {
+  return (session.messages || []).some(
+    msg => typeof msg.content === 'string' && msg.content.toLowerCase().includes(query)
+  );
+}
+
+// 过滤 + 按最近活动时间分组，组内按时间倒序，空组剔除。
+export function buildGroups(sessions, query) {
+  const q = query.trim().toLowerCase();
+  const matched = q ? sessions.filter(session => sessionMatchesQuery(session, q)) : sessions;
+  const sorted = [...matched].sort((a, b) => (lastActivityTs(b) || 0) - (lastActivityTs(a) || 0));
+
+  return GROUP_DEFS
+    .map(def => ({
+      key: def.key,
+      label: def.label,
+      sessions: sorted.filter(session => def.match(calendarDaysAgo(lastActivityTs(session) || Date.now()))),
+    }))
+    .filter(group => group.sessions.length > 0);
+}

--- a/client/src/utils/format.js
+++ b/client/src/utils/format.js
@@ -8,3 +8,63 @@ export function formatMsgTime(ts) {
     timeZone: 'Asia/Shanghai',
   }).format(ts);
 }
+
+function pad2(n) {
+  return n < 10 ? `0${n}` : `${n}`;
+}
+
+// 当天 0 点（本地时区）的时间戳。
+function startOfDay(ts) {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+// 距今天的自然日数（本地时区）：今天 = 0，昨天 = 1，依此类推。会话列表分组用。
+export function calendarDaysAgo(ts) {
+  return Math.floor((startOfDay(Date.now()) - startOfDay(ts)) / 86400000);
+}
+
+// 完整时间 YYYY-MM-DD HH:mm（本地时区），用于卡片绝对时间与 hover title。
+export function formatFullTime(ts) {
+  if (!ts) return '';
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return '';
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+}
+
+// 短绝对时间 MM-DD HH:mm（本地时区），用于卡片上与相对时间并列展示。
+export function formatShortTime(ts) {
+  if (!ts) return '';
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return '';
+  return `${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+}
+
+// 相对时间：刚刚 / N分钟前 / N小时前 / 昨天 / N天前 / MM-DD / YYYY-MM-DD。
+export function formatRelativeTime(ts) {
+  if (!ts) return '';
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return '';
+
+  const now = Date.now();
+  const diffMs = now - ts;
+  if (diffMs < 0) {
+    // 时钟漂移导致的“未来”时间，回退为完整日期。
+    return formatFullTime(ts);
+  }
+
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return '刚刚';
+  if (diffMin < 60) return `${diffMin}分钟前`;
+
+  const dayDiff = calendarDaysAgo(ts);
+  if (dayDiff === 0) return `${Math.floor(diffMin / 60)}小时前`;
+  if (dayDiff === 1) return '昨天';
+  if (dayDiff < 7) return `${dayDiff}天前`;
+
+  const sameYear = date.getFullYear() === new Date(now).getFullYear();
+  return sameYear
+    ? `${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`
+    : `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}

--- a/test/format.test.js
+++ b/test/format.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  calendarDaysAgo,
+  formatFullTime,
+  formatShortTime,
+  formatRelativeTime,
+} from '../client/src/utils/format.js';
+
+// 用本地时间构造时间戳，断言与运行时区无关（构造与格式化都走本地时区）。
+const at = (y, mo, d, h = 0, mi = 0) => new Date(y, mo, d, h, mi, 0).getTime();
+
+describe('formatFullTime / formatShortTime', () => {
+  it('完整时间 → YYYY-MM-DD HH:mm', () => {
+    expect(formatFullTime(at(2026, 5, 15, 14, 30))).toBe('2026-06-15 14:30');
+    expect(formatFullTime(at(2026, 0, 3, 9, 5))).toBe('2026-01-03 09:05');
+  });
+
+  it('短时间 → MM-DD HH:mm', () => {
+    expect(formatShortTime(at(2026, 5, 15, 14, 30))).toBe('06-15 14:30');
+  });
+
+  it('空/非法值 → 空串', () => {
+    expect(formatFullTime(0)).toBe('');
+    expect(formatFullTime(null)).toBe('');
+    expect(formatShortTime(undefined)).toBe('');
+    expect(formatFullTime(NaN)).toBe('');
+  });
+});
+
+describe('calendarDaysAgo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 15, 12, 0, 0));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('按本地自然日计算天数差', () => {
+    expect(calendarDaysAgo(at(2026, 5, 15, 1, 0))).toBe(0);
+    expect(calendarDaysAgo(at(2026, 5, 14, 23, 0))).toBe(1);
+    expect(calendarDaysAgo(at(2026, 5, 8, 12, 0))).toBe(7);
+  });
+});
+
+describe('formatRelativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 15, 12, 0, 0));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('一分钟内 → 刚刚', () => {
+    expect(formatRelativeTime(Date.now() - 30 * 1000)).toBe('刚刚');
+  });
+
+  it('一小时内 → N分钟前', () => {
+    expect(formatRelativeTime(Date.now() - 5 * 60 * 1000)).toBe('5分钟前');
+  });
+
+  it('当天更早 → N小时前', () => {
+    expect(formatRelativeTime(Date.now() - 3 * 60 * 60 * 1000)).toBe('3小时前');
+  });
+
+  it('昨天 → 昨天', () => {
+    expect(formatRelativeTime(at(2026, 5, 14, 20, 0))).toBe('昨天');
+  });
+
+  it('一周内 → N天前', () => {
+    expect(formatRelativeTime(at(2026, 5, 12, 9, 0))).toBe('3天前');
+  });
+
+  it('超过 7 天(同年) → MM-DD', () => {
+    expect(formatRelativeTime(at(2026, 5, 1, 10, 0))).toBe('06-01');
+  });
+
+  it('跨年 → YYYY-MM-DD', () => {
+    expect(formatRelativeTime(at(2025, 11, 25, 10, 0))).toBe('2025-12-25');
+  });
+
+  it('未来时间(时钟漂移) → 回退完整时间', () => {
+    const future = Date.now() + 60 * 60 * 1000;
+    expect(formatRelativeTime(future)).toBe(formatFullTime(future));
+  });
+
+  it('空值 → 空串', () => {
+    expect(formatRelativeTime(0)).toBe('');
+    expect(formatRelativeTime(null)).toBe('');
+  });
+});

--- a/test/session-grouping.test.js
+++ b/test/session-grouping.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  lastActivityTs,
+  sessionMatchesQuery,
+  buildGroups,
+} from '../client/src/components/session/session-grouping.js';
+
+const at = (y, mo, d, h = 0, mi = 0) => new Date(y, mo, d, h, mi, 0).getTime();
+
+describe('lastActivityTs', () => {
+  it('取最后一条带 ts 的消息时间', () => {
+    const s = {
+      messages: [
+        { role: 'user', content: 'a', ts: at(2026, 5, 10) },
+        { role: 'assistant', content: 'b', ts: at(2026, 5, 11) },
+      ],
+      updatedAt: at(2026, 5, 15),
+    };
+    expect(lastActivityTs(s)).toBe(at(2026, 5, 11));
+  });
+
+  it('末条消息缺 ts → 回退上一条带 ts 的消息(绕过被污染的 updatedAt)', () => {
+    const s = {
+      messages: [
+        { role: 'user', content: 'a', ts: at(2026, 5, 10) },
+        { role: 'assistant', content: 'b' }, // 流式 assistant 常丢 ts
+      ],
+      updatedAt: at(2026, 5, 15), // 被 trace 重建刷成更晚的时间
+    };
+    expect(lastActivityTs(s)).toBe(at(2026, 5, 10));
+  });
+
+  it('无任何消息 ts → 回退 updatedAt', () => {
+    const s = { messages: [{ role: 'user', content: 'a' }], updatedAt: at(2026, 5, 15), createdAt: at(2026, 5, 1) };
+    expect(lastActivityTs(s)).toBe(at(2026, 5, 15));
+  });
+
+  it('无消息且无 updatedAt → 回退 createdAt', () => {
+    const s = { messages: [], createdAt: at(2026, 5, 1) };
+    expect(lastActivityTs(s)).toBe(at(2026, 5, 1));
+  });
+});
+
+describe('sessionMatchesQuery', () => {
+  const s = {
+    messages: [
+      { role: 'user', content: '帮我写一个 Python 爬虫' },
+      { role: 'assistant', content: '好的，这是代码' },
+    ],
+  };
+
+  it('匹配消息内容(大小写不敏感)', () => {
+    expect(sessionMatchesQuery(s, 'python')).toBe(true);
+    expect(sessionMatchesQuery(s, '爬虫')).toBe(true);
+    expect(sessionMatchesQuery(s, '代码')).toBe(true);
+  });
+
+  it('无匹配 → false', () => {
+    expect(sessionMatchesQuery(s, 'java')).toBe(false);
+  });
+});
+
+describe('buildGroups', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 15, 12, 0, 0));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  const mk = (id, ts, updatedAt) => ({
+    id,
+    messages: ts ? [{ role: 'user', content: `消息 ${id}`, ts }] : [],
+    updatedAt,
+    createdAt: updatedAt,
+  });
+
+  it('按时间分组、空组剔除', () => {
+    const sessions = [
+      mk('a', at(2026, 5, 15, 9, 0)), // 今天
+      mk('b', at(2026, 5, 14, 9, 0)), // 昨天
+      mk('c', at(2026, 5, 12, 9, 0)), // 近 7 天
+      mk('d', at(2026, 4, 1, 9, 0)),  // 更早
+    ];
+    const groups = buildGroups(sessions, '');
+    expect(groups.map(g => g.key)).toEqual(['today', 'yesterday', 'week', 'earlier']);
+  });
+
+  it('同组内按最近活动倒序', () => {
+    const sessions = [
+      mk('old', at(2026, 5, 15, 8, 0)),
+      mk('new', at(2026, 5, 15, 11, 0)),
+    ];
+    const groups = buildGroups(sessions, '');
+    expect(groups[0].sessions.map(s => s.id)).toEqual(['new', 'old']);
+  });
+
+  it('用消息 ts 而非被污染的 updatedAt 分组(核心修复验证)', () => {
+    // updatedAt 被刷成今天，但真实消息在 3 天前 → 应进“近 7 天”而非“今天”
+    const sessions = [mk('s', at(2026, 5, 12, 9, 0), at(2026, 5, 15, 12, 0))];
+    const groups = buildGroups(sessions, '');
+    expect(groups[0].key).toBe('week');
+  });
+
+  it('搜索过滤命中会话', () => {
+    const a = mk('a', at(2026, 5, 15, 9, 0));
+    a.messages = [{ role: 'user', content: 'apple pie', ts: at(2026, 5, 15, 9, 0) }];
+    const b = mk('b', at(2026, 5, 15, 9, 0));
+    b.messages = [{ role: 'user', content: 'banana split', ts: at(2026, 5, 15, 9, 0) }];
+    const groups = buildGroups([a, b], 'APPLE');
+    expect(groups.length).toBe(1);
+    expect(groups[0].sessions.map(s => s.id)).toEqual(['a']);
+  });
+});


### PR DESCRIPTION
## 概述
为左侧会话列表增加三项能力，方便会话变多时快速定位。

## 改动
- **时间显示**：每张会话卡片显示最近活动时间，相对时间 + 绝对时间并列（如 `3天前 · 06-15 14:30`），hover 显示完整时间。新增 `formatRelativeTime` / `formatShortTime` / `formatFullTime` / `calendarDaysAgo`（`client/src/utils/format.js`）。
- **分组折叠**：按 今天 / 昨天 / 近 7 天 / 近 30 天 / 更早 分组，组内按 `updatedAt` 倒序，空组不显示；组头可点击折叠，折叠状态用 `usePersistentState` 持久化（默认全部展开）。
- **搜索**：顶部搜索框，按标题 + 消息全文过滤（大小写不敏感），带清除按钮；搜索时自动展开命中分组，无结果时有提示。
- 抽出内部 `SessionCard` 子组件；删除 / 清空按钮仍按总会话数判断显示。

## 验证
- `npm run lint` ✅ 无错误
- `npm run build:client` ✅ 构建通过