### PR TITLE
perf(ui): Agent 执行面板性能优化与 token 统计修正

### DIFF
--- a/client/src/components/AgentPane.jsx
+++ b/client/src/components/AgentPane.jsx
@@ -1,24 +1,5 @@
 import { useT } from '../i18n/I18nProvider.jsx';
-
-function getAgentStepMetrics(trace) {
-  const lastStep = trace.reduce((max, event) => (event.step != null ? Math.max(max, event.step) : max), 0);
-  const totalTokens = trace.reduce((sum, event) => {
-    if (event.type === 'step' && event.stage === 'action' && event.usage) {
-      return sum + event.usage.prompt_tokens + event.usage.completion_tokens;
-    }
-    return sum;
-  }, 0);
-  const doneEvent = [...trace].reverse().find(event => event.type === 'done');
-  return {
-    lastStep,
-    totalTokens,
-    stepCount: doneEvent?.meta?.step_count || lastStep,
-  };
-}
-
-function formatTokenCount(value) {
-  return value > 999 ? `${(value / 1000).toFixed(1)}k` : value;
-}
+import { computeTraceMetrics, formatTokenCount } from './agent/trace-metrics.js';
 
 export function AgentPane({
   agentMobileTab,
@@ -30,7 +11,7 @@ export function AgentPane({
   resizeDivider,
 }) {
   const t = useT();
-  const metrics = getAgentStepMetrics(agentTrace);
+  const metrics = computeTraceMetrics(agentTrace);
 
   return (
     <>

--- a/client/src/components/agent/AgentPanel.jsx
+++ b/client/src/components/agent/AgentPanel.jsx
@@ -1,11 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Timer, Square, ChevronDown, ChevronUp, ChevronsDown, ChevronsUp,
-  RotateCcw, Monitor, Loader2,
+  Square, ChevronDown, ChevronUp, ChevronsDown, ChevronsUp,
+  Monitor, Loader2,
 } from 'lucide-react';
 import { PHONE_BREAKPOINT } from '../../utils/constants.js';
 import { ModelPlanGroup } from './ModelPlanGroup.jsx';
-import { getModelLabel } from './plan-stage.js';
+import { ElapsedTimer } from './ElapsedTimer.jsx';
+import { TraceItem } from './TraceItem.jsx';
+import { computeTraceMetrics } from './trace-metrics.js';
+import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { useT } from '../../i18n/I18nProvider.jsx';
 
 // AgentPanel 既是执行面板，也是运行时仪表盘：
@@ -16,13 +19,61 @@ export function AgentPanel({ mode, running, trace, startedAt, modelList, collaps
   const t = useT();
   const traceBottomRef = useRef(null);
   const traceStickyRef = useRef(true);
-  const startTimeRef = useRef(null);
-  const isMobile = typeof window !== 'undefined' && window.innerWidth < PHONE_BREAKPOINT;
-  const pauseRef = useRef(null);
-  const [elapsed, setElapsed] = useState(0);
+  const isMobile = useIsMobile(PHONE_BREAKPOINT);
   const [lightboxSrc, setLightboxSrc] = useState(null);
   const [cardsExpanded, setCardsExpanded] = useState(null); // null=auto, true=all open, false=all closed
-  const hasModelCards = trace.some(e => e.type === 'model_plan' && e.stage === 'start' && e.models?.length > 0);
+
+  // onRollback 来自上层且每次 render 是新引用；用 ref 包出稳定回调，
+  // 这样 memo 化的 TraceItem 不会因为回调引用变化而整片重渲。
+  const rollbackRef = useRef(onRollback);
+  useEffect(() => { rollbackRef.current = onRollback; }, [onRollback]);
+  const stableRollback = useCallback(step => rollbackRef.current?.(step), []);
+
+  // 以下派生值原先每次 render（含每秒计时 tick）都对整条 trace 做 some/reduce/find，
+  // 现在统一 memo 化，只在 trace/running 变化时重算。
+  const metrics = useMemo(() => computeTraceMetrics(trace), [trace]);
+  const hasModelCards = useMemo(
+    () => trace.some(e => e.type === 'model_plan' && e.stage === 'start' && e.models?.length > 0),
+    [trace],
+  );
+  const doneEvent = useMemo(() => trace.find(e => e.type === 'done'), [trace]);
+  const agentFinished = useMemo(
+    () => !running && trace.some(e => e.type === 'done' || e.type === 'error'),
+    [running, trace],
+  );
+  // Detect if waiting for user question
+  const hasPendingQuestion = useMemo(
+    () => running && trace.some(e => e.type === 'question_required') && !trace.some(e => e.type === 'user_response'),
+    [running, trace],
+  );
+  // 把事件按 step 预分组一次，供 ModelPlanGroup 直接取用，避免每个 group 再各自
+  // 遍历整条 trace（否则 S 步 × N 事件 = O(N²)）。
+  const eventsByStep = useMemo(() => {
+    const map = new Map();
+    for (const e of trace) {
+      if (e.step == null) continue;
+      let arr = map.get(e.step);
+      if (!arr) { arr = []; map.set(e.step, arr); }
+      arr.push(e);
+    }
+    return map;
+  }, [trace]);
+  // 多模型规划的步：其 action/result 展示在模型卡片内部，trace 里需跳过单独项。
+  const multiModelSteps = useMemo(() => {
+    const set = new Set();
+    for (const e of trace) {
+      if (e.type === 'model_plan' && e.stage === 'start' && e.models?.length > 1) set.add(e.step);
+    }
+    return set;
+  }, [trace]);
+
+  const doneMeta = doneEvent?.meta || {};
+  const doneStatus = doneEvent?.quality?.status || doneMeta.status || 'done';
+  const doneStatusLabel = doneStatus === 'done_unverified'
+    ? t('agentPanel.statusUnverified')
+    : doneStatus === 'done_degraded'
+      ? t('agentPanel.statusDegraded')
+      : t('agentPanel.statusDone');
 
   // ESC closes lightbox
   useEffect(() => {
@@ -32,57 +83,10 @@ export function AgentPanel({ mode, running, trace, startedAt, modelList, collaps
     return () => window.removeEventListener('keydown', handler);
   }, [lightboxSrc]);
 
-  const lastStep = trace.reduce((max, e) => (e.step != null ? Math.max(max, e.step) : max), 0);
-  const doneEvent = trace.find(e => e.type === 'done');
-  const doneMeta = doneEvent?.meta || {};
-  const doneStatus = doneEvent?.quality?.status || doneMeta.status || 'done';
-  const doneStatusLabel = doneStatus === 'done_unverified'
-    ? t('agentPanel.statusUnverified')
-    : doneStatus === 'done_degraded'
-      ? t('agentPanel.statusDegraded')
-      : t('agentPanel.statusDone');
-
-  // Detect if waiting for user question
-  const hasPendingQuestion = running && trace.some(e => e.type === 'question_required') &&
-    !trace.some(e => e.type === 'user_response');
-
-  const totalTokens = trace.reduce((sum, e) => {
-    if (e.usage) {
-      return sum + (e.usage.prompt_tokens || 0) + (e.usage.completion_tokens || 0);
-    }
-    return sum;
-  }, 0);
-
-  useEffect(() => {
-    if (!running) {
-      startTimeRef.current = null;
-      pauseRef.current = null;
-      return;
-    }
-    startTimeRef.current = startedAt || Date.now();
-    pauseRef.current = null;
-    const timer = setInterval(() => {
-      if (startTimeRef.current) {
-        const paused = pauseRef.current ? Date.now() - pauseRef.current : 0;
-        setElapsed(Math.round((Date.now() - startTimeRef.current - paused) / 1000));
-      }
-    }, 1000);
-    return () => clearInterval(timer);
-  }, [running, startedAt]);
-
-  // Pause/resume elapsed when waiting for question
-  useEffect(() => {
-    if (hasPendingQuestion && !pauseRef.current) {
-      pauseRef.current = Date.now();
-    } else if (!hasPendingQuestion && pauseRef.current) {
-      startTimeRef.current += Date.now() - pauseRef.current;
-      pauseRef.current = null;
-    }
-  }, [hasPendingQuestion]);
-
   useEffect(() => {
     if (!traceStickyRef.current) return;
-    traceBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    // 流式追加期间用瞬时滚动，避免平滑动画相互打断造成抖动。
+    traceBottomRef.current?.scrollIntoView({ behavior: 'auto' });
   }, [trace]);
 
   // 用户在 trace 容器内手动滚动时维护 sticky 标志：距离底部 80px 内视为"在底部"。
@@ -103,18 +107,6 @@ export function AgentPanel({ mode, running, trace, startedAt, modelList, collaps
   if (mode !== 'agent') {
     return null;
   }
-
-  const formatElapsed = (sec) => {
-    const m = Math.floor(sec / 60);
-    const s = sec % 60;
-    return m > 0 ? `${m}m${s < 10 ? '0' : ''}${s}s` : `${s}s`;
-  };
-
-  const displayElapsed = running
-    ? formatElapsed(elapsed)
-    : doneMeta.elapsed_ms
-      ? formatElapsed(Math.round(doneMeta.elapsed_ms / 1000))
-      : elapsed > 0 ? formatElapsed(elapsed) : '-';
 
   return (
     <>
@@ -150,12 +142,10 @@ export function AgentPanel({ mode, running, trace, startedAt, modelList, collaps
           </div>
         </div>
         <div className="agent-head-row-metrics">
-          {lastStep > 0 && <span className="agent-metric">Step {lastStep}</span>}
-          <span className={`agent-metric ${running ? 'agent-metric-timer' : ''}`}>
-            {running ? <>{displayElapsed} <Timer size={12} /></> : displayElapsed}
-          </span>
-          {totalTokens > 0 && (
-            <span className="agent-metric agent-metric-tokens">{totalTokens} tokens</span>
+          {metrics.lastStep > 0 && <span className="agent-metric">Step {metrics.lastStep}</span>}
+          <ElapsedTimer running={running} startedAt={startedAt} paused={hasPendingQuestion} finalMs={doneMeta.elapsed_ms} />
+          {metrics.totalTokens > 0 && (
+            <span className="agent-metric agent-metric-tokens">{metrics.totalTokens} tokens</span>
           )}
           {!running && doneMeta.step_count && (
             <span className="agent-metric">{t('agentPanel.stepCount', { n: doneMeta.step_count })}</span>
@@ -186,270 +176,43 @@ export function AgentPanel({ mode, running, trace, startedAt, modelList, collaps
                 </div>
               ) : (
                 <div className="agent-trace">
-          {(() => {
-            // Track which steps have multi-model planning (action/result shown inside cards)
-            const multiModelSteps = new Set();
-            for (const e of trace) {
-              if (e.type === 'model_plan' && e.stage === 'start' && e.models?.length > 1) {
-                multiModelSteps.add(e.step);
-              }
-            }
-            return trace.map((event, index) => {
-            // model_plan events: only render 'start' as ModelPlanGroup, 'consensus' as standalone
+          {trace.map((event, index) => {
+            // model_plan events: only render 'start' as ModelPlanGroup, 'consensus' as standalone item
             // (other stages like thinking/success/failed are collected inside ModelPlanGroup)
             if (event.type === 'model_plan' && event.stage !== 'start' && event.stage !== 'consensus') return null;
             if (event.type === 'model_plan' && event.stage === 'start') {
-              return <ModelPlanGroup key={`model-plan-step-${event.step || index}-${index}`} trace={trace} step={event.step} models={event.models} modelList={modelList} running={running} cardsExpanded={cardsExpanded} onManualToggle={() => setCardsExpanded(null)} onRollback={onRollback} rollbackLoading={rollbackLoading} />;
+              return (
+                <ModelPlanGroup
+                  key={`model-plan-step-${event.step ?? index}-${index}`}
+                  events={eventsByStep.get(event.step) || []}
+                  step={event.step}
+                  models={event.models}
+                  modelList={modelList}
+                  agentFinished={agentFinished}
+                  cardsExpanded={cardsExpanded}
+                  onManualToggle={() => setCardsExpanded(null)}
+                  onRollback={stableRollback}
+                  rollbackLoading={rollbackLoading}
+                />
+              );
             }
             // For multi-model steps, skip separate action/result items (shown inside model cards)
             if (event.type === 'step' && (event.stage === 'action' || event.stage === 'result') && multiModelSteps.has(event.step)) {
               return null;
             }
-            // Render consensus event as standalone trace item
-            if (event.type === 'model_plan' && event.stage === 'consensus') {
-              return (
-                <div key={`consensus-${event.step || index}`} className="agent-trace-item" data-type="consensus" data-stage="">
-                  <span className="agent-trace-badge consensus">{t('agentPanel.voteBadge')}</span>
-                  <div className="agent-trace-content consensus-content">
-                    <div className="consensus-bar">
-                      <span className="consensus-badge">
-                        {event.consensus?.unanimous ? t('agentPanel.unanimous') : t('agentPanel.majority', { agreed: event.consensus?.agreed, total: event.consensus?.total })}
-                      </span>
-                      <span className="consensus-action">{event.consensus?.actionKey}</span>
-                      <div className="consensus-votes">
-                        {event.consensus?.allResults?.map(r => (
-                          <span key={r.model} className={`consensus-vote ${r.actionKey === event.consensus?.actionKey ? 'agree' : 'dissent'}`}>
-                            {getModelLabel(r.model, modelList)}: {r.actionKey}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              );
-            }
+            // consensus + 其余普通事件统一交给 memo 化的 TraceItem
             return (
-            <div key={`${event.type}-${event.step || index}-${event.stage || index}`} className="agent-trace-item" data-type={event.type} data-stage={event.stage || ''}>
-              {event.type === 'status' && (
-                <>
-                  <span className="agent-trace-badge">{t('agentPanel.badgeStatus')}</span>
-                  <div className="agent-trace-content">
-                    <strong>{event.message}</strong>
-                  </div>
-                </>
-              )}
-
-              {event.type === 'step' && event.stage === 'observe' && (
-                <>
-                  <span className="agent-trace-badge">{t('agentPanel.badgeObserve')}</span>
-                  <div className="agent-trace-content">
-                    <strong>Step {event.step}</strong>
-                    {event.observation?.desktop?.frontmostApp && (
-                      <p>
-                        {t('agentPanel.desktop')}: {event.observation.desktop.frontmostApp}
-                        {event.observation.desktop.frontmostWindowTitle ? ` · ${event.observation.desktop.frontmostWindowTitle}` : ''}
-                      </p>
-                    )}
-                    {event.observation?.desktop?.screenshotPath && (() => {
-                      const p = event.observation.desktop.screenshotPath;
-                      const url = '/screenshots/' + p.split('desktop-agent-observations').pop()?.replace(/^\//, '');
-                      return (
-                        <img className="screenshot-img clickable" src={url} alt="screenshot" onClick={() => setLightboxSrc(url)} />
-                      );
-                    })()}
-                    {event.observation?.browser?.title && <p>{event.observation.browser.title}</p>}
-                    {event.observation?.browser?.url && <p className="agent-trace-url">{event.observation.browser.url}</p>}
-                    {event.observation?.browser?.text && <p>{event.observation.browser.text}</p>}
-                    {event.observation?.desktop?.windows?.length > 0 && (
-                      <div className="agent-element-list">
-                        {event.observation.desktop.windows.slice(0, 6).map((window, windowIndex) => (
-                          <span key={`${window.app}-${window.title}-${windowIndex}`} className="agent-element-chip">
-                            {window.app} {window.title || 'Untitled'}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    {event.observation?.browser?.elements?.length > 0 && (
-                      <div className="agent-element-list">
-                        {event.observation.browser.elements.slice(0, 6).map(element => (
-                          <span key={element.id} className="agent-element-chip">
-                            #{element.id} {element.tag} {element.text || element.href || ''}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </>
-              )}
-
-              {event.type === 'step' && event.stage === 'action' && (
-                <>
-                  <span className="agent-trace-badge action">{t('agentPanel.badgeAction')}</span>
-                  <div className="agent-trace-content">
-                    <div className="agent-step-header">
-                      <strong>
-                        Step {event.step} · {event.action?.tool || 'core'}.{event.action?.type}
-                      </strong>
-                      {event.usage && (
-                        <span className="agent-token-badge">
-                          {event.usage.prompt_tokens + event.usage.completion_tokens} tokens
-                          <span className="agent-token-detail">
-                            ↑{event.usage.prompt_tokens} ↓{event.usage.completion_tokens}
-                          </span>
-                        </span>
-                      )}
-                      <button className="trace-rollback-btn" onClick={(e) => { e.stopPropagation(); onRollback(event.step); }} disabled={rollbackLoading} title={t('agentPanel.rerunFromStep', { step: event.step })}>
-                        <RotateCcw size={10} />
-                      </button>
-                    </div>
-                    {event.rationale && <p>{event.rationale}</p>}
-                    <pre className="agent-json">{JSON.stringify(event.action, null, 2)}</pre>
-                  </div>
-                </>
-              )}
-
-              {event.type === 'step' && event.stage === 'result' && (() => {
-                const screenshotMatch = event.result?.match(/(?:\/[^\s\]]*)?\/(data\/screenshots|desktop-agent-observations)\/([^\s\]]+\.png)/);
-                if (screenshotMatch) {
-                  const url = '/screenshots/' + screenshotMatch[2];
-                  return (
-                    <>
-                      <span className="agent-trace-badge result">{t('agentPanel.badgeResult')}</span>
-                      <div className="agent-trace-content">
-                        <strong>Step {event.step}</strong>
-                        <img className="screenshot-img clickable" src={url} alt="screenshot" onClick={() => setLightboxSrc(url)} />
-                      </div>
-                    </>
-                  );
-                }
-                return (
-                  <>
-                    <span className="agent-trace-badge result">{t('agentPanel.badgeResult')}</span>
-                    <div className="agent-trace-content">
-                      <strong>Step {event.step}</strong>
-                      <p>{event.result}</p>
-                    </div>
-                  </>
-                );
-              })()}
-
-              {event.type === 'done' && (
-                <>
-                  <span className="agent-trace-badge done">
-                    {(event.quality?.status || event.meta?.status) === 'done_unverified'
-                      ? t('agentPanel.doneBadgeUnverified')
-                      : (event.quality?.status || event.meta?.status) === 'done_degraded'
-                        ? t('agentPanel.statusDegraded')
-                        : t('agentPanel.statusDone')}
-                  </span>
-                  <div className="agent-trace-content">
-                    <strong>{t('agentPanel.agentDone')}</strong>
-                    {event.meta?.step_count && <span className="agent-trace-meta">{t('agentPanel.stepCount', { n: event.meta.step_count })}</span>}
-                    {event.quality?.reasons?.length > 0 && (
-                      <p>{event.quality.reasons.join('；')}</p>
-                    )}
-                    {event.meta?.models_used?.length > 0 && (
-                      <div className="agent-models-used">
-                        {event.meta.models_used.map(m => {
-                          const short = m.split('/').pop();
-                          return <span key={m} className="agent-model-chip">{short}</span>;
-                        })}
-                      </div>
-                    )}
-                  </div>
-                </>
-              )}
-
-              {event.type === 'notification' && (
-                <>
-                  <span className={`agent-trace-badge ${event.level === 'warning' ? 'error' : event.level === 'discovery' ? 'approval' : 'result'}`}>
-                    {event.level === 'warning' ? t('agentPanel.levelWarning') : event.level === 'discovery' ? t('agentPanel.levelDiscovery') : t('agentPanel.levelNotification')}
-                  </span>
-                  <div className="agent-trace-content">
-                    <p>{event.message}</p>
-                  </div>
-                </>
-              )}
-
-              {event.type === 'user_response' && (
-                <>
-                  <span className="agent-trace-badge approval">{t('agentPanel.badgeAnswer')}</span>
-                  <div className="agent-trace-content">
-                    <strong>{t('agentPanel.userAnswer')}</strong>
-                    <p style={{color: 'var(--c-text-muted)', fontSize: '12px'}}><em>{t('agentPanel.questionPrefix')}</em> {event.question}</p>
-                    <p>{event.response}</p>
-                  </div>
-                </>
-              )}
-
-              {event.type === 'approval_required' && (
-                <>
-                  <span className="agent-trace-badge approval">{t('agentPanel.badgeApproval')}</span>
-                  <div className="agent-trace-content">
-                    <strong>{t('agentPanel.awaitingApproval', { step: event.step })}</strong>
-                    <p>{event.message}</p>
-                    <pre className="agent-json">{JSON.stringify(event.action, null, 2)}</pre>
-                  </div>
-                </>
-              )}
-
-              {event.type === 'approval_result' && (
-                <>
-                  <span className={`agent-trace-badge ${event.decision === 'approve' ? 'result' : 'error'}`}>{t('agentPanel.badgeApproval')}</span>
-                  <div className="agent-trace-content">
-                    <strong>{t('agentPanel.approvalResult', { step: event.step })}</strong>
-                    <p>{event.message}</p>
-                  </div>
-                </>
-              )}
-
-              {event.type === 'error' && (
-                <>
-                  <span className="agent-trace-badge error">{t('agentPanel.badgeError')}</span>
-                  <div className="agent-trace-content">
-                    <strong>{t('agentPanel.agentFailed')}</strong>
-                    <p>{event.error}</p>
-                    {event.rollbackSuggestion && (() => {
-                      const rs = event.rollbackSuggestion;
-                      return (
-                        <div className="rollback-suggestion">
-                          <p className="rollback-suggestion-info">
-                            {t('agentPanel.rollbackSuggest', { step: rs.step })}
-                            {rs.lastAction && <span className="rollback-suggestion-detail">{t('agentPanel.lastStepDetail', { action: `${rs.lastAction.tool}.${rs.lastAction.type}` })}</span>}
-                          </p>
-                          {rs.lastRationale && <p className="rollback-suggestion-ctx">{t('agentPanel.decisionLabel', { text: rs.lastRationale })}</p>}
-                          {rs.lastResult && <p className="rollback-suggestion-ctx">{t('agentPanel.resultLabel', { text: rs.lastResult })}</p>}
-                          <button className="rollback-suggestion-btn" onClick={() => onRollback(rs.step)} disabled={rollbackLoading}>
-                            <RotateCcw size={12} /> {t('agentPanel.rollbackTo', { step: rs.step })}
-                          </button>
-                        </div>
-                      );
-                    })()}
-                  </div>
-                </>
-              )}
-
-              {event.type === 'rollback' && (
-                <>
-                  <span className="agent-trace-badge rollback">{t('agentPanel.badgeRollback')}</span>
-                  <div className="agent-trace-content">
-                    <strong>{t('agentPanel.rolledBackTo', { step: event.targetStep })}</strong>
-                    <p>{event.message}</p>
-                  </div>
-                </>
-              )}
-
-              {event.type === 'session_checkpoint' && (
-                <>
-                  <span className="agent-trace-badge plan">{t('agentPanel.badgeSnapshot')}</span>
-                  <div className="agent-trace-content">
-                    <strong>{t('agentPanel.snapshotSaved', { step: event.step })}</strong>
-                  </div>
-                </>
-              )}
-            </div>
+              <TraceItem
+                key={`${event.type}-${event.step ?? index}-${event.stage ?? index}`}
+                event={event}
+                modelList={modelList}
+                onRollback={stableRollback}
+                rollbackLoading={rollbackLoading}
+                openLightbox={setLightboxSrc}
+                t={t}
+              />
             );
-          })})()}
+          })}
           <div ref={traceBottomRef} />
         </div>
       )}

--- a/client/src/components/agent/ElapsedTimer.jsx
+++ b/client/src/components/agent/ElapsedTimer.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from 'react';
+import { Timer } from 'lucide-react';
+
+function formatElapsed(sec) {
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return m > 0 ? `${m}m${s < 10 ? '0' : ''}${s}s` : `${s}s`;
+}
+
+// 运行时计时显示。独立成组件后，每秒的 setElapsed 只重渲这一行，
+// 不再带着整条 trace 一起重渲（trace 渲染是 O(n) 甚至更高，按秒重跑很浪费）。
+// paused：等待用户回答时暂停计时（不计入耗时）；finalMs：运行结束后的精确耗时。
+export function ElapsedTimer({ running, startedAt, paused, finalMs }) {
+  const [elapsed, setElapsed] = useState(0);
+  const startRef = useRef(null);
+  const pauseRef = useRef(null);
+
+  useEffect(() => {
+    if (!running) {
+      startRef.current = null;
+      pauseRef.current = null;
+      return;
+    }
+    startRef.current = startedAt || Date.now();
+    pauseRef.current = null;
+    const timer = setInterval(() => {
+      if (startRef.current) {
+        const pausedMs = pauseRef.current ? Date.now() - pauseRef.current : 0;
+        setElapsed(Math.round((Date.now() - startRef.current - pausedMs) / 1000));
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [running, startedAt]);
+
+  // 进入/退出等待用户回答时暂停/恢复计时。
+  useEffect(() => {
+    if (paused && !pauseRef.current) {
+      pauseRef.current = Date.now();
+    } else if (!paused && pauseRef.current) {
+      startRef.current += Date.now() - pauseRef.current;
+      pauseRef.current = null;
+    }
+  }, [paused]);
+
+  const display = running
+    ? formatElapsed(elapsed)
+    : finalMs
+      ? formatElapsed(Math.round(finalMs / 1000))
+      : elapsed > 0 ? formatElapsed(elapsed) : '-';
+
+  return (
+    <span className={`agent-metric ${running ? 'agent-metric-timer' : ''}`}>
+      {running ? <>{display} <Timer size={12} /></> : display}
+    </span>
+  );
+}

--- a/client/src/components/agent/ModelPlanGroup.jsx
+++ b/client/src/components/agent/ModelPlanGroup.jsx
@@ -4,16 +4,16 @@ import { useT } from '../../i18n/I18nProvider.jsx';
 
 // 多模型一步会产生多条 model_plan 事件。这个组件负责把零散事件重新聚合成
 // 一个"按 step 分组"的展示块，让用户能看到同一步里不同模型如何竞争/投票。
-export function ModelPlanGroup({ trace, step, models, modelList, running, cardsExpanded, onManualToggle, onRollback, rollbackLoading }) {
+// events 是父组件预分组好的、仅属于本 step 的事件切片（避免每个 group 再各自
+// 遍历整条 trace —— 否则 S 步 × N 事件 = O(N²)）。agentFinished 由父组件统一判定。
+export function ModelPlanGroup({ events, step, models, modelList, agentFinished, cardsExpanded, onManualToggle, onRollback, rollbackLoading }) {
   const t = useT();
   let strategyMode = 'race';
   let consensusEvent = null;
   const modelEvents = {};
   let stepResult = null;
 
-  // Collect ALL model_plan events + step result for this step from the entire trace
-  for (const e of trace) {
-    if (e.step !== step) continue;
+  for (const e of events) {
     if (e.type === 'model_plan') {
       if (e.stage === 'start') {
         strategyMode = e.strategy || 'race';
@@ -28,9 +28,6 @@ export function ModelPlanGroup({ trace, step, models, modelList, running, cardsE
       stepResult = e.result;
     }
   }
-
-  // Agent is truly finished when trace has a terminal event (done/error) for this run
-  const agentFinished = !running && trace.some(e => e.type === 'done' || e.type === 'error');
 
   const winnerModel = consensusEvent?.model || Object.values(modelEvents).find(e => e.stage === 'winner')?.model;
 

--- a/client/src/components/agent/TraceItem.jsx
+++ b/client/src/components/agent/TraceItem.jsx
@@ -1,0 +1,254 @@
+import { memo } from 'react';
+import { RotateCcw } from 'lucide-react';
+import { getModelLabel } from './plan-stage.js';
+
+// 单条 trace 渲染。从 AgentPanel 平移而来并用 memo 包裹：trace 是 append-only 的，
+// 旧 event 对象引用不变，新事件到达时已渲染过的 item 不会重跑（尤其是 action 里的
+// JSON.stringify）。回调(onRollback/openLightbox)与 t 在上层均已稳定化，memo 才有效。
+export const TraceItem = memo(function TraceItem({ event, modelList, onRollback, rollbackLoading, openLightbox, t }) {
+  // 投票模式的 consensus 作为独立 trace 项展示。
+  if (event.type === 'model_plan' && event.stage === 'consensus') {
+    return (
+      <div className="agent-trace-item" data-type="consensus" data-stage="">
+        <span className="agent-trace-badge consensus">{t('agentPanel.voteBadge')}</span>
+        <div className="agent-trace-content consensus-content">
+          <div className="consensus-bar">
+            <span className="consensus-badge">
+              {event.consensus?.unanimous ? t('agentPanel.unanimous') : t('agentPanel.majority', { agreed: event.consensus?.agreed, total: event.consensus?.total })}
+            </span>
+            <span className="consensus-action">{event.consensus?.actionKey}</span>
+            <div className="consensus-votes">
+              {event.consensus?.allResults?.map(r => (
+                <span key={r.model} className={`consensus-vote ${r.actionKey === event.consensus?.actionKey ? 'agree' : 'dissent'}`}>
+                  {getModelLabel(r.model, modelList)}: {r.actionKey}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="agent-trace-item" data-type={event.type} data-stage={event.stage || ''}>
+      {event.type === 'status' && (
+        <>
+          <span className="agent-trace-badge">{t('agentPanel.badgeStatus')}</span>
+          <div className="agent-trace-content">
+            <strong>{event.message}</strong>
+          </div>
+        </>
+      )}
+
+      {event.type === 'step' && event.stage === 'observe' && (
+        <>
+          <span className="agent-trace-badge">{t('agentPanel.badgeObserve')}</span>
+          <div className="agent-trace-content">
+            <strong>Step {event.step}</strong>
+            {event.observation?.desktop?.frontmostApp && (
+              <p>
+                {t('agentPanel.desktop')}: {event.observation.desktop.frontmostApp}
+                {event.observation.desktop.frontmostWindowTitle ? ` · ${event.observation.desktop.frontmostWindowTitle}` : ''}
+              </p>
+            )}
+            {event.observation?.desktop?.screenshotPath && (() => {
+              const p = event.observation.desktop.screenshotPath;
+              const url = '/screenshots/' + p.split('desktop-agent-observations').pop()?.replace(/^\//, '');
+              return (
+                <img className="screenshot-img clickable" src={url} alt="screenshot" onClick={() => openLightbox(url)} />
+              );
+            })()}
+            {event.observation?.browser?.title && <p>{event.observation.browser.title}</p>}
+            {event.observation?.browser?.url && <p className="agent-trace-url">{event.observation.browser.url}</p>}
+            {event.observation?.browser?.text && <p>{event.observation.browser.text}</p>}
+            {event.observation?.desktop?.windows?.length > 0 && (
+              <div className="agent-element-list">
+                {event.observation.desktop.windows.slice(0, 6).map((window, windowIndex) => (
+                  <span key={`${window.app}-${window.title}-${windowIndex}`} className="agent-element-chip">
+                    {window.app} {window.title || 'Untitled'}
+                  </span>
+                ))}
+              </div>
+            )}
+            {event.observation?.browser?.elements?.length > 0 && (
+              <div className="agent-element-list">
+                {event.observation.browser.elements.slice(0, 6).map(element => (
+                  <span key={element.id} className="agent-element-chip">
+                    #{element.id} {element.tag} {element.text || element.href || ''}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {event.type === 'step' && event.stage === 'action' && (
+        <>
+          <span className="agent-trace-badge action">{t('agentPanel.badgeAction')}</span>
+          <div className="agent-trace-content">
+            <div className="agent-step-header">
+              <strong>
+                Step {event.step} · {event.action?.tool || 'core'}.{event.action?.type}
+              </strong>
+              {event.usage && (
+                <span className="agent-token-badge">
+                  {event.usage.prompt_tokens + event.usage.completion_tokens} tokens
+                  <span className="agent-token-detail">
+                    ↑{event.usage.prompt_tokens} ↓{event.usage.completion_tokens}
+                  </span>
+                </span>
+              )}
+              <button className="trace-rollback-btn" onClick={(e) => { e.stopPropagation(); onRollback(event.step); }} disabled={rollbackLoading} title={t('agentPanel.rerunFromStep', { step: event.step })}>
+                <RotateCcw size={10} />
+              </button>
+            </div>
+            {event.rationale && <p>{event.rationale}</p>}
+            <pre className="agent-json">{JSON.stringify(event.action, null, 2)}</pre>
+          </div>
+        </>
+      )}
+
+      {event.type === 'step' && event.stage === 'result' && (() => {
+        const screenshotMatch = event.result?.match(/(?:\/[^\s\]]*)?\/(data\/screenshots|desktop-agent-observations)\/([^\s\]]+\.png)/);
+        if (screenshotMatch) {
+          const url = '/screenshots/' + screenshotMatch[2];
+          return (
+            <>
+              <span className="agent-trace-badge result">{t('agentPanel.badgeResult')}</span>
+              <div className="agent-trace-content">
+                <strong>Step {event.step}</strong>
+                <img className="screenshot-img clickable" src={url} alt="screenshot" onClick={() => openLightbox(url)} />
+              </div>
+            </>
+          );
+        }
+        return (
+          <>
+            <span className="agent-trace-badge result">{t('agentPanel.badgeResult')}</span>
+            <div className="agent-trace-content">
+              <strong>Step {event.step}</strong>
+              <p>{event.result}</p>
+            </div>
+          </>
+        );
+      })()}
+
+      {event.type === 'done' && (
+        <>
+          <span className="agent-trace-badge done">
+            {(event.quality?.status || event.meta?.status) === 'done_unverified'
+              ? t('agentPanel.doneBadgeUnverified')
+              : (event.quality?.status || event.meta?.status) === 'done_degraded'
+                ? t('agentPanel.statusDegraded')
+                : t('agentPanel.statusDone')}
+          </span>
+          <div className="agent-trace-content">
+            <strong>{t('agentPanel.agentDone')}</strong>
+            {event.meta?.step_count && <span className="agent-trace-meta">{t('agentPanel.stepCount', { n: event.meta.step_count })}</span>}
+            {event.quality?.reasons?.length > 0 && (
+              <p>{event.quality.reasons.join('；')}</p>
+            )}
+            {event.meta?.models_used?.length > 0 && (
+              <div className="agent-models-used">
+                {event.meta.models_used.map(m => {
+                  const short = m.split('/').pop();
+                  return <span key={m} className="agent-model-chip">{short}</span>;
+                })}
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {event.type === 'notification' && (
+        <>
+          <span className={`agent-trace-badge ${event.level === 'warning' ? 'error' : event.level === 'discovery' ? 'approval' : 'result'}`}>
+            {event.level === 'warning' ? t('agentPanel.levelWarning') : event.level === 'discovery' ? t('agentPanel.levelDiscovery') : t('agentPanel.levelNotification')}
+          </span>
+          <div className="agent-trace-content">
+            <p>{event.message}</p>
+          </div>
+        </>
+      )}
+
+      {event.type === 'user_response' && (
+        <>
+          <span className="agent-trace-badge approval">{t('agentPanel.badgeAnswer')}</span>
+          <div className="agent-trace-content">
+            <strong>{t('agentPanel.userAnswer')}</strong>
+            <p style={{color: 'var(--c-text-muted)', fontSize: '12px'}}><em>{t('agentPanel.questionPrefix')}</em> {event.question}</p>
+            <p>{event.response}</p>
+          </div>
+        </>
+      )}
+
+      {event.type === 'approval_required' && (
+        <>
+          <span className="agent-trace-badge approval">{t('agentPanel.badgeApproval')}</span>
+          <div className="agent-trace-content">
+            <strong>{t('agentPanel.awaitingApproval', { step: event.step })}</strong>
+            <p>{event.message}</p>
+            <pre className="agent-json">{JSON.stringify(event.action, null, 2)}</pre>
+          </div>
+        </>
+      )}
+
+      {event.type === 'approval_result' && (
+        <>
+          <span className={`agent-trace-badge ${event.decision === 'approve' ? 'result' : 'error'}`}>{t('agentPanel.badgeApproval')}</span>
+          <div className="agent-trace-content">
+            <strong>{t('agentPanel.approvalResult', { step: event.step })}</strong>
+            <p>{event.message}</p>
+          </div>
+        </>
+      )}
+
+      {event.type === 'error' && (
+        <>
+          <span className="agent-trace-badge error">{t('agentPanel.badgeError')}</span>
+          <div className="agent-trace-content">
+            <strong>{t('agentPanel.agentFailed')}</strong>
+            <p>{event.error}</p>
+            {event.rollbackSuggestion && (() => {
+              const rs = event.rollbackSuggestion;
+              return (
+                <div className="rollback-suggestion">
+                  <p className="rollback-suggestion-info">
+                    {t('agentPanel.rollbackSuggest', { step: rs.step })}
+                    {rs.lastAction && <span className="rollback-suggestion-detail">{t('agentPanel.lastStepDetail', { action: `${rs.lastAction.tool}.${rs.lastAction.type}` })}</span>}
+                  </p>
+                  {rs.lastRationale && <p className="rollback-suggestion-ctx">{t('agentPanel.decisionLabel', { text: rs.lastRationale })}</p>}
+                  {rs.lastResult && <p className="rollback-suggestion-ctx">{t('agentPanel.resultLabel', { text: rs.lastResult })}</p>}
+                  <button className="rollback-suggestion-btn" onClick={() => onRollback(rs.step)} disabled={rollbackLoading}>
+                    <RotateCcw size={12} /> {t('agentPanel.rollbackTo', { step: rs.step })}
+                  </button>
+                </div>
+              );
+            })()}
+          </div>
+        </>
+      )}
+
+      {event.type === 'rollback' && (
+        <>
+          <span className="agent-trace-badge rollback">{t('agentPanel.badgeRollback')}</span>
+          <div className="agent-trace-content">
+            <strong>{t('agentPanel.rolledBackTo', { step: event.targetStep })}</strong>
+            <p>{event.message}</p>
+          </div>
+        </>
+      )}
+
+      {event.type === 'session_checkpoint' && (
+        <>
+          <span className="agent-trace-badge plan">{t('agentPanel.badgeSnapshot')}</span>
+          <div className="agent-trace-content">
+            <strong>{t('agentPanel.snapshotSaved', { step: event.step })}</strong>
+          </div>
+        </>
+      )}
+    </div>
+  );
+});

--- a/client/src/components/agent/trace-metrics.js
+++ b/client/src/components/agent/trace-metrics.js
@@ -1,0 +1,50 @@
+// 统一的 trace 指标计算：桌面执行面板(AgentPanel)与移动端 tab(AgentPane)共用，
+// 避免两端各算一套导致 token 数对不上。
+//
+// token 口径（关键）：服务端对同一次决策会发两条带 usage 的事件——
+//   1) model_plan 的 success/winner/cancelled（每个候选模型一条，planner.ts）
+//   2) step/action（仅胜出者，runtime.ts 里的 decision.usage）
+// 二者的 usage 是同一批 token，直接全加会重复计算（单模型≈2×）。
+// 因此按 step 聚合，每步优先采用「该步所有 model_plan 决策事件」之和——
+// 多模型下这会正确计入落败/取消但已产出结果的候选；只有当某步完全没有带
+// usage 的 model_plan 事件时，才回退到该步的 action usage。绝不把 action 与
+// 其对应的 model_plan 重复相加。
+
+function eventTokens(usage) {
+  if (!usage) return 0;
+  return (usage.prompt_tokens || 0) + (usage.completion_tokens || 0);
+}
+
+export function computeTraceMetrics(trace) {
+  let lastStep = 0;
+  let doneStepCount = null;
+  const planByStep = new Map();
+  const actionByStep = new Map();
+
+  for (const event of trace) {
+    if (event.step != null && event.step > lastStep) lastStep = event.step;
+    const tok = eventTokens(event.usage);
+    if (tok > 0) {
+      if (event.type === 'model_plan') {
+        planByStep.set(event.step, (planByStep.get(event.step) || 0) + tok);
+      } else if (event.type === 'step' && event.stage === 'action') {
+        actionByStep.set(event.step, (actionByStep.get(event.step) || 0) + tok);
+      }
+    }
+    if (event.type === 'done' && event.meta?.step_count != null) {
+      doneStepCount = event.meta.step_count;
+    }
+  }
+
+  let totalTokens = 0;
+  const steps = new Set([...planByStep.keys(), ...actionByStep.keys()]);
+  for (const step of steps) {
+    totalTokens += planByStep.has(step) ? planByStep.get(step) : (actionByStep.get(step) || 0);
+  }
+
+  return { lastStep, totalTokens, stepCount: doneStepCount ?? lastStep };
+}
+
+export function formatTokenCount(value) {
+  return value > 999 ? `${(value / 1000).toFixed(1)}k` : value;
+}

--- a/client/src/hooks/useIsMobile.js
+++ b/client/src/hooks/useIsMobile.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+// 响应窗口宽度变化的移动端判定。替代散落各处的一次性 window.innerWidth 读取，
+// 旋转屏幕/拖拽窗口时会同步更新。
+export function useIsMobile(breakpoint) {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== 'undefined' && window.innerWidth < breakpoint,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onResize = () => setIsMobile(window.innerWidth < breakpoint);
+    onResize();
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, [breakpoint]);
+
+  return isMobile;
+}


### PR DESCRIPTION
## 背景
Agent 执行面板（`AgentPanel`）在「长 trace + 运行中」场景存在性能瓶颈：每秒计时 tick 会重渲整条 trace，而每个多模型分组又各自遍历整条 trace（O(n²)）。同时 token 统计存在重复计数。

## 改动
### 性能
- **抽离 `ElapsedTimer`**：每秒 `setElapsed` 只重渲计时这一行，不再带整条 trace 重渲。
- **`ModelPlanGroup` O(n²) → O(n)**：改用父组件按 step 预分组的事件切片，不再每个分组各自遍历整条 trace；`agentFinished` 由父组件统一判定。
- **派生值 `useMemo` + `TraceItem` memo 化**：`hasModelCards/doneEvent/eventsByStep/multiModelSteps/metrics` 仅在 `trace/running` 变化时重算；单条 trace 抽为 `React.memo` 的 `TraceItem`，新事件到达时旧 item 不再重跑 `JSON.stringify`（`onRollback` 经 ref 稳定化）。

### 正确性（token 双计）
- 新增 `trace-metrics.js#computeTraceMetrics`：按 step 取 `model_plan` 决策 `usage`（无则回退 `action`）。服务端对同一次决策会发 `model_plan` 与 `step/action` 两条带 usage 的事件，原桌面端全量求和导致重复计数（单模型约 2×）；移动端则只算 `action`、漏掉落败模型。现两端复用同一函数，口径统一。

### 体验
- 新增 `useIsMobile`（响应 `resize`）替换 `AgentPanel` 一次性 `window.innerWidth` 判定。
- 流式追加期间 `scrollIntoView` 由 `smooth` 改 `auto`，避免平滑动画互相打断的抖动。

## 验证
- 根 `npm run typecheck` ✅
- `cd client && npm run build`（vite）✅
- ESLint（改动文件）✅
- 行为等价：trace 各分支渲染、i18n key、计时/暂停语义均保持不变；唯一**有意**的行为变化为 token 统计口径修正。