### PR TITLE
feat(config): Agent 行为参数前台可配热生效，API Key 只读展示

### DIFF
--- a/agent/core/memory.ts
+++ b/agent/core/memory.ts
@@ -37,10 +37,10 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { cleanText } from './utils.ts';
+import { runtimeConfig } from './runtime-config.ts';
 
 const MEMORY_FILE = 'agent-memory.json';
 const MAX_CHARS = 3000;
-const MAX_CONVERSATION_ENTRIES = Number(process.env.AGENT_MEMORY_MAX_ENTRIES || 20);
 const MAX_KNOWLEDGE_PER_CATEGORY = 50;
 
 function emptyMemory() {
@@ -255,7 +255,8 @@ export function extractProjectKnowledge(memory, { task: _task, result }) {
   }
 }
 
-export async function compactConversationMemory(memory, { maxEntries = MAX_CONVERSATION_ENTRIES, summarizeFn }: { maxEntries?: number; summarizeFn?: (text: string) => Promise<string> } = {}) {
+export async function compactConversationMemory(memory, { maxEntries, summarizeFn }: { maxEntries?: number; summarizeFn?: (text: string) => Promise<string> } = {}) {
+  if (maxEntries == null) maxEntries = runtimeConfig.get().memoryMaxEntries;
   const conv = memory.conversation;
   if (conv.length <= maxEntries) {
     return;

--- a/agent/core/runtime-config.ts
+++ b/agent/core/runtime-config.ts
@@ -1,0 +1,192 @@
+/**
+ * Runtime Config — 集中的运行时配置层（单一数据源 + 落盘）
+ *
+ * 把原先散落在 server.ts / runtime.ts / memory.ts 里、启动时从 process.env
+ * 冻结的 Agent 行为参数收敛到这里。消费点改为每次读 get()，因此前台改完
+ * 下次 agent 任务即自动生效，无需重启进程。
+ *
+ * 数据来源优先级：data/runtime-config.json（前台覆盖） > .env（默认值底）。
+ *   - computeEnvDefaults() 从 process.env 算默认值（保留各处原有默认）
+ *   - runtime-config.json 只存用户在前台改过的覆盖项
+ *   - reset() 清空覆盖，回到 .env 默认
+ *
+ * get() 是同步的（compressHistory 等热路径是同步函数）；current 在模块加载时
+ * 即初始化为 env 默认值，init() 再叠加 json，故任何时刻 get() 都安全。
+ *
+ * API Key 不在此管理（前台只读展示，仍在 .env 改）。
+ */
+
+import { readFile, writeFile, rename, unlink } from 'node:fs/promises';
+import path from 'node:path';
+import { log } from '../../helpers/logger.ts';
+
+export interface RuntimeConfig {
+  maxSteps: number;
+  modelTimeoutSec: number;
+  staggerDelaySec: number;
+  batchSize: number;
+  observeDesktop: boolean;
+  maxHistorySteps: number;
+  maxResultChars: number;
+  maxParallelResultChars: number;
+  memoryMaxEntries: number;
+}
+
+type FieldSpec = { type: 'int' | 'bool'; min?: number; max?: number };
+
+// 字段范围（防呆上下限）。staggerDelay 允许 0（无错峰）。
+const FIELD_SPEC: Record<keyof RuntimeConfig, FieldSpec> = {
+  maxSteps: { type: 'int', min: 1, max: 512 },
+  modelTimeoutSec: { type: 'int', min: 1, max: 3600 },
+  staggerDelaySec: { type: 'int', min: 0, max: 120 },
+  batchSize: { type: 'int', min: 1, max: 32 },
+  observeDesktop: { type: 'bool' },
+  maxHistorySteps: { type: 'int', min: 1, max: 200 },
+  maxResultChars: { type: 'int', min: 100, max: 200000 },
+  maxParallelResultChars: { type: 'int', min: 100, max: 1000000 },
+  memoryMaxEntries: { type: 'int', min: 1, max: 1000 },
+};
+
+const FIELD_KEYS = Object.keys(FIELD_SPEC) as (keyof RuntimeConfig)[];
+
+/** 纯函数：从 env 计算默认值（保留 server.ts / runtime.ts / memory.ts 原有默认）。 */
+export function computeEnvDefaults(env: Record<string, string | undefined> = process.env): RuntimeConfig {
+  return {
+    maxSteps: Number(env.AGENT_MAX_STEPS) || 8,
+    modelTimeoutSec: Number(env.AGENT_MODEL_TIMEOUT) || 90,
+    staggerDelaySec: Number(env.AGENT_STAGGER_DELAY) || 5,
+    batchSize: Number(env.AGENT_BATCH_SIZE) || 1,
+    observeDesktop: env.AGENT_OBSERVE_DESKTOP === 'true',
+    maxHistorySteps: Number(env.AGENT_MAX_HISTORY_STEPS) || 20,
+    maxResultChars: Number(env.AGENT_MAX_RESULT_CHARS) || 8000,
+    maxParallelResultChars: Number(env.AGENT_MAX_PARALLEL_RESULT_CHARS) || 32000,
+    memoryMaxEntries: Number(env.AGENT_MEMORY_MAX_ENTRIES) || 20,
+  };
+}
+
+/**
+ * 纯函数：校验前台传来的 patch，返回 { clean, errors }。
+ * - 只认识 FIELD_SPEC 里的键，未知键忽略
+ * - int 字段必须是有限整数且在 [min,max]；bool 字段必须是布尔
+ * - 任一字段非法记入 errors，且不进入 clean
+ */
+export function validateConfig(patch: any): { clean: Partial<RuntimeConfig>; errors: string[] } {
+  const clean: Partial<RuntimeConfig> = {};
+  const errors: string[] = [];
+  if (!patch || typeof patch !== 'object') {
+    return { clean, errors: ['配置必须是对象'] };
+  }
+  for (const key of FIELD_KEYS) {
+    if (!(key in patch)) continue;
+    const spec = FIELD_SPEC[key];
+    const v = (patch as any)[key];
+    if (spec.type === 'bool') {
+      if (typeof v !== 'boolean') {
+        errors.push(`${key} 必须是布尔值`);
+        continue;
+      }
+      (clean as any)[key] = v;
+    } else {
+      const n = typeof v === 'number' ? v : Number(v);
+      if (!Number.isFinite(n) || !Number.isInteger(n)) {
+        errors.push(`${key} 必须是整数`);
+        continue;
+      }
+      if (spec.min != null && n < spec.min) {
+        errors.push(`${key} 不能小于 ${spec.min}`);
+        continue;
+      }
+      if (spec.max != null && n > spec.max) {
+        errors.push(`${key} 不能大于 ${spec.max}`);
+        continue;
+      }
+      (clean as any)[key] = n;
+    }
+  }
+  return { clean, errors };
+}
+
+/** 纯函数：默认值 + 覆盖项合并（覆盖项只取已知且非空的键）。 */
+export function mergeConfig(defaults: RuntimeConfig, overrides: Partial<RuntimeConfig> | null | undefined): RuntimeConfig {
+  const merged = { ...defaults };
+  if (overrides && typeof overrides === 'object') {
+    for (const key of FIELD_KEYS) {
+      if (key in overrides && (overrides as any)[key] != null) {
+        (merged as any)[key] = (overrides as any)[key];
+      }
+    }
+  }
+  return merged;
+}
+
+// ── 单例 ──────────────────────────────────────────────
+let envDefaults = computeEnvDefaults();
+let overrides: Partial<RuntimeConfig> = {};
+let current: RuntimeConfig = { ...envDefaults };
+let filePath: string | null = null;
+let saveChain: Promise<void> = Promise.resolve();
+
+function recompute() {
+  current = mergeConfig(envDefaults, overrides);
+}
+
+async function persist() {
+  if (!filePath) return;
+  const target = filePath;
+  const tmp = target + '.tmp';
+  await writeFile(tmp, JSON.stringify(overrides, null, 2));
+  await rename(tmp, target);
+}
+
+export const runtimeConfig = {
+  /** 启动时调用一次：设定落盘目录并加载 json 覆盖。 */
+  async init(persistDir: string): Promise<RuntimeConfig> {
+    envDefaults = computeEnvDefaults();
+    filePath = path.join(persistDir, 'runtime-config.json');
+    try {
+      const raw = await readFile(filePath, 'utf-8');
+      overrides = validateConfig(JSON.parse(raw)).clean;
+    } catch {
+      overrides = {};
+    }
+    recompute();
+    return current;
+  },
+
+  /** 同步返回当前完整配置（热路径用）。 */
+  get(): RuntimeConfig {
+    return current;
+  },
+
+  /** env 默认值（前端展示「恢复默认」对照用）。 */
+  defaults(): RuntimeConfig {
+    return { ...envDefaults };
+  },
+
+  /** 校验并合并 patch，落盘后返回最新配置。校验失败抛错（含原因）。 */
+  async update(patch: any): Promise<RuntimeConfig> {
+    const { clean, errors } = validateConfig(patch);
+    if (errors.length) {
+      throw new Error(errors.join('；'));
+    }
+    overrides = { ...overrides, ...clean };
+    recompute();
+    saveChain = saveChain.then(persist).catch(err => log.error('[RuntimeConfig] 保存失败:', err?.message || err));
+    await saveChain;
+    return current;
+  },
+
+  /** 清空覆盖，回到 env 默认（删除覆盖文件）。 */
+  async reset(): Promise<RuntimeConfig> {
+    overrides = {};
+    recompute();
+    if (filePath) {
+      const target = filePath;
+      saveChain = saveChain.then(() => unlink(target)).catch(() => {});
+      await saveChain;
+    }
+    return current;
+  },
+};
+
+export type RuntimeConfigStore = typeof runtimeConfig;

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -36,11 +36,7 @@ import {
   HEALTH_CHECKPOINT_INTERVAL,
 } from "./checkpoint.js";
 import { assessResultQuality } from "./result-quality.ts";
-
-const MAX_HISTORY_STEPS = Number(process.env.AGENT_MAX_HISTORY_STEPS || 20);
-const MAX_RESULT_CHARS = Number(process.env.AGENT_MAX_RESULT_CHARS || 8000);
-// parallel_fetch 把多个页面拼成单步 result，按 URL 数放大该步预算，封顶此值，避免被截到只剩第一页
-const MAX_PARALLEL_RESULT_CHARS = Number(process.env.AGENT_MAX_PARALLEL_RESULT_CHARS || 32000);
+import { runtimeConfig } from "./runtime-config.ts";
 
 function actionTargetUrl(action) {
   if (typeof action?.url === 'string' && action.url) return action.url;
@@ -48,7 +44,10 @@ function actionTargetUrl(action) {
   return null;
 }
 
-function compressHistory(history, maxSteps = MAX_HISTORY_STEPS) {
+function compressHistory(history, maxSteps?) {
+  // 历史截断预算每次从运行时配置读取，前台改完无需重启即生效
+  const { maxHistorySteps, maxResultChars: MAX_RESULT_CHARS, maxParallelResultChars: MAX_PARALLEL_RESULT_CHARS } = runtimeConfig.get();
+  if (maxSteps == null) maxSteps = maxHistorySteps;
   // Progressive truncation: recent steps keep more context, old steps get shorter results
   const truncateEntry = (h, remaining) => {
     // Last 3 steps: full (up to MAX_RESULT_CHARS)
@@ -179,7 +178,7 @@ export async function runAgentRuntime({
         observation,
       });
 
-      const compactHistory = compressHistory(history, MAX_HISTORY_STEPS);
+      const compactHistory = compressHistory(history);
 
       // ---- 决策前再次检查取消 ----
       if (cancelled()) {

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -45,6 +45,7 @@ import { observeDesktopAgent } from './observer.ts';
 import { createDesktopPlanner, DEFAULT_MODEL_TIMEOUT_MS } from './planner.ts';
 import { saveCheckpoint } from '../core/checkpoint.ts';
 import { log } from '../../helpers/logger.ts';
+import { runtimeConfig } from '../core/runtime-config.ts';
 
 export function createDesktopAgentRunner({
   registry,
@@ -64,12 +65,26 @@ export function createDesktopAgentRunner({
   const domainRules = createDomainRules(checkpointDir);
   const { ensureBrowserSession } = createSharedBrowserSessionManager();
 
+  // Agent 行为参数每次 run 实时读取（前台改完无需重启即生效）；
+  // 构造参数（maxSteps 等）保留为兜底，运行时优先用 runtimeConfig。
+  function liveConfig() {
+    const c = runtimeConfig.get();
+    return {
+      maxSteps: c.maxSteps,
+      modelTimeoutMs: c.modelTimeoutSec * 1000,
+      staggerDelayMs: c.staggerDelaySec * 1000,
+      batchSize: c.batchSize,
+      observeDesktop: c.observeDesktop,
+    };
+  }
+
   // Sub-agent runner factory: creates isolated runners for parallel execution
   function createSubAgentRunner(parentRunId: string, parentModel: string, parentAgentModels: string[], parentStrategy: string, parentSystemPrompt: string | null, parentCancelSignal: AbortSignal) {
     const subBrowserManager = createSharedBrowserSessionManager();
 
     return async (task: string, subIndex: number) => {
       const subRunId = `${parentRunId}::sub${subIndex}`;
+      const { maxSteps, modelTimeoutMs, staggerDelayMs, batchSize } = liveConfig();
       log.info(`[SubAgent] 启动子任务 ${subIndex}: ${task.slice(0, 60)}...`);
 
       const subBlacklistedModels = new Set();
@@ -236,6 +251,7 @@ export function createDesktopAgentRunner({
     conversationHistory = [],
     memory = true,
   }) {
+    const { maxSteps, modelTimeoutMs, staggerDelayMs, batchSize, observeDesktop } = liveConfig();
     const blacklistedModels = new Set();
     const plan = createDesktopPlanner({ registry, modelConfig, blacklistedModels, modelTimeoutMs, staggerDelayMs, batchSize });
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2529,6 +2529,37 @@ textarea:disabled {
 .dialog-btn.cancel:hover { background: #eee; }
 .dialog-btn.confirm { background: var(--c-danger); color: var(--c-surface); border-color: var(--c-danger); }
 .dialog-btn.confirm:hover { background: var(--c-danger-hover); }
+.dialog-btn.primary { background: var(--c-primary); color: var(--c-surface); border-color: var(--c-primary); }
+.dialog-btn.primary:hover { filter: brightness(0.95); }
+.dialog-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Settings dialog ── */
+.hero-settings { position: absolute; top: 0; right: 40px; }
+
+.settings-dialog { width: min(560px, 94vw); max-height: 86vh; overflow-y: auto; }
+.settings-section { margin-bottom: 20px; }
+.settings-section-title { font-size: var(--f-sm); font-weight: 600; margin-bottom: 4px; }
+
+.settings-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px 16px; }
+.settings-field { display: flex; flex-direction: column; gap: 4px; font-size: var(--f-sm); color: var(--c-text-secondary); }
+.settings-field input[type="number"] {
+  height: 34px; padding: 0 10px; border: 1px solid var(--c-border);
+  border-radius: var(--r-sm); background: var(--c-surface); font-size: 14px; color: var(--c-text);
+}
+.settings-field-switch { flex-direction: row; align-items: center; justify-content: space-between; grid-column: 1 / -1; }
+.settings-field-switch input { width: 18px; height: 18px; }
+
+.settings-keys { display: flex; flex-direction: column; gap: 8px; }
+.settings-key-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 8px 12px; border: 1px solid var(--c-border); border-radius: var(--r-sm); font-size: var(--f-sm);
+}
+.settings-key-provider { font-weight: 600; text-transform: capitalize; }
+.settings-key-status.on { color: #2e7d32; font-family: monospace; }
+.settings-key-status.off { color: #9a9aa5; }
+
+.settings-error { color: var(--c-danger); font-size: var(--f-sm); margin-top: 8px; }
+.settings-ok { color: #2e7d32; font-size: var(--f-sm); margin-top: 8px; }
 
 
 /* ── Attachments ── */

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,7 @@ import { CopyButton } from './components/CopyButton.jsx';
 import { ResetDialog } from './components/dialogs/ResetDialog.jsx';
 import { ApprovalDialog } from './components/dialogs/ApprovalDialog.jsx';
 import { QuestionDialog } from './components/dialogs/QuestionDialog.jsx';
+import { SettingsDialog } from './components/dialogs/SettingsDialog.jsx';
 import { SessionList } from './components/session/SessionList.jsx';
 import { AgentPanel } from './components/agent/AgentPanel.jsx';
 import { ModelSelector } from './components/ModelSelector.jsx';
@@ -151,6 +152,7 @@ export default function App() {
   } = useAgentRun();
   const [agentMemory, setAgentMemory] = usePersistentState('agent_memory', true, booleanStorage);
   const [showReset, setShowReset] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const { showSessions, setShowSessions } = useResponsiveLayout({
     dockedBreakpoint: DOCKED_LAYOUT_BREAKPOINT,
     panelSizeKey: PANEL_SIZE_KEY,
@@ -837,6 +839,7 @@ export default function App() {
             setTimeout(() => handleSubmit(), 0);
           }}
           onToggleSessions={() => setShowSessions(v => !v)}
+          onOpenSettings={() => setShowSettings(true)}
         />
       ) : (
         <div className="layout">
@@ -857,6 +860,7 @@ export default function App() {
             onToggleSessions={() => setShowSessions(v => !v)}
             onCreateSession={handleCreateSession}
             onReset={() => setShowReset(true)}
+            onOpenSettings={() => setShowSettings(true)}
           />
 
           <div className={`layout-body ${mode === 'agent' ? 'agent-layout' : 'chat-layout'}`}>
@@ -935,6 +939,7 @@ export default function App() {
       />
 
       {showReset && <ResetDialog onConfirm={handleReset} onCancel={() => setShowReset(false)} />}
+      {showSettings && <SettingsDialog onClose={() => setShowSettings(false)} />}
     </div>
     </ErrorBoundary>
   );

--- a/client/src/api/config.js
+++ b/client/src/api/config.js
@@ -1,0 +1,25 @@
+// Agent 行为参数配置 + API Key 只读状态 API。
+// GET 拉取当前配置/默认值/Key 状态；POST 保存参数；reset 恢复默认。
+
+export async function fetchConfig() {
+  const res = await fetch('/api/config');
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+export async function saveConfig(patch) {
+  const res = await fetch('/api/config', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+
+export async function resetConfig() {
+  const res = await fetch('/api/config/reset', { method: 'POST' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}

--- a/client/src/components/AppHeader.jsx
+++ b/client/src/components/AppHeader.jsx
@@ -1,4 +1,4 @@
-import { Menu, Trash2 } from 'lucide-react';
+import { Menu, Settings, Trash2 } from 'lucide-react';
 
 // 已开始会话后的顶部 header：左侧菜单/新建/标题，右侧模式切换/模型选择/标签/清空。
 // modeSwitch、modelSelect 由父组件传 slot 进来（同一控件在 hero 和 header 共用）。
@@ -14,6 +14,7 @@ export function AppHeader({
   onToggleSessions,
   onCreateSession,
   onReset,
+  onOpenSettings,
 }) {
   return (
     <div className="header">
@@ -32,6 +33,9 @@ export function AppHeader({
         {sessionStarted && mode !== 'agent' && (
           <span className="header-model-label">{selectedChatModelLabel}</span>
         )}
+        <button className="header-icon-btn" onClick={onOpenSettings} title="设置">
+          <Settings size={14} />
+        </button>
         <button
           className="header-icon-btn"
           onClick={onReset}

--- a/client/src/components/HeroScreen.jsx
+++ b/client/src/components/HeroScreen.jsx
@@ -1,4 +1,4 @@
-import { Menu } from 'lucide-react';
+import { Menu, Settings } from 'lucide-react';
 import { SuggestionsList } from './SuggestionsList.jsx';
 
 // 首屏：brand + 输入卡 + 推荐列表。
@@ -21,6 +21,7 @@ export function HeroScreen({
   onPickSuggestion,
   onSubmitSuggestion,
   onToggleSessions,
+  onOpenSettings,
 }) {
   const { modeSwitch, modelSelect, memoryToggle, sendButton, attachButton } = toolbarSlots;
   return (
@@ -28,6 +29,9 @@ export function HeroScreen({
       <div className="hero">
         <button className="session-toggle-btn hero-menu" onClick={onToggleSessions} title="会话列表">
           <Menu size={16} />
+        </button>
+        <button className="session-toggle-btn hero-settings" onClick={onOpenSettings} title="设置">
+          <Settings size={16} />
         </button>
 
         <div className="hero-brand">

--- a/client/src/components/dialogs/SettingsDialog.jsx
+++ b/client/src/components/dialogs/SettingsDialog.jsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from 'react';
+import { fetchConfig, saveConfig, resetConfig } from '../../api/config.js';
+
+// Agent 行为参数（可写，热生效）。单位与 .env 一致，换算放后端消费点。
+const NUM_FIELDS = [
+  { key: 'maxSteps', label: '单次任务最大步数' },
+  { key: 'modelTimeoutSec', label: '单模型超时（秒）' },
+  { key: 'staggerDelaySec', label: '竞速批次间隔（秒）' },
+  { key: 'batchSize', label: '每批启动模型数' },
+  { key: 'maxHistorySteps', label: '最大历史步数' },
+  { key: 'maxResultChars', label: '每步结果最大字符数' },
+  { key: 'maxParallelResultChars', label: '并行抓取字符上限' },
+  { key: 'memoryMaxEntries', label: '记忆压缩阈值' },
+];
+
+// 设置面板：Agent 行为参数可写（保存后下次任务即生效），API Key 只读展示。
+export function SettingsDialog({ onClose }) {
+  const [agent, setAgent] = useState(null);
+  const [keys, setKeys] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    fetchConfig()
+      .then(data => {
+        if (!alive) return;
+        setAgent(data.agent);
+        setKeys(data.keys || []);
+      })
+      .catch(e => { if (alive) setError(e.message); })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, []);
+
+  const setField = (key, value) => {
+    setAgent(prev => ({ ...prev, [key]: value }));
+    setSaved(false);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const data = await saveConfig(agent);
+      setAgent(data.agent);
+      setSaved(true);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setSaving(true);
+    setError('');
+    try {
+      const data = await resetConfig();
+      setAgent(data.agent);
+      setSaved(true);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="dialog-mask" onClick={onClose}>
+      <div className="dialog settings-dialog" onClick={e => e.stopPropagation()}>
+        <p className="dialog-title">设置</p>
+
+        {loading ? (
+          <p className="dialog-desc">加载中…</p>
+        ) : !agent ? (
+          <p className="settings-error">{error || '加载失败'}</p>
+        ) : (
+          <>
+            <div className="settings-section">
+              <p className="settings-section-title">Agent 行为参数</p>
+              <p className="dialog-desc">保存后下次任务即生效，无需重启后端。</p>
+              <div className="settings-grid">
+                {NUM_FIELDS.map(f => (
+                  <label key={f.key} className="settings-field">
+                    <span>{f.label}</span>
+                    <input
+                      type="number"
+                      value={agent[f.key]}
+                      onChange={e => setField(f.key, e.target.value === '' ? '' : Number(e.target.value))}
+                    />
+                  </label>
+                ))}
+                <label className="settings-field settings-field-switch">
+                  <span>观测 macOS 桌面</span>
+                  <input
+                    type="checkbox"
+                    checked={!!agent.observeDesktop}
+                    onChange={e => setField('observeDesktop', e.target.checked)}
+                  />
+                </label>
+              </div>
+            </div>
+
+            <div className="settings-section">
+              <p className="settings-section-title">API Key（只读）</p>
+              <p className="dialog-desc">Key 在 .env 配置，修改后需重启后端。</p>
+              <div className="settings-keys">
+                {keys.map(k => (
+                  <div key={k.envVar} className="settings-key-row">
+                    <span className="settings-key-provider">{k.provider}</span>
+                    <span className={`settings-key-status ${k.configured ? 'on' : 'off'}`}>
+                      {k.configured ? k.masked : '未配置'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {error && <p className="settings-error">{error}</p>}
+            {saved && !error && <p className="settings-ok">已保存</p>}
+          </>
+        )}
+
+        <div className="dialog-actions">
+          <button className="dialog-btn cancel" onClick={onClose} disabled={saving}>关闭</button>
+          <button className="dialog-btn" onClick={handleReset} disabled={loading || saving || !agent}>恢复默认</button>
+          <button className="dialog-btn primary" onClick={handleSave} disabled={loading || saving || !agent}>保存</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/routes/agent-config.ts
+++ b/routes/agent-config.ts
@@ -1,0 +1,70 @@
+import { Router } from 'express';
+import { deriveProviderName } from '../agent/core/ai-client.ts';
+import type { AgentRouterContext } from './agent-types.ts';
+
+// 只读展示用：脱敏 API Key（仅保留后 4 位，绝不回传明文）。
+function maskKey(key?: string): string | null {
+  if (!key) return null;
+  return `••••${key.slice(-4)}`;
+}
+
+// 三家供应商的 Key 状态（只读）。Key 仍在 .env 配置，前台仅展示是否已配置 + 脱敏尾号。
+function describeKeys() {
+  const nvidiaKey = process.env.NVIDIA_API_KEY;
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  const geminiKey = process.env.GEMINI_API_KEY;
+  return [
+    {
+      envVar: 'NVIDIA_API_KEY',
+      provider: deriveProviderName(process.env.NVIDIA_BASE_URL),
+      baseUrl: process.env.NVIDIA_BASE_URL || 'https://integrate.api.nvidia.com/v1',
+      configured: !!nvidiaKey,
+      masked: maskKey(nvidiaKey),
+    },
+    {
+      envVar: 'ANTHROPIC_API_KEY',
+      provider: 'anthropic',
+      baseUrl: process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com',
+      configured: !!anthropicKey,
+      masked: maskKey(anthropicKey),
+    },
+    {
+      envVar: 'GEMINI_API_KEY',
+      provider: 'gemini',
+      baseUrl: 'https://generativelanguage.googleapis.com',
+      configured: !!geminiKey,
+      masked: maskKey(geminiKey),
+    },
+  ];
+}
+
+export function createAgentConfigRouter({ runtimeConfig }: AgentRouterContext) {
+  const router = Router();
+
+  // 当前 Agent 行为参数 + env 默认值（供前端「恢复默认」对照）+ Key 只读状态。
+  router.get('/api/config', (_req, res) => {
+    res.json({
+      agent: runtimeConfig.get(),
+      defaults: runtimeConfig.defaults(),
+      keys: describeKeys(),
+    });
+  });
+
+  // 更新 Agent 行为参数；校验失败返回 400 + 原因，成功后落盘并下次任务即生效。
+  router.post('/api/config', async (req, res) => {
+    try {
+      const agent = await runtimeConfig.update(req.body ?? {});
+      res.json({ agent });
+    } catch (err: any) {
+      res.status(400).json({ error: err?.message || '配置校验失败' });
+    }
+  });
+
+  // 清空前台覆盖，回到 .env 默认值。
+  router.post('/api/config/reset', async (_req, res) => {
+    const agent = await runtimeConfig.reset();
+    res.json({ agent });
+  });
+
+  return router;
+}

--- a/routes/agent-types.ts
+++ b/routes/agent-types.ts
@@ -1,4 +1,5 @@
 import type { ProviderRegistry } from '../agent/core/providers/registry.ts';
+import type { RuntimeConfigStore } from '../agent/core/runtime-config.ts';
 
 export interface AgentRouterContext {
   runDesktopAgent: any;
@@ -9,4 +10,5 @@ export interface AgentRouterContext {
   domainRules: any;
   modelConfig: any[];
   registry: ProviderRegistry;
+  runtimeConfig: RuntimeConfigStore;
 }

--- a/routes/agent.ts
+++ b/routes/agent.ts
@@ -13,6 +13,7 @@ import { Router } from 'express';
 import { createAgentRunRouter } from './agent-run.ts';
 import { createAgentApprovalRouter } from './agent-approval.ts';
 import { createAgentFetchRulesRouter } from './agent-fetch-rules.ts';
+import { createAgentConfigRouter } from './agent-config.ts';
 import { createAgentMemoryRouter } from './agent-memory.ts';
 import { createAgentCheckpointRouter } from './agent-checkpoints.ts';
 import { createAgentTraceRouter } from './agent-traces.ts';
@@ -25,6 +26,7 @@ export function createAgentRouter(context: AgentRouterContext) {
   router.use(createAgentRunRouter(context));
   router.use(createAgentApprovalRouter(context));
   router.use(createAgentFetchRulesRouter(context));
+  router.use(createAgentConfigRouter(context));
   router.use(createAgentMemoryRouter(context));
   router.use(createAgentCheckpointRouter(context));
   router.use(createAgentTraceRouter(context));

--- a/server.ts
+++ b/server.ts
@@ -52,6 +52,7 @@ import { loadMemory, saveMemory } from './agent/core/memory.ts';
 import { createBaseEventSender, loadMemoryForPrompt, cleanupAgentRun } from './helpers/run-agent.ts';
 import { padEndW, truncateW } from './agent/core/utils.ts';
 import { log } from './helpers/logger.ts';
+import { runtimeConfig } from './agent/core/runtime-config.ts';
 
 const app = express();
 app.use(cors());
@@ -72,6 +73,9 @@ const AGENT_RESUME = process.env.AGENT_RESUME !== 'false';
 
 initLlmLogger(MEMORY_DIR);
 initWebViewDataStore(MEMORY_DIR);
+// 运行时配置层：以 .env 为默认值底，叠加 data/runtime-config.json 的前台覆盖。
+// 必须在 createDesktopAgentRunner 之前 init，且供 runtime.ts/memory.ts 热读取。
+await runtimeConfig.init(MEMORY_DIR);
 
 const AGENT_MAX_STEPS = Number(process.env.AGENT_MAX_STEPS || 8);
 const VISION_MODEL = (process.env.VISION_MODEL || DEFAULT_VISION_MODEL).trim();
@@ -97,7 +101,7 @@ const SCREENSHOT_DIR = path.join(MEMORY_DIR, 'screenshots');
 app.use('/screenshots', express.static(SCREENSHOT_DIR));
 
 app.use(createChatRouter({ registry, modelConfig }));
-app.use(createAgentRouter({ runDesktopAgent, agentRunStore, approvalStore, memoryDir: MEMORY_DIR, checkpointDir: CHECKPOINT_DIR, domainRules: runDesktopAgent.domainRules, modelConfig, registry }));
+app.use(createAgentRouter({ runDesktopAgent, agentRunStore, approvalStore, memoryDir: MEMORY_DIR, checkpointDir: CHECKPOINT_DIR, domainRules: runDesktopAgent.domainRules, modelConfig, registry, runtimeConfig }));
 app.use(createCompletionsRouter({ registry, modelConfig }));
 app.use(createSuggestionsRouter({ store: createSuggestionStore(path.join(__dirname, 'data')) }));
 
@@ -158,6 +162,7 @@ async function resumeFromCheckpoint(cp) {
 }
 
 app.listen(Number(PORT), HOST, async () => {
+  const cfg = runtimeConfig.get();
   const multiModels = loadAgentMultiModels();
   const ideConfig = loadIdeMcpConfig();
   const chromeConfig = loadChromeMcpConfig();
@@ -175,14 +180,14 @@ app.listen(Number(PORT), HOST, async () => {
   ${multiModels.length > 0 ? row('MultiModel', multiModels.join(', ')) : ''}
   ${row('VISION_MODEL', VISION_MODEL)}
   ${hLine}
-  ${row('AGENT_MAX_STEPS', AGENT_MAX_STEPS)}
-  ${row('AGENT_MODEL_TIMEOUT', `${process.env.AGENT_MODEL_TIMEOUT || 90}s`)}
-  ${row('AGENT_STAGGER_DELAY', `${process.env.AGENT_STAGGER_DELAY || 5}s`)}
-  ${row('AGENT_BATCH_SIZE', process.env.AGENT_BATCH_SIZE || 1)}
-  ${row('AGENT_MEMORY_MAX_ENTRIES', process.env.AGENT_MEMORY_MAX_ENTRIES || 20)}
+  ${row('AGENT_MAX_STEPS', cfg.maxSteps)}
+  ${row('AGENT_MODEL_TIMEOUT', `${cfg.modelTimeoutSec}s`)}
+  ${row('AGENT_STAGGER_DELAY', `${cfg.staggerDelaySec}s`)}
+  ${row('AGENT_BATCH_SIZE', cfg.batchSize)}
+  ${row('AGENT_MEMORY_MAX_ENTRIES', cfg.memoryMaxEntries)}
   ${hLine}
   ${row('AGENT_HEADLESS', process.env.AGENT_HEADLESS || false)}
-  ${row('AGENT_OBSERVE_DESKTOP', process.env.AGENT_OBSERVE_DESKTOP || false)}
+  ${row('AGENT_OBSERVE_DESKTOP', cfg.observeDesktop)}
   ${row('AGENT_RESUME', AGENT_RESUME)}
   ${row('CHROME_PATH', process.env.AGENT_BROWSER_PATH || 'auto')}
   ${ideConfig.enabled ? row('IDE_MCP', `${ideConfig.transport} @ ${ideConfig.transport === 'stdio' ? ideConfig.command : (ideConfig.url || `${ideConfig.host}:${ideConfig.port}${ideConfig.ssePath}`)}`) : row('IDE_MCP', 'disabled')}

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -36,6 +36,7 @@ beforeEach(async () => {
   const { createAgentRouter } = await import('../routes/agent.js');
   const { createAgentRunStore } = await import('../helpers/run-store.js');
   const { createApprovalStore } = await import('../agent/core/approval-store.js');
+  const { runtimeConfig } = await import('../agent/core/runtime-config.js');
 
   const agentRunStore = createAgentRunStore();
   const approvalStore = createApprovalStore();
@@ -49,6 +50,7 @@ beforeEach(async () => {
     domainRules: null,
     modelConfig: [{ id: 'test-model', provider: 'test' }],
     registry: mockRegistry,
+    runtimeConfig,
   });
 
   app = express();

--- a/test/runtime-config.test.ts
+++ b/test/runtime-config.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { computeEnvDefaults, validateConfig, mergeConfig } from '../agent/core/runtime-config.js';
+
+describe('computeEnvDefaults', () => {
+  it('空 env 用内置默认值（与改造前各处默认一致）', () => {
+    const d = computeEnvDefaults({});
+    expect(d).toEqual({
+      maxSteps: 8,
+      modelTimeoutSec: 90,
+      staggerDelaySec: 5,
+      batchSize: 1,
+      observeDesktop: false,
+      maxHistorySteps: 20,
+      maxResultChars: 8000,
+      maxParallelResultChars: 32000,
+      memoryMaxEntries: 20,
+    });
+  });
+
+  it('从 env 读取覆盖值', () => {
+    const d = computeEnvDefaults({ AGENT_MAX_STEPS: '64', AGENT_MODEL_TIMEOUT: '120', AGENT_OBSERVE_DESKTOP: 'true' });
+    expect(d.maxSteps).toBe(64);
+    expect(d.modelTimeoutSec).toBe(120);
+    expect(d.observeDesktop).toBe(true);
+  });
+
+  it('observeDesktop 仅字符串 "true" 为真', () => {
+    expect(computeEnvDefaults({ AGENT_OBSERVE_DESKTOP: 'false' }).observeDesktop).toBe(false);
+    expect(computeEnvDefaults({ AGENT_OBSERVE_DESKTOP: '1' }).observeDesktop).toBe(false);
+  });
+});
+
+describe('validateConfig', () => {
+  it('接受合法整数与布尔', () => {
+    const { clean, errors } = validateConfig({ maxSteps: 10, observeDesktop: true });
+    expect(errors).toEqual([]);
+    expect(clean).toEqual({ maxSteps: 10, observeDesktop: true });
+  });
+
+  it('字符串数字会被转换', () => {
+    const { clean, errors } = validateConfig({ maxSteps: '12' });
+    expect(errors).toEqual([]);
+    expect(clean.maxSteps).toBe(12);
+  });
+
+  it('忽略未知键', () => {
+    const { clean, errors } = validateConfig({ foo: 1, maxSteps: 5 });
+    expect(errors).toEqual([]);
+    expect(clean).toEqual({ maxSteps: 5 });
+  });
+
+  it('拒绝超出范围（含原因）', () => {
+    const { clean, errors } = validateConfig({ maxSteps: 0 });
+    expect(clean.maxSteps).toBeUndefined();
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('maxSteps');
+  });
+
+  it('拒绝非整数', () => {
+    expect(validateConfig({ batchSize: 1.5 }).errors.length).toBe(1);
+  });
+
+  it('observeDesktop 非布尔被拒', () => {
+    expect(validateConfig({ observeDesktop: 'yes' }).errors.length).toBe(1);
+  });
+
+  it('staggerDelaySec 允许 0', () => {
+    const { clean, errors } = validateConfig({ staggerDelaySec: 0 });
+    expect(errors).toEqual([]);
+    expect(clean.staggerDelaySec).toBe(0);
+  });
+
+  it('非对象返回错误', () => {
+    expect(validateConfig(null).errors.length).toBe(1);
+  });
+});
+
+describe('mergeConfig', () => {
+  const defaults = computeEnvDefaults({});
+
+  it('overrides 覆盖默认，其余保持', () => {
+    const m = mergeConfig(defaults, { maxSteps: 3 });
+    expect(m.maxSteps).toBe(3);
+    expect(m.batchSize).toBe(defaults.batchSize);
+  });
+
+  it('空 overrides 返回默认副本（非同一引用）', () => {
+    const m = mergeConfig(defaults, {});
+    expect(m).toEqual(defaults);
+    expect(m).not.toBe(defaults);
+  });
+
+  it('忽略未知键', () => {
+    const m: any = mergeConfig(defaults, { foo: 1 } as any);
+    expect(m.foo).toBeUndefined();
+  });
+
+  it('覆盖 staggerDelaySec=0 生效（不被当成缺省）', () => {
+    expect(mergeConfig(defaults, { staggerDelaySec: 0 }).staggerDelaySec).toBe(0);
+  });
+});


### PR DESCRIPTION
## 背景
此前所有配置仅来自 .env，启动时一次性加载并「冻结」进模块常量/闭包，改配置必须重启进程。本 PR 引入集中的运行时配置层，让 Agent 行为参数可在前台调整并热生效；API Key 出于安全按只读展示。

## 改动
**后端**
- 新增 `agent/core/runtime-config.ts`：单例 + 纯函数（computeEnvDefaults / validateConfig / mergeConfig）。.env 为默认值底，`data/runtime-config.json` 存前台覆盖；`get()` 同步供热路径，`update()` 校验后原子落盘，`reset()` 回默认。
- 消除「启动冻结」：`runtime.ts`、`memory.ts`、`desktop/agent.ts` 改为每次任务实时读取，改完下次任务即生效、无需重启。
- 新增 `routes/agent-config.ts`：`GET/POST /api/config` 与 `/reset`，GET 附带三家 Key 脱敏只读状态（绝不回传明文）。

**前端**
- 设置面板入口（首屏 + header 齿轮）+ `SettingsDialog`：Agent 参数可写、API Key 只读。

## 验证
- `npm run build`（typecheck + 前端构建）通过
- `npm run test` 88 测试全绿（含 13 个 runtime-config 单测）
- 落盘 / 重启 reload / reset / 校验 往返手测通过

## 范围
不含 PORT/HOST、MEMORY_DIR、MCP 连接（启动期绑定，需重启）；API Key 仅只读（仍在 .env 配置）。

## 手动验收
启动后在设置里把「单次任务最大步数」改成 3 保存，不重启发一个 agent 任务，应在第 3 步停止；`data/runtime-config.json` 应已落盘。