### PR TITLE
feat(codegraph): 本地代码知识图谱（Code Graph）MVP (#206)

### DIFF
--- a/agent/core/action-types.ts
+++ b/agent/core/action-types.ts
@@ -21,6 +21,8 @@ export const ACTION_TYPE_TO_TOOL = {
   parallel_fetch: 'browser',
   // search
   web_search: 'search',
+  // codegraph
+  codegraph_query: 'codegraph',
   // vision
   image_analyze: 'vision',
   // fs

--- a/agent/core/codegraph.ts
+++ b/agent/core/codegraph.ts
@@ -1,0 +1,477 @@
+/**
+ * Code Graph — 项目代码知识图谱 / Project code knowledge graph
+ *
+ * 给 Agent「项目感知」能力:扫描项目源码,生成模块依赖图 + LLM 语义描述,
+ * 落盘到 {dataDir}/codegraph.json(按项目隔离,与 agent-memory.json 同目录)。
+ *
+ * 设计原则(issue #206 MVP):
+ *   - 结构静态算:文件树、import/export 依赖边、stats —— 确定、免费、本地。
+ *   - 语义 LLM 补:每模块一句话 description + 分组 —— LLM 只花 token 在「读不出来的东西」。
+ *   - LLM 失败回退:description 退化为文件头注释首行,保证「至少有一张图」。
+ *
+ * 调用场景:
+ *   - routes/agent-codegraph.ts: reindex = scanSkeleton → buildCodegraphWithLLM → saveCodegraph
+ *   - routes/agent-codegraph.ts / agent/tools/codegraph: loadCodegraph + queryCodegraph
+ *
+ * 存储位置: {dataDir}/codegraph.json(dataDir 由 resolveRunPaths 按 projectId 解析)
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { log } from '../../helpers/logger.ts';
+import { cleanText } from './utils.ts';
+import type { ProviderRegistry } from './providers/registry.ts';
+import type { ModelInfo } from './providers/types.ts';
+
+const CODEGRAPH_FILE = 'codegraph.json';
+// 默认跳过的目录(依赖/产物/IDE/VCS);.gitignore 的简单目录名条目会追加进来。
+const SKIP_DIRS = new Set([
+  'node_modules', 'dist', 'build', 'out', 'coverage',
+  '.git', '.idea', '.vscode', '.next', '.cache', 'data',
+]);
+const CODE_EXTS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+const MAX_FILES = 2000;        // 超大项目安全上限,超出截断并告警
+const MAX_FILE_BYTES = 256_000; // 单文件读取上限,避免巨型生成文件拖垮扫描
+// LLM 分批预算:每批文件数与字符数双限,先到先分。
+const BATCH_MAX_FILES = 20;
+const BATCH_MAX_CHARS = 8000;
+
+// ── 数据模型 ──
+
+export interface CodegraphModule {
+  path: string;        // 相对项目根的 posix 路径(静态)
+  exports: string[];   // 顶层导出符号名(静态)
+  dependsOn: string[]; // 指向项目内其他模块的相对路径(静态,import 解析)
+  description: string;  // 一句话职责(LLM;失败→头注释首行)
+  group: string;        // 模块分组(LLM;失败→顶层目录名)
+  loc: number;          // 行数(静态)
+  mtime: string;        // 最后修改时间(静态)
+}
+
+export interface Codegraph {
+  version: number;
+  project: string;
+  language: string;
+  rootPath: string;
+  lastIndexed: string;
+  model: string;
+  stats: { totalFiles: number; totalModules: number; coverage: string };
+  modules: CodegraphModule[];
+  entryPoints: string[];
+  summary: string;
+}
+
+// ── 落盘读写(仿 memory.ts) ──
+
+export async function loadCodegraph(dir: string): Promise<Codegraph | null> {
+  try {
+    const raw = await fs.readFile(path.join(dir, CODEGRAPH_FILE), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.modules)) return null;
+    return parsed as Codegraph;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCodegraph(dir: string, graph: Codegraph): Promise<void> {
+  const filePath = path.join(dir, CODEGRAPH_FILE);
+  const tmp = filePath + '.tmp';
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(tmp, JSON.stringify(graph, null, 2), 'utf8');
+  await fs.rename(tmp, filePath);
+}
+
+// ── 静态骨架扫描 ──
+
+export interface FileSkeleton {
+  path: string;          // 相对 posix 路径
+  headComment: string;   // 文件头注释首行
+  importSpecs: string[]; // 原始 import/require specifier
+  dependsOn: string[];   // 解析后指向项目内文件的相对路径
+  exports: string[];     // 顶层导出符号
+  loc: number;
+  mtime: string;
+}
+
+/** 把绝对路径转成相对项目根的 posix 风格路径(跨平台一致) */
+function toPosixRel(rootPath: string, abs: string): string {
+  return path.relative(rootPath, abs).split(path.sep).join('/');
+}
+
+/** 读 .gitignore 的「纯目录/文件名」简单条目,追加到跳过集合(复杂 glob 不处理) */
+async function loadGitignoreDirs(rootPath: string): Promise<Set<string>> {
+  const skip = new Set<string>();
+  try {
+    const raw = await fs.readFile(path.join(rootPath, '.gitignore'), 'utf8');
+    for (const line of raw.split('\n')) {
+      const t = line.trim();
+      if (!t || t.startsWith('#') || t.includes('*') || t.includes('!')) continue;
+      const name = t.replace(/^\/+/, '').replace(/\/+$/, '');
+      if (name && !name.includes('/')) skip.add(name);
+    }
+  } catch { /* 没有 .gitignore 就只用默认 SKIP_DIRS */ }
+  return skip;
+}
+
+/** 递归收集代码文件的绝对路径 */
+async function walkFiles(rootPath: string): Promise<string[]> {
+  const extra = await loadGitignoreDirs(rootPath);
+  const out: string[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    if (out.length >= MAX_FILES) return;
+    let entries: any[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (out.length >= MAX_FILES) return;
+      const name = entry.name;
+      if (name.startsWith('.') && name !== '.gitignore') {
+        // 跳过点目录/点文件(.git/.idea 等),但目录扫描本就不读文件内容的隐藏文件
+        if (entry.isDirectory()) continue;
+      }
+      const full = path.join(dir, name);
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(name) || extra.has(name)) continue;
+        await walk(full);
+      } else if (entry.isFile()) {
+        if (CODE_EXTS.includes(path.extname(name))) out.push(full);
+      }
+    }
+  }
+
+  await walk(rootPath);
+  return out;
+}
+
+/** 提取文件头注释首行(支持 /** ... *\/ 与连续 // 两种) */
+function extractHeadComment(content: string): string {
+  const src = content.replace(/^﻿/, '').trimStart();
+  if (src.startsWith('/*')) {
+    const end = src.indexOf('*/');
+    const block = end === -1 ? src : src.slice(0, end);
+    for (const rawLine of block.split('\n')) {
+      const line = rawLine.replace(/^\s*\/?\*+/, '').trim();
+      if (line) return cleanText(line, 120);
+    }
+  } else if (src.startsWith('//')) {
+    for (const rawLine of src.split('\n')) {
+      const line = rawLine.trim();
+      if (!line.startsWith('//')) break;
+      const text = line.replace(/^\/+/, '').trim();
+      if (text) return cleanText(text, 120);
+    }
+  }
+  return '';
+}
+
+/** 提取 import/require specifier(原始字符串) */
+function extractImportSpecs(content: string): string[] {
+  const specs = new Set<string>();
+  const importRe = /(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/g;
+  const bareImportRe = /import\s*['"]([^'"]+)['"]/g;
+  const requireRe = /require\(\s*['"]([^'"]+)['"]\s*\)/g;
+  const dynImportRe = /import\(\s*['"]([^'"]+)['"]\s*\)/g;
+  for (const re of [importRe, bareImportRe, requireRe, dynImportRe]) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(content)) !== null) specs.add(m[1]);
+  }
+  return [...specs];
+}
+
+/** 提取顶层导出符号名 */
+function extractExports(content: string): string[] {
+  const names = new Set<string>();
+  // export function/const/let/var/class/interface/type/enum NAME
+  const declRe = /export\s+(?:default\s+)?(?:async\s+)?(?:function\*?|const|let|var|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = declRe.exec(content)) !== null) names.add(m[1]);
+  // export { a, b as c }
+  const braceRe = /export\s*\{([^}]*)\}/g;
+  while ((m = braceRe.exec(content)) !== null) {
+    for (const part of m[1].split(',')) {
+      const seg = part.trim().split(/\s+as\s+/);
+      const name = (seg[1] || seg[0] || '').trim();
+      if (name && /^[A-Za-z_$][\w$]*$/.test(name)) names.add(name);
+    }
+  }
+  if (/export\s+default/.test(content)) names.add('default');
+  return [...names].slice(0, 30);
+}
+
+/** 把相对 import specifier 解析为项目内的实际相对路径(命中文件集才算) */
+function resolveDep(spec: string, fromRel: string, relSet: Set<string>): string | null {
+  if (!spec.startsWith('.')) return null; // 只处理项目内相对依赖,裸包忽略
+  const fromDir = path.posix.dirname(fromRel);
+  const base = path.posix.normalize(path.posix.join(fromDir, spec));
+  const candidates = [
+    base,
+    ...CODE_EXTS.map(e => base + e),
+    ...CODE_EXTS.map(e => path.posix.join(base, 'index' + e)),
+  ];
+  for (const c of candidates) {
+    if (relSet.has(c)) return c;
+  }
+  return null;
+}
+
+/**
+ * 扫描项目根,产出每文件的静态骨架(含解析后的项目内依赖边)。
+ * 纯本地、确定性、零 LLM。
+ */
+export async function scanSkeleton(rootPath: string): Promise<FileSkeleton[]> {
+  const absFiles = await walkFiles(rootPath);
+  if (absFiles.length >= MAX_FILES) {
+    log.warn(`[Codegraph] 文件数达到上限 ${MAX_FILES},已截断扫描`);
+  }
+
+  const partial: Array<Omit<FileSkeleton, 'dependsOn'> & { _abs: string }> = [];
+  for (const abs of absFiles) {
+    try {
+      const stat = await fs.stat(abs);
+      if (stat.size > MAX_FILE_BYTES) continue;
+      const content = await fs.readFile(abs, 'utf8');
+      partial.push({
+        path: toPosixRel(rootPath, abs),
+        headComment: extractHeadComment(content),
+        importSpecs: extractImportSpecs(content),
+        exports: extractExports(content),
+        loc: content.split('\n').length,
+        mtime: stat.mtime.toISOString(),
+        _abs: abs,
+      });
+    } catch { /* 读不了的文件跳过 */ }
+  }
+
+  // 第二遍:有了全量相对路径集合后再解析依赖边。
+  const relSet = new Set(partial.map(p => p.path));
+  return partial.map(p => {
+    const dependsOn = [...new Set(
+      p.importSpecs.map(spec => resolveDep(spec, p.path, relSet)).filter((x): x is string => !!x),
+    )];
+    const { _abs, ...rest } = p;
+    return { ...rest, dependsOn };
+  });
+}
+
+// ── 容错 JSON 解析(剥 ```json 围栏 + 提取首个数组/对象) ──
+
+function parseJsonLoose(text: string): any {
+  if (typeof text !== 'string') return null;
+  let src = text.trim();
+  const fenced = src.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fenced?.[1]) src = fenced[1].trim();
+  // 直接尝试
+  try { return JSON.parse(src); } catch { /* fallthrough */ }
+  // 提取首个 [...] 或 {...}(平衡括号)
+  for (const open of ['[', '{']) {
+    const close = open === '[' ? ']' : '}';
+    const start = src.indexOf(open);
+    if (start === -1) continue;
+    let depth = 0, inStr = false, esc = false;
+    for (let i = start; i < src.length; i++) {
+      const ch = src[i];
+      if (inStr) {
+        if (esc) esc = false;
+        else if (ch === '\\') esc = true;
+        else if (ch === '"') inStr = false;
+        continue;
+      }
+      if (ch === '"') inStr = true;
+      else if (ch === open) depth++;
+      else if (ch === close) {
+        depth--;
+        if (depth === 0) {
+          try { return JSON.parse(src.slice(start, i + 1)); } catch { break; }
+        }
+      }
+    }
+  }
+  return null;
+}
+
+// ── LLM 语义增强(map-reduce 分批) ──
+
+function batchByBudget(skeletons: FileSkeleton[]): FileSkeleton[][] {
+  const batches: FileSkeleton[][] = [];
+  let cur: FileSkeleton[] = [];
+  let curChars = 0;
+  for (const s of skeletons) {
+    const cost = s.path.length + s.headComment.length + s.exports.join(',').length + s.importSpecs.join(',').length + 40;
+    if (cur.length > 0 && (cur.length >= BATCH_MAX_FILES || curChars + cost > BATCH_MAX_CHARS)) {
+      batches.push(cur);
+      cur = [];
+      curChars = 0;
+    }
+    cur.push(s);
+    curChars += cost;
+  }
+  if (cur.length > 0) batches.push(cur);
+  return batches;
+}
+
+function buildBatchMessages(batch: FileSkeleton[]): any[] {
+  const fileLines = batch.map(s => {
+    const parts = [`path: ${s.path}`];
+    if (s.headComment) parts.push(`注释: ${s.headComment}`);
+    if (s.exports.length) parts.push(`导出: ${s.exports.slice(0, 12).join(', ')}`);
+    if (s.dependsOn.length) parts.push(`依赖: ${s.dependsOn.slice(0, 8).join(', ')}`);
+    return `- ${parts.join(' | ')}`;
+  }).join('\n');
+
+  return [
+    {
+      role: 'system',
+      content: [
+        '你是代码库分析助手。根据每个文件的路径、头注释、导出符号、依赖,',
+        '为每个文件生成一句话中文职责描述(description,≤30字)和一个模块分组(group,简短英文短横线命名,如 agent-core / routes / client-ui)。',
+        '只输出一个 JSON 数组,每项形如 {"path":"...","description":"...","group":"..."},',
+        'path 必须与输入完全一致。不要输出 JSON 以外的任何文字、不要用 markdown 围栏。',
+      ].join(''),
+    },
+    {
+      role: 'user',
+      content: `请分析以下 ${batch.length} 个文件:\n${fileLines}`,
+    },
+  ];
+}
+
+/**
+ * 在静态骨架上叠加 LLM 语义,组装完整 codegraph。
+ * onProgress(done, total) 在每批 LLM 完成后回调,驱动前端进度。
+ * 任一批 LLM 失败 → 该批模块回退到头注释/目录名,流程不中断。
+ */
+export async function buildCodegraphWithLLM({
+  skeleton,
+  registry,
+  model,
+  modelConfig,
+  projectName,
+  rootPath,
+  onProgress,
+}: {
+  skeleton: FileSkeleton[];
+  registry: ProviderRegistry;
+  model: string;
+  modelConfig?: ModelInfo[] | null;
+  projectName: string;
+  rootPath: string;
+  onProgress?: (done: number, total: number) => void;
+}): Promise<Codegraph> {
+  const semantics = new Map<string, { description: string; group: string }>();
+  const batches = batchByBudget(skeleton);
+  const total = batches.length;
+  let done = 0;
+
+  for (const batch of batches) {
+    try {
+      const provider = registry.resolve(model, modelConfig);
+      const result = await provider.completionJson({
+        model,
+        messages: buildBatchMessages(batch),
+        temperature: 0.1,
+        top_p: 1,
+        max_tokens: 4096,
+      });
+      const content = result?.choices?.[0]?.message?.content ?? '';
+      const arr = parseJsonLoose(typeof content === 'string' ? content : JSON.stringify(content));
+      if (Array.isArray(arr)) {
+        for (const item of arr) {
+          if (item && typeof item.path === 'string') {
+            semantics.set(item.path, {
+              description: cleanText(String(item.description || ''), 60),
+              group: cleanText(String(item.group || ''), 30),
+            });
+          }
+        }
+      }
+    } catch (err: any) {
+      log.warn(`[Codegraph] 批次语义生成失败,回退头注释: ${err?.message || err}`);
+    }
+    done += 1;
+    onProgress?.(done, total);
+  }
+
+  const modules: CodegraphModule[] = skeleton.map(s => {
+    const sem = semantics.get(s.path);
+    const fallbackGroup = s.path.split('/')[0] || 'root';
+    return {
+      path: s.path,
+      exports: s.exports,
+      dependsOn: s.dependsOn,
+      description: sem?.description || s.headComment || '',
+      group: sem?.group || fallbackGroup,
+      loc: s.loc,
+      mtime: s.mtime,
+    };
+  });
+
+  const describedCount = modules.filter(m => semantics.has(m.path)).length;
+  const coverage = modules.length > 0 ? `${Math.round((describedCount / modules.length) * 100)}%` : '0%';
+
+  return {
+    version: 1,
+    project: projectName,
+    language: detectLanguage(skeleton),
+    rootPath,
+    lastIndexed: new Date().toISOString(),
+    model,
+    stats: { totalFiles: skeleton.length, totalModules: modules.length, coverage },
+    modules,
+    entryPoints: detectEntryPoints(skeleton),
+    summary: '',
+  };
+}
+
+function detectLanguage(skeleton: FileSkeleton[]): string {
+  let ts = 0, js = 0;
+  for (const s of skeleton) {
+    if (s.path.endsWith('.ts') || s.path.endsWith('.tsx')) ts++;
+    else js++;
+  }
+  if (ts > 0 && ts >= js) return 'TypeScript';
+  if (js > 0) return 'JavaScript';
+  return 'Unknown';
+}
+
+/** 启发式入口点:常见入口文件名(MVP 不调 LLM) */
+function detectEntryPoints(skeleton: FileSkeleton[]): string[] {
+  const prefer = ['server.ts', 'server.js', 'index.ts', 'index.js', 'main.ts', 'main.js', 'app.ts', 'app.js'];
+  const set = new Set(skeleton.map(s => s.path));
+  const found = prefer.filter(p => set.has(p));
+  // 退而求其次:被依赖数为 0 但导出多的根级文件不易判断,这里保持简单只取常见入口。
+  return found.slice(0, 6);
+}
+
+// ── 查询(纯静态关键词匹配) ──
+
+export function queryCodegraph(graph: Codegraph | null, q: string, limit = 8): CodegraphModule[] {
+  if (!graph || !Array.isArray(graph.modules)) return [];
+  const query = String(q || '').trim().toLowerCase();
+  if (!query) return [];
+  const terms = query.split(/\s+/).filter(Boolean);
+
+  const scored = graph.modules.map(m => {
+    const hay = [
+      m.path,
+      m.description,
+      m.group,
+      m.exports.join(' '),
+    ].join(' ').toLowerCase();
+    let score = 0;
+    for (const term of terms) {
+      if (!hay.includes(term)) continue;
+      score += 1;
+      if (m.path.toLowerCase().includes(term)) score += 2;       // 路径命中加权
+      if (m.exports.some(e => e.toLowerCase().includes(term))) score += 2; // 导出符号命中加权
+    }
+    return { m, score };
+  }).filter(x => x.score > 0);
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit).map(x => x.m);
+}

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -169,6 +169,7 @@ export function buildNvidiaTaskMessages({
         '{"rationale":"搜索并提取链接","action":{"tool":"browser","type":"http_fetch","url":"https://example.com/search?q=关键词","extractLinks":true}}',
         '{"rational":"并发抓取多个页面","action":{"tool":"browser","type":"parallel_fetch","urls":["https://example.com/a","https://example.com/b"]}}',
         '{"rationale":"网络搜索关键词","action":{"tool":"search","type":"web_search","query":"2026 北京最低工资标准"}}',
+        '{"rationale":"查询项目代码图谱定位相关模块","action":{"tool":"codegraph","type":"codegraph_query","query":"记忆 memory"}}',
         '{"rationale":"分析图片内容","action":{"tool":"vision","type":"image_analyze","image":"/abs/path/to/image.png","question":"图片里有什么内容？请详细描述。"}}',
         '{"rationale":"并行分析多个文件","action":{"tool":"spawn","type":"spawn","tasks":["分析 src/index.ts 的架构","检查 test/ 目录的测试覆盖率","搜索项目中的 TODO 注释"]}}',
         ...(ideEnabled

--- a/agent/core/schemas.ts
+++ b/agent/core/schemas.ts
@@ -140,6 +140,15 @@ function normalizeSearchAction(type, action) {
   throw new Error(`不支持的搜索动作: ${type}`);
 }
 
+function normalizeCodegraphAction(type, action) {
+  if (type === 'codegraph_query') {
+    const query = typeof action.query === 'string' ? action.query.trim() : '';
+    if (!query) throw new Error('codegraph_query 缺少 query');
+    return { tool: 'codegraph', type, query };
+  }
+  throw new Error(`不支持的代码图谱动作: ${type}`);
+}
+
 function normalizeVisionAction(type, action) {
   if (type === 'image_analyze') {
     const image = typeof action.image === 'string' ? action.image.trim() : '';
@@ -389,6 +398,8 @@ export function normalizeDesktopAgentDecision(payload) {
     normalizedAction = normalizeFsAction(type, action);
   } else if (tool === 'search') {
     normalizedAction = normalizeSearchAction(type, action);
+  } else if (tool === 'codegraph') {
+    normalizedAction = normalizeCodegraphAction(type, action);
   } else if (tool === 'vision') {
     normalizedAction = normalizeVisionAction(type, action);
   } else if (tool === 'terminal') {

--- a/agent/core/tool-definitions.ts
+++ b/agent/core/tool-definitions.ts
@@ -173,6 +173,17 @@ export function createModelTools() {
       },
     },
     {
+      name: 'codegraph_query',
+      description: '查询项目代码知识图谱：按关键词返回相关模块的路径、职责、导出与依赖，帮你快速定位代码而无需逐个 read_file/list_dir 探索。适合任务开始时先了解项目结构。图谱需用户先在记忆面板「Code Graph」生成，未生成时工具会给出提示。',
+      input_schema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: '要查找的模块/功能关键词（如 "记忆 memory"、"项目隔离 project"、"路由 router"）' },
+        },
+        required: ['query'],
+      },
+    },
+    {
       name: 'run_safe',
       description: '运行只读终端命令（白名单内，不含管道等复杂操作）',
       input_schema: {

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -33,6 +33,7 @@ import { createAgentAuthorizer, createReadOnlyAuthorizer } from '../policy/appro
 import { executeBrowserAction } from '../tools/browser/execute.ts';
 import { executeFsAction } from '../tools/fs/execute.ts';
 import { executeSearchAction } from '../tools/search/execute.ts';
+import { executeCodegraphQueryAction } from '../tools/codegraph/execute.ts';
 import { executeVisionAction } from '../tools/vision/execute.ts';
 import { executeSpawnAction } from '../tools/spawn/execute.ts';
 import { createDomainRules } from '../tools/fetch/domain-rules.ts';
@@ -79,7 +80,7 @@ export function createDesktopAgentRunner({
   }
 
   // Sub-agent runner factory: creates isolated runners for parallel execution
-  function createSubAgentRunner(parentRunId: string, parentModel: string, parentAgentModels: string[], parentStrategy: string, parentSystemPrompt: string | null, parentCancelSignal: AbortSignal, parentProjectRoot: string | null = null) {
+  function createSubAgentRunner(parentRunId: string, parentModel: string, parentAgentModels: string[], parentStrategy: string, parentSystemPrompt: string | null, parentCancelSignal: AbortSignal, parentProjectRoot: string | null = null, parentDataDir: string | null = null) {
     const subBrowserManager = createSharedBrowserSessionManager();
 
     return async (task: string, subIndex: number) => {
@@ -117,6 +118,7 @@ export function createDesktopAgentRunner({
           },
           fs: async (_state, action) => executeFsAction(action, { cwd: parentProjectRoot }),
           search: async (_state, action) => executeSearchAction(action),
+          codegraph: async (_state, action) => executeCodegraphQueryAction(action, { dataDir: parentDataDir }),
           vision: async (_state, action) => executeVisionAction(action, { openai_client, visionModel }),
           ide: async (_state, action) => executeIdeAction(action),
           chrome: async (_state, action) => executeChromeAction(action),
@@ -210,6 +212,7 @@ export function createDesktopAgentRunner({
       },
       fs: async (state, action) => executeFsAction(action, { cwd: state.projectRoot }),
       search: async (_state, action) => executeSearchAction(action),
+      codegraph: async (state, action) => executeCodegraphQueryAction(action, { dataDir: state.dataDir }),
       vision: async (_state, action) => executeVisionAction(action, { openai_client, visionModel }),
       ide: async (_state, action) => executeIdeAction(action),
       chrome: async (_state, action) => executeChromeAction(action),
@@ -227,7 +230,8 @@ export function createDesktopAgentRunner({
           state.strategy,
           state.systemPrompt,
           state.cancelSignal,
-          state.projectRoot
+          state.projectRoot,
+          state.dataDir
         );
         return executeSpawnAction(action, { runSubAgent });
       },
@@ -297,6 +301,7 @@ export function createDesktopAgentRunner({
         systemPrompt,
         cancelSignal,
         projectRoot,
+        dataDir,
       }),
       observe: observeDesktopAgent,
       decide: async ({ task: currentTask, step, history, observation }) =>

--- a/agent/tools/codegraph/execute.ts
+++ b/agent/tools/codegraph/execute.ts
@@ -1,0 +1,40 @@
+/**
+ * Codegraph Query Tool — 让 Agent 查询项目代码知识图谱
+ *
+ * 读取 {dataDir}/codegraph.json,按关键词静态匹配模块,返回路径/职责/导出/依赖文本,
+ * 帮 Agent 在不逐个 read_file 探索的情况下快速定位相关代码。
+ * 图谱由用户在记忆面板「Code Graph」点「重新索引」生成;未索引时引导用户去生成。
+ *
+ * 入参 dataDir 来自 desktop/agent.ts state.dataDir(按项目隔离;无项目为全局 data 目录)。
+ */
+
+import { loadCodegraph, queryCodegraph } from '../../core/codegraph.ts';
+
+export async function executeCodegraphQueryAction(
+  action: any,
+  { dataDir }: { dataDir?: string | null } = {},
+): Promise<string> {
+  const query = typeof action?.query === 'string' ? action.query.trim() : '';
+  if (!query) return 'codegraph_query 失败:query 为空';
+  if (!dataDir) return 'codegraph_query 失败:当前会话没有项目数据目录,无法读取代码图谱';
+
+  const graph = await loadCodegraph(dataDir);
+  if (!graph) {
+    return '该项目尚未建立代码图谱(codegraph)。请在左侧记忆面板的「Code Graph」标签页点「重新索引」生成后再查询;在此之前可用 list_dir / search_files 直接探索目录。';
+  }
+
+  const results = queryCodegraph(graph, query);
+  if (results.length === 0) {
+    return `codegraph_query 未找到与 "${query}" 相关的模块(项目 ${graph.project} 共 ${graph.modules.length} 个模块)。可换关键词,或用 search_files 直接搜内容。`;
+  }
+
+  const lines = results.map((m, i) => {
+    const head = `${i + 1}. ${m.path}`;
+    const desc = m.description ? `   职责: ${m.description}` : '';
+    const exp = m.exports.length ? `   导出: ${m.exports.slice(0, 8).join(', ')}` : '';
+    const dep = m.dependsOn.length ? `   依赖: ${m.dependsOn.slice(0, 6).join(', ')}` : '';
+    return [head, desc, exp, dep].filter(Boolean).join('\n');
+  });
+
+  return `codegraph 匹配 "${query}"(项目 ${graph.project} / ${graph.modules.length} 个模块,命中 ${results.length} 个):\n${lines.join('\n\n')}`;
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -4459,6 +4459,145 @@ textarea:disabled {
 .memory-compact-btn:hover { background: var(--c-primary-bg); }
 .memory-compact-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
+/* ── Code Graph tab ── */
+
+.codegraph-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.codegraph-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.codegraph-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.codegraph-stats-main { font-size: 11px; font-weight: 500; color: var(--c-text); }
+.codegraph-stats-sub { font-size: 10px; color: var(--c-text-tertiary); }
+.codegraph-stats-empty { font-size: 11px; color: var(--c-text-secondary); }
+
+.codegraph-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.codegraph-model-select {
+  flex: 1;
+  min-width: 0;
+  padding: 4px 6px;
+  font-size: 11px;
+  color: var(--c-text);
+  background: var(--c-surface-inline);
+  border: 1px solid var(--c-border-input);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+}
+
+.codegraph-reindex-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+  color: var(--c-badge-plan);
+  background: var(--c-badge-plan-bg);
+  border: 1px solid var(--c-primary-light);
+  border-radius: var(--r-sm);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.codegraph-reindex-btn:hover:not(:disabled) { background: var(--c-primary-bg); }
+.codegraph-reindex-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.codegraph-reindex-btn .spinning { animation: codegraph-spin 1s linear infinite; }
+@keyframes codegraph-spin { to { transform: rotate(360deg); } }
+
+.codegraph-progress {
+  font-size: 11px;
+  color: var(--c-text-secondary);
+  background: var(--c-surface-hover);
+  padding: 5px 8px;
+  border-radius: var(--r-sm);
+}
+.codegraph-progress-error { color: var(--c-danger); background: var(--c-danger-bg); }
+
+.codegraph-summary {
+  font-size: 11px;
+  color: var(--c-text-secondary);
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.codegraph-search-input {
+  width: 100%;
+  padding: 5px 8px;
+  font-size: 11px;
+  color: var(--c-text);
+  background: var(--c-surface-inline);
+  border: 1px solid var(--c-border-input);
+  border-radius: var(--r-sm);
+}
+
+.codegraph-modules {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.codegraph-group-title {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--c-badge-plan);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+  padding-bottom: 2px;
+  border-bottom: 1px solid var(--c-badge-plan-bg);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.codegraph-group-count {
+  font-weight: 400;
+  color: var(--c-text-tertiary);
+  text-transform: none;
+}
+
+.codegraph-module {
+  padding: 5px 8px;
+  margin-bottom: 4px;
+  background: var(--c-surface-hover);
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-sm);
+}
+.codegraph-module-path {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--c-text);
+  word-break: break-all;
+}
+.codegraph-module-desc {
+  font-size: 10px;
+  color: var(--c-text-secondary);
+  line-height: 1.4;
+  margin-top: 2px;
+}
+.codegraph-module-deps {
+  font-size: 9px;
+  color: var(--c-text-tertiary);
+  margin-top: 2px;
+}
+
 /* ── Focus-visible outlines ── */
 
 button:focus-visible,

--- a/client/src/api/codegraph.js
+++ b/client/src/api/codegraph.js
@@ -1,0 +1,38 @@
+// 代码知识图谱(Code Graph)API：拉取/重新索引/搜索,均按当前项目 id 隔离。
+import { apiFetch } from './http.js';
+
+function withParams(path, projectId, extra = {}) {
+  const params = new URLSearchParams();
+  if (projectId) params.set('projectId', projectId);
+  for (const [k, v] of Object.entries(extra)) {
+    if (v != null && v !== '') params.set(k, v);
+  }
+  const qs = params.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+
+// 返回 { graph, job }：graph 为 codegraph.json 内容(可能 null),job 为当前索引任务状态(可能 null)。
+export async function fetchCodegraph(projectId) {
+  const res = await apiFetch(withParams('/api/agent/codegraph', projectId));
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+// 触发后台重新索引,立即返回 { ok, job }。需指定用于生成语义的模型。
+export async function reindexCodegraph(projectId, model) {
+  const res = await apiFetch(withParams('/api/agent/codegraph/reindex', projectId), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+
+// 静态关键词搜索,返回 { results: [...modules] }。
+export async function searchCodegraph(projectId, q) {
+  const res = await apiFetch(withParams('/api/agent/codegraph/query', projectId, { q }));
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}

--- a/client/src/components/session/MemoryPanel.jsx
+++ b/client/src/components/session/MemoryPanel.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
-import { ChevronUp } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronUp, RefreshCw } from 'lucide-react';
 import { useT } from '../../i18n/I18nProvider.jsx';
 import { apiFetch } from '../../api/http.js';
+import { fetchCodegraph, reindexCodegraph } from '../../api/codegraph.js';
 
-export function MemoryPanel({ onClose, activeProjectId = null }) {
+export function MemoryPanel({ onClose, activeProjectId = null, modelList = [] }) {
   const t = useT();
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -59,11 +60,16 @@ export function MemoryPanel({ onClose, activeProjectId = null }) {
           <button className={`memory-tab ${tab === 'knowledge' ? 'active' : ''}`} onClick={() => setTab('knowledge')}>
             {t('memory.tabKnowledge', { n: (pk.structure?.length || 0) + Object.keys(pk.paths || {}).length + (pk.preferences?.length || 0) + (pk.learnings?.length || 0) })}
           </button>
+          <button className={`memory-tab ${tab === 'codegraph' ? 'active' : ''}`} onClick={() => setTab('codegraph')}>
+            {t('codegraph.tab')}
+          </button>
         </div>
         <button className="memory-panel-close" onClick={onClose}><ChevronUp size={14} /></button>
       </div>
       <div className="memory-panel-body">
-        {loading ? (
+        {tab === 'codegraph' ? (
+          <CodeGraphTab activeProjectId={activeProjectId} modelList={modelList} />
+        ) : loading ? (
           <div className="memory-loading">{t('common.loading')}</div>
         ) : tab === 'conversation' ? (
           <>
@@ -126,19 +132,199 @@ export function MemoryPanel({ onClose, activeProjectId = null }) {
           </>
         )}
       </div>
-      <div className="memory-panel-footer">
-        <button className="memory-compact-btn" onClick={handleCompact} disabled={compacting}>
-          {compacting ? t('memory.compacting') : t('memory.compactHistory')}
-        </button>
-        <div className="memory-clear-group">
-          <button className="memory-clear-btn" onClick={() => handleClear('/api/agent/memory/knowledge')} title={t('memory.clearKnowledgeTitle')}>
-            {t('memory.clearKnowledge')}
+      {tab !== 'codegraph' && (
+        <div className="memory-panel-footer">
+          <button className="memory-compact-btn" onClick={handleCompact} disabled={compacting}>
+            {compacting ? t('memory.compacting') : t('memory.compactHistory')}
           </button>
-          <button className="memory-clear-btn danger" onClick={() => handleClear('/api/agent/memory')} title={t('memory.clearAllTitle')}>
-            {t('common.clearAll')}
+          <div className="memory-clear-group">
+            <button className="memory-clear-btn" onClick={() => handleClear('/api/agent/memory/knowledge')} title={t('memory.clearKnowledgeTitle')}>
+              {t('memory.clearKnowledge')}
+            </button>
+            <button className="memory-clear-btn danger" onClick={() => handleClear('/api/agent/memory')} title={t('memory.clearAllTitle')}>
+              {t('common.clearAll')}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Code Graph 标签页：状态卡 + 模型下拉 + 重新索引(后台任务,轮询进度) + 本地搜索 + 模块依赖列表。
+function CodeGraphTab({ activeProjectId, modelList }) {
+  const t = useT();
+  const [cg, setCg] = useState(null);          // { graph, job }
+  const [loading, setLoading] = useState(true);
+  const [model, setModel] = useState('');
+  const [reindexing, setReindexing] = useState(false);
+  const [search, setSearch] = useState('');
+
+  // 默认选用模型列表第一个。
+  useEffect(() => {
+    if (!model && modelList.length > 0) setModel(modelList[0].id);
+  }, [modelList, model]);
+
+  // 切到该 tab / 切项目时拉一次。
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchCodegraph(activeProjectId)
+      .then(d => { if (!cancelled) setCg(d); })
+      .catch(() => { if (!cancelled) setCg(null); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [activeProjectId]);
+
+  // 索引进行中时轮询进度,直到 done/error。
+  useEffect(() => {
+    if (cg?.job?.status !== 'indexing') return undefined;
+    const timer = setTimeout(() => {
+      fetchCodegraph(activeProjectId).then(setCg).catch(() => {});
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [cg, activeProjectId]);
+
+  const handleReindex = async () => {
+    if (!model) return;
+    setReindexing(true);
+    try {
+      const d = await reindexCodegraph(activeProjectId, model);
+      setCg(prev => ({ graph: prev?.graph ?? null, job: d.job }));
+    } catch (err) {
+      alert(t('codegraph.error', { error: err.message || String(err) }));
+    } finally {
+      setReindexing(false);
+    }
+  };
+
+  const graph = cg?.graph || null;
+  const job = cg?.job || null;
+  const indexing = job?.status === 'indexing';
+
+  // 本地过滤(图谱已在前端,无需再请求后端)。
+  const filtered = useMemo(() => {
+    const all = graph?.modules || [];
+    const q = search.trim().toLowerCase();
+    if (!q) return all;
+    return all.filter(m =>
+      m.path.toLowerCase().includes(q)
+      || (m.description || '').toLowerCase().includes(q)
+      || (m.group || '').toLowerCase().includes(q)
+      || (m.exports || []).some(e => e.toLowerCase().includes(q))
+    );
+  }, [graph, search]);
+
+  // 按 group 分组,组内按路径排序,组按大小降序。
+  const grouped = useMemo(() => {
+    const map = new Map();
+    for (const m of filtered) {
+      const g = m.group || 'other';
+      if (!map.has(g)) map.set(g, []);
+      map.get(g).push(m);
+    }
+    return [...map.entries()]
+      .map(([g, mods]) => [g, mods.sort((a, b) => a.path.localeCompare(b.path))])
+      .sort((a, b) => b[1].length - a[1].length);
+  }, [filtered]);
+
+  return (
+    <div className="codegraph-tab">
+      {/* 状态卡 + 操作 */}
+      <div className="codegraph-controls">
+        {graph ? (
+          <div className="codegraph-stats">
+            <span className="codegraph-stats-main">{t('codegraph.stats', {
+              files: graph.stats?.totalFiles ?? 0,
+              modules: graph.stats?.totalModules ?? 0,
+              coverage: graph.stats?.coverage ?? '0%',
+            })}</span>
+            {graph.lastIndexed && (
+              <span className="codegraph-stats-sub">
+                {t('codegraph.lastIndexed', { time: new Date(graph.lastIndexed).toLocaleString() })}
+                {graph.model ? ` · ${graph.model.split('/').pop()}` : ''}
+              </span>
+            )}
+          </div>
+        ) : (
+          <div className="codegraph-stats codegraph-stats-empty">{t('codegraph.notIndexed')}</div>
+        )}
+
+        <div className="codegraph-actions">
+          <select
+            className="codegraph-model-select"
+            value={model}
+            onChange={e => setModel(e.target.value)}
+            disabled={indexing || reindexing}
+            title={t('codegraph.modelTitle')}
+          >
+            {modelList.length === 0 && <option value="">{t('codegraph.noModel')}</option>}
+            {modelList.map(m => <option key={m.id} value={m.id}>{m.label || m.id}</option>)}
+          </select>
+          <button
+            className="codegraph-reindex-btn"
+            onClick={handleReindex}
+            disabled={indexing || reindexing || !model}
+          >
+            <RefreshCw size={12} className={indexing ? 'spinning' : ''} />
+            {indexing ? t('codegraph.indexing') : t('codegraph.reindex')}
           </button>
         </div>
       </div>
+
+      {/* 进度 / 错误 */}
+      {indexing && (
+        <div className="codegraph-progress">
+          {job.phase === 'scanning'
+            ? t('codegraph.scanning')
+            : t('codegraph.describing', { done: job.done ?? 0, total: job.total ?? 0 })}
+        </div>
+      )}
+      {job?.status === 'error' && (
+        <div className="codegraph-progress codegraph-progress-error">{t('codegraph.error', { error: job.error || '' })}</div>
+      )}
+
+      {/* 主体 */}
+      {loading ? (
+        <div className="memory-loading">{t('common.loading')}</div>
+      ) : !graph ? (
+        <div className="memory-empty">{t('codegraph.empty')}</div>
+      ) : (
+        <>
+          {graph.summary && <p className="codegraph-summary">{graph.summary}</p>}
+          <div className="codegraph-search">
+            <input
+              type="text"
+              className="codegraph-search-input"
+              placeholder={t('codegraph.searchPlaceholder')}
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
+          </div>
+          {filtered.length === 0 ? (
+            <div className="memory-empty">{t('codegraph.noMatch')}</div>
+          ) : (
+            <div className="codegraph-modules">
+              {grouped.map(([group, mods]) => (
+                <div key={group} className="codegraph-group">
+                  <p className="codegraph-group-title">{group} <span className="codegraph-group-count">{mods.length}</span></p>
+                  {mods.map(m => (
+                    <div key={m.path} className="codegraph-module">
+                      <div className="codegraph-module-path">{m.path}</div>
+                      {m.description && <div className="codegraph-module-desc">{m.description}</div>}
+                      {m.dependsOn?.length > 0 && (
+                        <div className="codegraph-module-deps" title={m.dependsOn.join('\n')}>
+                          {t('codegraph.dependsOn', { n: m.dependsOn.length })}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/components/session/SessionList.jsx
+++ b/client/src/components/session/SessionList.jsx
@@ -133,7 +133,7 @@ export function SessionList({
       </div>
 
       {showMemoryPanel ? (
-        <MemoryPanel onClose={onToggleMemory} activeProjectId={activeProjectId} />
+        <MemoryPanel onClose={onToggleMemory} activeProjectId={activeProjectId} modelList={modelList} />
       ) : (
         <>
           <ProjectSwitcher

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -234,6 +234,23 @@ export const en = {
   'memory.clearKnowledge': 'Clear knowledge',
   'memory.clearAllTitle': 'Clear all memory',
 
+  // Code Graph
+  'codegraph.tab': 'Code Graph',
+  'codegraph.stats': '{files} files · {modules} modules · {coverage} coverage',
+  'codegraph.lastIndexed': 'Last indexed {time}',
+  'codegraph.notIndexed': 'Not indexed yet',
+  'codegraph.empty': 'No code graph for this project yet. Pick a model and click "Reindex" to generate.',
+  'codegraph.reindex': 'Reindex',
+  'codegraph.indexing': 'Indexing…',
+  'codegraph.scanning': 'Scanning files…',
+  'codegraph.describing': 'Describing {done}/{total}',
+  'codegraph.searchPlaceholder': 'Search modules…',
+  'codegraph.noMatch': 'No matching modules',
+  'codegraph.noModel': 'No models available',
+  'codegraph.modelTitle': 'Model used to generate graph semantics',
+  'codegraph.dependsOn': 'deps {n}',
+  'codegraph.error': 'Index failed: {error}',
+
   // Dialogs
   'reset.title': 'Clear current session?',
   'reset.desc': 'The session is kept, but its messages are removed.',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -235,6 +235,23 @@ export const zh = {
   'memory.clearKnowledge': '清空知识',
   'memory.clearAllTitle': '清空全部记忆',
 
+  // 代码图谱 Code Graph
+  'codegraph.tab': '代码图谱',
+  'codegraph.stats': '{files} 文件 · {modules} 模块 · 覆盖率 {coverage}',
+  'codegraph.lastIndexed': '上次索引 {time}',
+  'codegraph.notIndexed': '尚未建立图谱',
+  'codegraph.empty': '该项目还没有代码图谱。选择模型后点「重新索引」生成。',
+  'codegraph.reindex': '重新索引',
+  'codegraph.indexing': '索引中…',
+  'codegraph.scanning': '扫描文件中…',
+  'codegraph.describing': '生成语义 {done}/{total}',
+  'codegraph.searchPlaceholder': '搜索模块…',
+  'codegraph.noMatch': '无匹配模块',
+  'codegraph.noModel': '无可用模型',
+  'codegraph.modelTitle': '选择用于生成图谱语义的模型',
+  'codegraph.dependsOn': '依赖 {n}',
+  'codegraph.error': '索引失败：{error}',
+
   // 对话框
   'reset.title': '清空当前会话内容？',
   'reset.desc': '当前会话会保留，但消息记录会被移除。',

--- a/routes/agent-codegraph.ts
+++ b/routes/agent-codegraph.ts
@@ -1,0 +1,133 @@
+/**
+ * Codegraph Router — 代码知识图谱的查看 / 重新索引 / 搜索
+ *
+ * 端点(均按 ?projectId 隔离;未指定即全局,语义同 resolveRunPaths):
+ *   GET  /api/agent/codegraph              返回 codegraph.json 内容 + 当前索引任务状态(供轮询进度)
+ *   POST /api/agent/codegraph/reindex      body { model } 触发后台异步索引,立即返回;已在跑→409
+ *   GET  /api/agent/codegraph/query?q=     纯静态关键词搜索匹配模块
+ *
+ * 索引是分钟级重操作:POST 立即返回,后台跑 scanSkeleton → buildCodegraphWithLLM → saveCodegraph,
+ * 进度记录在内存 IndexJob,前端轮询 GET 拿 done/total。
+ */
+
+import { Router } from 'express';
+import path from 'node:path';
+import {
+  loadCodegraph,
+  saveCodegraph,
+  scanSkeleton,
+  buildCodegraphWithLLM,
+  queryCodegraph,
+} from '../agent/core/codegraph.ts';
+import { resolveRunPaths } from '../agent/core/project-store.ts';
+import { log } from '../helpers/logger.ts';
+import type { AgentRouterContext } from './agent-types.ts';
+
+interface IndexJob {
+  status: 'indexing' | 'done' | 'error';
+  phase: 'scanning' | 'describing';
+  total: number;
+  done: number;
+  startedAt: number;
+  finishedAt?: number;
+  error?: string;
+}
+
+export function createAgentCodegraphRouter({
+  memoryDir,
+  modelConfig,
+  registry,
+  projectStore,
+}: AgentRouterContext) {
+  const router = Router();
+
+  // 索引任务状态:按项目隔离(无项目用 __global__),供前端轮询进度。
+  const jobs = new Map<string, IndexJob>();
+  const jobKey = (projectId: string | null) => projectId || '__global__';
+
+  const resolvePaths = (req: any) => {
+    const pid = typeof req.query.projectId === 'string' ? req.query.projectId : null;
+    return resolveRunPaths(projectStore, pid, memoryDir);
+  };
+
+  // 当前图谱 + 索引任务状态
+  router.get('/api/agent/codegraph', async (req, res) => {
+    try {
+      const { projectId, dataDir } = resolvePaths(req);
+      const graph = await loadCodegraph(dataDir);
+      res.json({ graph, job: jobs.get(jobKey(projectId)) ?? null });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // 触发后台重新索引
+  router.post('/api/agent/codegraph/reindex', async (req, res) => {
+    const { projectId, projectRoot, dataDir } = resolvePaths(req);
+    const key = jobKey(projectId);
+
+    const existing = jobs.get(key);
+    if (existing?.status === 'indexing') {
+      return res.status(409).json({ error: '索引正在进行中', job: existing });
+    }
+
+    const model = req.body?.model;
+    if (!model || typeof model !== 'string') {
+      return res.status(400).json({ error: '缺少 model 参数' });
+    }
+
+    const job: IndexJob = { status: 'indexing', phase: 'scanning', total: 0, done: 0, startedAt: Date.now() };
+    jobs.set(key, job);
+
+    // 立即返回,后台异步执行(不 await)。
+    res.json({ ok: true, job });
+
+    (async () => {
+      try {
+        const project = projectId ? projectStore.get(projectId) : null;
+        const projectName = project?.name || path.basename(projectRoot) || 'project';
+        log.info(`[Codegraph] 开始索引 project=${projectName} root=${projectRoot} model=${model}`);
+
+        const skeleton = await scanSkeleton(projectRoot);
+        job.phase = 'describing';
+
+        const graph = await buildCodegraphWithLLM({
+          skeleton,
+          registry,
+          model,
+          modelConfig,
+          projectName,
+          rootPath: projectRoot,
+          onProgress: (done, total) => {
+            job.done = done;
+            job.total = total;
+          },
+        });
+
+        await saveCodegraph(dataDir, graph);
+        job.status = 'done';
+        job.finishedAt = Date.now();
+        log.info(`[Codegraph] 索引完成 project=${projectName} 模块=${graph.modules.length} 覆盖率=${graph.stats.coverage} 耗时=${Date.now() - job.startedAt}ms`);
+      } catch (err: any) {
+        job.status = 'error';
+        job.error = err?.message || String(err);
+        job.finishedAt = Date.now();
+        log.warn(`[Codegraph] 索引失败: ${job.error}`);
+      }
+    })();
+  });
+
+  // 静态关键词搜索
+  router.get('/api/agent/codegraph/query', async (req, res) => {
+    try {
+      const { dataDir } = resolvePaths(req);
+      const q = typeof req.query.q === 'string' ? req.query.q : '';
+      const graph = await loadCodegraph(dataDir);
+      res.json({ results: queryCodegraph(graph, q) });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  return router;
+}

--- a/routes/agent.ts
+++ b/routes/agent.ts
@@ -19,6 +19,7 @@ import { createAgentCheckpointRouter } from './agent-checkpoints.ts';
 import { createAgentTraceRouter } from './agent-traces.ts';
 import { createAgentUploadsRouter } from './agent-uploads.ts';
 import { createAgentProjectsRouter } from './agent-projects.ts';
+import { createAgentCodegraphRouter } from './agent-codegraph.ts';
 import type { AgentRouterContext } from './agent-types.ts';
 
 export function createAgentRouter(context: AgentRouterContext) {
@@ -33,6 +34,7 @@ export function createAgentRouter(context: AgentRouterContext) {
   router.use(createAgentTraceRouter(context));
   router.use(createAgentUploadsRouter(context));
   router.use(createAgentProjectsRouter(context));
+  router.use(createAgentCodegraphRouter(context));
 
   return router;
 }


### PR DESCRIPTION
## 背景

issue #206 想给 Agent 加「本地代码知识图谱（Code Graph）」，让 Agent 执行任务前就掌握项目模块结构，减少逐个 read_file/list_dir 探索的 token 开销。本 PR 承接 #257 的「一等 Project」隔离基座（`resolveRunPaths` 已能给出每项目的 `dataDir` 与 `projectRoot`）。

经讨论将原 issue 裁剪为 **MVP**：
- 范围 = 索引 + 可视化 + `codegraph_query` 工具，**不碰 Agent 执行核心路径**（自动上下文注入留作下一步）。
- 索引引擎 = **静态骨架 + LLM 语义增强**：结构（文件树 / import 依赖边 / stats）静态算，语义（description / 分组）由 LLM 补，map-reduce 分批、异步后台跑，LLM 失败回退头注释。
- 原提案的 `sagent codegraph init/status/query` CLI **改为记忆面板内的按钮 / 搜索框**。
- 重新索引时**前端下拉选用的模型**。

## 改动

### 后端
- 新增 `agent/core/codegraph.ts`：`scanSkeleton`（递归扫描，跳过 node_modules/dist/.git/data + .gitignore 简单条目，正则抽 import/export/头注释，解析项目内依赖边）、`buildCodegraphWithLLM`（分批 `completionJson` 生成语义，含容错 JSON 解析与失败回退）、`loadCodegraph/saveCodegraph`（原子写）、`queryCodegraph`（静态关键词匹配）。
- 新增 `routes/agent-codegraph.ts`：`GET /api/agent/codegraph`（图谱 + 索引任务状态）、`POST .../reindex`（后台异步、立即返回、内存 IndexJob 记录进度）、`GET .../query`。按 `?projectId` 经 `resolveRunPaths` 隔离落盘到 `data/projects/<id>/codegraph.json`，注册到 `routes/agent.ts`。
- 新增 `codegraph_query` Agent 工具，贯穿 5 处接入：`tool-definitions.ts`（schema）、`action-types.ts`（type→tool 映射）、`schemas.ts`（normalize 分支）、`prompts.ts`（nvidia 示例）、`agent/desktop/agent.ts`（router 分发 + `initialize` 补 `dataDir` + 子 Agent 接通），执行器 `agent/tools/codegraph/execute.ts`。

### 前端
- `MemoryPanel.jsx` 新增第三个 tab「Code Graph」：状态卡、模型下拉、重新索引按钮（后台任务 + 轮询进度）、本地搜索、按 group 分组的模块依赖列表。
- `SessionList.jsx` 透传 `modelList`；新增 `client/src/api/codegraph.js`；补 zh/en 文案与 `App.css` 样式（复用 `--c-*` 变量与暗黑模式约定）。

## 明确不做（MVP 边界）
- 自动上下文注入（不改 `agent-run-start.ts` 执行路径）、git 增量索引、npm start 自动索引、与记忆系统长期摘要联动、embedding 语义检索 —— 均留后续。

## 验证
- `npm run build`（typecheck + 前端构建）通过；`npm test` 全绿（15 文件 / 114 用例）。
- 端到端手测要点（建议合并前确认）：建 / 激活项目 → 记忆面板 Code Graph → 选模型 → 重新索引 → 进度到完成 → 模块列表 / 搜索正常 → Agent 模式发任务触发 `codegraph_query`。
- 向后兼容：无项目（全局态）功能正常；未索引项目打开 tab 显示空态而非报错。

## 关联 Issue
- 实现 **#206**（本地代码知识图谱）的 MVP；自动上下文注入 / git 增量索引 / 记忆系统联动留作后续，故用 `Refs` 关联而非 `Closes`，issue 保持开放以追踪剩余工作。
- 相关 **#238**（Agent 记忆系统知识图谱化）—— 另一维度的结构化探索，可在本图谱基座上协同。

Refs #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
