### PR TITLE
fix(agent): 限流(429)真实错误被"模型超时"掩盖

### DIFF
--- a/agent/core/planner.ts
+++ b/agent/core/planner.ts
@@ -51,7 +51,7 @@ export function createJsonPlanner({
 
     let response;
     try {
-      response = await retryAsync(() => client.chat.completions.create(createOpts, reqOpts), undefined, retryContext);
+      response = await retryAsync(() => client.chat.completions.create(createOpts, reqOpts), undefined, retryContext, { retryRateLimit: false });
     } catch (err) {
       logLlmError(model, err, retryContext);
       throw err;
@@ -97,7 +97,7 @@ export function createJsonPlanner({
         message_count: retryMessages.length,
         max_tokens: maxTokens,
       };
-      const retryResponse = await retryAsync(() => client.chat.completions.create(retryOpts, reqOpts), undefined, retryContext);
+      const retryResponse = await retryAsync(() => client.chat.completions.create(retryOpts, reqOpts), undefined, retryContext, { retryRateLimit: false });
       const retryParsed = parser(retryResponse);
 
       if (!retryParsed.parseFailed) {

--- a/agent/core/providers/anthropic.ts
+++ b/agent/core/providers/anthropic.ts
@@ -108,7 +108,7 @@ export function createAnthropicProvider(client: any): LLMProvider {
       if (signal) streamOpts.signal = signal;
 
       logLlmRequest(model, messages);
-      const stream = await retryAsync(() => client.messages.stream(streamOpts));
+      const stream = await retryAsync(() => client.messages.stream(streamOpts), undefined, undefined, { retryRateLimit: false });
       for await (const _event of stream) {
         // 仅用最终消息拿完整 tool_use
       }

--- a/agent/core/providers/gemini.ts
+++ b/agent/core/providers/gemini.ts
@@ -111,7 +111,7 @@ export function createGeminiProvider(client: GoogleGenAI): LLMProvider {
       if (signal) config.abortSignal = signal;
 
       logLlmRequest(model, contents);
-      const response = await retryAsync(() => client.models.generateContent({ model, contents, config } as any));
+      const response = await retryAsync(() => client.models.generateContent({ model, contents, config } as any), undefined, undefined, { retryRateLimit: false });
       const usage = buildGeminiUsage((response as any).usageMetadata);
       logLlmResponse(model, { usage: { input_tokens: usage?.prompt_tokens, output_tokens: usage?.completion_tokens }, choices: [{ message: response }] });
 

--- a/helpers/retry.ts
+++ b/helpers/retry.ts
@@ -87,13 +87,18 @@ function extractRetryDelayMs(err) {
   return null;
 }
 
-export async function retryAsync(fn, maxRetries = MAX_RETRIES, context = {}) {
+export async function retryAsync(fn, maxRetries = MAX_RETRIES, context = {}, options: { retryRateLimit?: boolean } = {}) {
+  const { retryRateLimit = true } = options;
   const contextText = Object.keys(context).length ? ` context=${JSON.stringify(context)}` : '';
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
     try {
       return await fn();
     } catch (err) {
-      if (attempt === maxRetries || !isRetryableError(err)) {
+      // 默认会重试 429 限流。但带单步超时的调用（如 agentPlan）会传 retryRateLimit=false：
+      // 让 429 立即上抛，交由 planner 层处理（展示真实配额错误 + 冷却/降级）。
+      // 否则这里的长退避（30~60s × 多次）会撑满模型超时，把“配额超限”掩盖成“模型超时”。
+      const rateLimitedNoRetry = !retryRateLimit && isRateLimitError(err);
+      if (attempt === maxRetries || !isRetryableError(err) || rateLimitedNoRetry) {
         log.warn(`[Retry] final failure${contextText} error=${formatErrorDiagnostics(err)}`);
         throw err;
       }

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { retryAsync } from '../helpers/retry.ts';
+
+afterEach(() => { vi.useRealTimers(); });
+
+function rateLimitError() {
+  const err: any = new Error('{"error":{"code":429,"message":"quota exceeded"}}');
+  err.status = 429;
+  return err;
+}
+
+describe('retryAsync 限流处理', () => {
+  it('retryRateLimit=false 时 429 立即上抛，不退避重试', async () => {
+    let calls = 0;
+    await expect(
+      retryAsync(
+        () => { calls += 1; return Promise.reject(rateLimitError()); },
+        4,
+        undefined,
+        { retryRateLimit: false },
+      ),
+    ).rejects.toThrow(/429|quota/);
+    // 不重试 → 仅调用一次，真实 429 错误立即上抛（不会被单步超时掩盖）
+    expect(calls).toBe(1);
+  });
+
+  it('默认会重试 429（最终仍失败则抛出真实错误）', async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const p = retryAsync(() => { calls += 1; return Promise.reject(rateLimitError()); }, 1);
+    const assertion = expect(p).rejects.toThrow(/429|quota/);
+    await vi.runAllTimersAsync();
+    await assertion;
+    // maxRetries=1 → 首次 + 1 次重试 = 2 次调用
+    expect(calls).toBe(2);
+  });
+
+  it('retryRateLimit=false 仍会重试 5xx 等瞬时错误', async () => {
+    vi.useFakeTimers();
+    let calls = 0;
+    const p = retryAsync(
+      () => {
+        calls += 1;
+        if (calls < 2) {
+          const err: any = new Error('server error');
+          err.status = 503;
+          return Promise.reject(err);
+        }
+        return Promise.resolve('ok');
+      },
+      4,
+      undefined,
+      { retryRateLimit: false },
+    );
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toBe('ok');
+    expect(calls).toBe(2);
+  });
+});


### PR DESCRIPTION
## 问题

Google API 返回的错误(如 429 配额超限 `RESOURCE_EXHAUSTED`)未显示到前端,任务只显示 **"模型超时 (180s)"**,真实错误被吞掉。

最新任务 `run_mqkz1687` 与 `data/logs/app-2026-06-18.log` 佐证:超时在 `13:17:15` 触发,而 `[Retry] final failure 429` 在 `13:17:50` 才出现——超时赢了竞速,真实 429 被丢弃。

## 根因

1. provider 层 `agentPlan` 把请求包在 `retryAsync` 里,对 429 长退避重试(30+60+60+60 ≈ 210s);
2. `planner.ts` 的 `planWithTimeout` 有 180s 单步超时,**超时先触发**,抛出 "模型超时 (180s)";
3. 该超时错误覆盖真实 429,顶层 `error` 事件(`agent-run-execution.ts:128`)把假错误发给前端;
4. planner 自身能携带真实错误到前端的限流处理(`rate_limited`/`failed` 事件)因底层一直重试而没机会执行。

## 修复

让限流错误立即上抛给 planner 层(由它展示真实错误 + 冷却/降级),不在底层做超过超时预算的长退避:

- `helpers/retry.ts`:`retryAsync` 增加 `options.retryRateLimit`(默认 `true`,不改旧行为);为 `false` 时 429 立即上抛。
- 三处带单步超时的 `agentPlan` 调用传 `{ retryRateLimit: false }`:`gemini.ts`、`anthropic.ts`、`planner.ts`(openai 兼容)。
- `summarize` 等后台调用保持原样,仍重试 429。

修复后单模型路径走 planner 限流逻辑(~15s,远低于 180s),最终通过 `rate_limited`/`error` 事件把真实 "429 You exceeded your current quota..." 显示到前端。

## 验证

- `npm run typecheck` 通过
- 新增 `test/retry.test.ts`(默认重试 429 / `retryRateLimit:false` 立即上抛 / 5xx 仍重试)
- 全量测试 **114 passed**