### PR TITLE
feat(ui): 首页"试试这些任务"建议面板支持隐藏并记忆状态

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -502,6 +502,55 @@ select,
   cursor: not-allowed;
 }
 
+.suggestions-head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* 收起整个推荐面板的小按钮(标题栏右侧 X) */
+.suggestions-hide {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  color: var(--c-text-muted);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all var(--ease);
+}
+
+.suggestions-hide:hover {
+  color: var(--c-primary);
+  border-color: var(--c-primary-light);
+  background: var(--c-primary-bg);
+}
+
+/* 面板隐藏后,输入卡下方的"显示建议"重新唤出入口 */
+.suggestions-show {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px dashed var(--c-border);
+  background: transparent;
+  color: var(--c-text-muted);
+  border-radius: 999px;
+  font-size: var(--f-xs);
+  cursor: pointer;
+  transition: all var(--ease);
+}
+
+.suggestions-show:hover {
+  color: var(--c-primary);
+  border-color: var(--c-primary-light);
+  background: var(--c-primary-bg);
+}
+
 .suggestions-tabs {
   width: 100%;
   display: flex;

--- a/client/src/components/HeroScreen.jsx
+++ b/client/src/components/HeroScreen.jsx
@@ -1,6 +1,17 @@
-import { Menu, Settings } from 'lucide-react';
+import { useState } from 'react';
+import { Menu, Settings, Lightbulb } from 'lucide-react';
 import { SuggestionsList } from './SuggestionsList.jsx';
 import { useT } from '../i18n/I18nProvider.jsx';
+
+// 首页推荐面板的隐藏状态持久化到 localStorage(纯前端 UI 偏好,刷新/下次打开保持)。
+const SUGGESTIONS_HIDDEN_KEY = 'sagent.suggestionsHidden';
+function readSuggestionsHidden() {
+  try {
+    return localStorage.getItem(SUGGESTIONS_HIDDEN_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
 
 // 首屏：brand + 输入卡 + 推荐列表。
 // 工具栏控件（ModeSwitch / ModelSelector / MemoryToggle / SendButton / AttachButton）
@@ -26,6 +37,17 @@ export function HeroScreen({
 }) {
   const { modeSwitch, modelSelect, memoryToggle, sendButton, attachButton } = toolbarSlots;
   const t = useT();
+  const [suggestionsHidden, setSuggestionsHidden] = useState(readSuggestionsHidden);
+
+  const hideSuggestions = () => {
+    setSuggestionsHidden(true);
+    try { localStorage.setItem(SUGGESTIONS_HIDDEN_KEY, '1'); } catch { /* 隐私模式下忽略写入失败 */ }
+  };
+  const showSuggestions = () => {
+    setSuggestionsHidden(false);
+    try { localStorage.removeItem(SUGGESTIONS_HIDDEN_KEY); } catch { /* 隐私模式下忽略写入失败 */ }
+  };
+
   return (
     <div className="hero-wrap">
       <div className="hero">
@@ -61,17 +83,24 @@ export function HeroScreen({
           </div>
         </div>
 
-        <SuggestionsList
-          mode={mode}
-          suggestions={suggestions}
-          categories={categories}
-          activeCategoryId={activeCategoryId}
-          onSelectCategory={onSelectCategory}
-          sessionLocked={sessionLocked}
-          onShuffle={onShuffle}
-          onPick={onPickSuggestion}
-          onSubmit={onSubmitSuggestion}
-        />
+        {suggestionsHidden ? (
+          <button className="suggestions-show" onClick={showSuggestions} title={t('suggestions.show')}>
+            <Lightbulb size={12} /> {t('suggestions.show')}
+          </button>
+        ) : (
+          <SuggestionsList
+            mode={mode}
+            suggestions={suggestions}
+            categories={categories}
+            activeCategoryId={activeCategoryId}
+            onSelectCategory={onSelectCategory}
+            sessionLocked={sessionLocked}
+            onShuffle={onShuffle}
+            onPick={onPickSuggestion}
+            onSubmit={onSubmitSuggestion}
+            onHide={hideSuggestions}
+          />
+        )}
       </div>
     </div>
   );

--- a/client/src/components/SuggestionsList.jsx
+++ b/client/src/components/SuggestionsList.jsx
@@ -1,9 +1,10 @@
-import { RotateCcw } from 'lucide-react';
+import { RotateCcw, X } from 'lucide-react';
 import { useT } from '../i18n/I18nProvider.jsx';
 
-// 推荐任务/问题列表 + "换一组" 按钮。
+// 推荐任务/问题列表 + "换一组" 按钮 + "隐藏" 按钮。
 // 单击 → 把内容填入输入框;双击 → 直接发送。
 // agent 模式下,categories 非空时显示分类 Tabs。
+// onHide:点右上角 X 收起整个面板(由父组件决定隐藏后的展示)。
 export function SuggestionsList({
   mode,
   suggestions,
@@ -14,20 +15,31 @@ export function SuggestionsList({
   onShuffle,
   onPick,
   onSubmit,
+  onHide,
 }) {
   const t = useT();
   return (
     <>
       <div className="suggestions-head">
         <span className="suggestions-label">{mode === 'agent' ? t('suggestions.tryTasks') : t('suggestions.tryQuestions')}</span>
-        <button
-          className="suggestions-refresh"
-          onClick={onShuffle}
-          disabled={sessionLocked}
-          title={t('suggestions.shuffle')}
-        >
-          <RotateCcw size={12} /> {t('suggestions.shuffle')}
-        </button>
+        <div className="suggestions-head-actions">
+          <button
+            className="suggestions-refresh"
+            onClick={onShuffle}
+            disabled={sessionLocked}
+            title={t('suggestions.shuffle')}
+          >
+            <RotateCcw size={12} /> {t('suggestions.shuffle')}
+          </button>
+          <button
+            className="suggestions-hide"
+            onClick={onHide}
+            title={t('suggestions.hide')}
+            aria-label={t('suggestions.hide')}
+          >
+            <X size={14} />
+          </button>
+        </div>
       </div>
 
       {categories && categories.length > 0 && (

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -256,6 +256,8 @@ export const en = {
   'suggestions.tryTasks': 'Try these tasks',
   'suggestions.tryQuestions': 'Try these questions',
   'suggestions.shuffle': 'Shuffle',
+  'suggestions.hide': 'Hide',
+  'suggestions.show': 'Show suggestions',
   'think.done': 'Thoughts',
   'think.thinking': 'Thinking',
   'think.organizing': 'Organizing thoughts…',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -257,6 +257,8 @@ export const zh = {
   'suggestions.tryTasks': '试试这些任务',
   'suggestions.tryQuestions': '试试这些问题',
   'suggestions.shuffle': '换一组',
+  'suggestions.hide': '隐藏',
+  'suggestions.show': '显示建议',
   'think.done': '思考过程',
   'think.thinking': '思考中',
   'think.organizing': '正在组织思路…',


### PR DESCRIPTION
## 概述
首页底部的「试试这些任务 / 试试这些问题」建议面板现在支持**隐藏**,并记住用户的选择。

## 改动点
- **隐藏入口**:`SuggestionsList` 标题栏「换一组」旁新增 X 隐藏按钮
- **隐藏后**:整个面板(含标题栏)收起,输入卡下方居中显示「💡 显示建议」入口,点击恢复
- **状态记忆**:隐藏/显示状态写入 localStorage(`sagent.suggestionsHidden`),刷新与下次打开均保持
- **i18n**:新增 `suggestions.hide` / `suggestions.show`(中英各一份)
- **样式**:复用现有 CSS 变量,自动适配明暗主题

## 涉及文件
- `client/src/components/SuggestionsList.jsx`
- `client/src/components/HeroScreen.jsx`
- `client/src/App.css`
- `client/src/i18n/locales/zh.js`、`en.js`

## 验证
- ✅ `vite build` 通过(1809 模块转译无错)
- ✅ 明暗两版视觉自查通过(隐藏按钮与「显示建议」入口在两种主题下均协调)

## 手动测试
1. 首页点标题栏右侧 X → 面板隐藏,输入卡下方出现「显示建议」
2. 点「显示建议」→ 面板恢复
3. 隐藏后刷新页面 → 仍保持隐藏
