### PR TITLE
fix(codegraph): code review 修复 — Claude 索引 / 死代码清理

### DIFF
--- a/agent/core/codegraph.ts
+++ b/agent/core/codegraph.ts
@@ -130,13 +130,10 @@ async function walkFiles(rootPath: string): Promise<string[]> {
     for (const entry of entries) {
       if (out.length >= MAX_FILES) return;
       const name = entry.name;
-      if (name.startsWith('.') && name !== '.gitignore') {
-        // 跳过点目录/点文件(.git/.idea 等),但目录扫描本就不读文件内容的隐藏文件
-        if (entry.isDirectory()) continue;
-      }
       const full = path.join(dir, name);
       if (entry.isDirectory()) {
-        if (SKIP_DIRS.has(name) || extra.has(name)) continue;
+        // 跳过隐藏目录(.git/.idea 等)与默认 / .gitignore 忽略目录
+        if (name.startsWith('.') || SKIP_DIRS.has(name) || extra.has(name)) continue;
         await walk(full);
       } else if (entry.isFile()) {
         if (CODE_EXTS.includes(path.extname(name))) out.push(full);
@@ -323,19 +320,19 @@ function buildBatchMessages(batch: FileSkeleton[]): any[] {
     return `- ${parts.join(' | ')}`;
   }).join('\n');
 
+  // 指令并入单条 user message:Anthropic 的 messages 不接受 system 角色(system 须作顶层参数,
+  // 见 providers/anthropic.ts agentPlan),单条 user message 对 anthropic/gemini/openai-compat 都安全。
+  const instruction = [
+    '你是代码库分析助手。根据每个文件的路径、头注释、导出符号、依赖,',
+    '为每个文件生成一句话中文职责描述(description,≤30字)和一个模块分组(group,简短英文短横线命名,如 agent-core / routes / client-ui)。',
+    '只输出一个 JSON 数组,每项形如 {"path":"...","description":"...","group":"..."},',
+    'path 必须与输入完全一致。不要输出 JSON 以外的任何文字、不要用 markdown 围栏。',
+  ].join('');
+
   return [
     {
-      role: 'system',
-      content: [
-        '你是代码库分析助手。根据每个文件的路径、头注释、导出符号、依赖,',
-        '为每个文件生成一句话中文职责描述(description,≤30字)和一个模块分组(group,简短英文短横线命名,如 agent-core / routes / client-ui)。',
-        '只输出一个 JSON 数组,每项形如 {"path":"...","description":"...","group":"..."},',
-        'path 必须与输入完全一致。不要输出 JSON 以外的任何文字、不要用 markdown 围栏。',
-      ].join(''),
-    },
-    {
       role: 'user',
-      content: `请分析以下 ${batch.length} 个文件:\n${fileLines}`,
+      content: `${instruction}\n\n请分析以下 ${batch.length} 个文件:\n${fileLines}`,
     },
   ];
 }

--- a/client/src/api/codegraph.js
+++ b/client/src/api/codegraph.js
@@ -29,10 +29,3 @@ export async function reindexCodegraph(projectId, model) {
   if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
   return data;
 }
-
-// 静态关键词搜索,返回 { results: [...modules] }。
-export async function searchCodegraph(projectId, q) {
-  const res = await apiFetch(withParams('/api/agent/codegraph/query', projectId, { q }));
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
-}

--- a/routes/agent-codegraph.ts
+++ b/routes/agent-codegraph.ts
@@ -4,7 +4,6 @@
  * 端点(均按 ?projectId 隔离;未指定即全局,语义同 resolveRunPaths):
  *   GET  /api/agent/codegraph              返回 codegraph.json 内容 + 当前索引任务状态(供轮询进度)
  *   POST /api/agent/codegraph/reindex      body { model } 触发后台异步索引,立即返回;已在跑→409
- *   GET  /api/agent/codegraph/query?q=     纯静态关键词搜索匹配模块
  *
  * 索引是分钟级重操作:POST 立即返回,后台跑 scanSkeleton → buildCodegraphWithLLM → saveCodegraph,
  * 进度记录在内存 IndexJob,前端轮询 GET 拿 done/total。
@@ -17,7 +16,6 @@ import {
   saveCodegraph,
   scanSkeleton,
   buildCodegraphWithLLM,
-  queryCodegraph,
 } from '../agent/core/codegraph.ts';
 import { resolveRunPaths } from '../agent/core/project-store.ts';
 import { log } from '../helpers/logger.ts';
@@ -115,18 +113,6 @@ export function createAgentCodegraphRouter({
         log.warn(`[Codegraph] 索引失败: ${job.error}`);
       }
     })();
-  });
-
-  // 静态关键词搜索
-  router.get('/api/agent/codegraph/query', async (req, res) => {
-    try {
-      const { dataDir } = resolvePaths(req);
-      const q = typeof req.query.q === 'string' ? req.query.q : '';
-      const graph = await loadCodegraph(dataDir);
-      res.json({ results: queryCodegraph(graph, q) });
-    } catch (err: any) {
-      res.status(500).json({ error: err.message });
-    }
   });
 
   return router;


### PR DESCRIPTION
## 背景

PR #258（本地代码知识图谱 MVP，**已合并入 main**）的 code review 发现 3 个问题，本 PR 修复。基于最新 main，diff 仅含这 3 个修复。

> 替代之前 base 错叠在 `feat/codegraph` 上、显得混乱的 PR #260（已关闭）。

## 修复

- **#1 真 bug — Claude 模型索引静默失效**：`agent/core/codegraph.ts` 的 `buildBatchMessages` 原用 `{role:'system'}` 消息，而 `providers/anthropic.ts` 的 `completionJson` 不抽离 system 角色（Anthropic Messages API 要求 system 作顶层参数，见同文件 `agentPlan`）。结果：配置 ANTHROPIC_API_KEY 后选 Claude 模型重新索引，每批 LLM 调用 400、被 catch 静默回退头注释 → 语义层全废且无报错。改为将指令并入**单条 user message**，对 anthropic / gemini / openai-compat 均安全。

- **#2 死代码**：删除从未被调用的 REST `GET /api/agent/codegraph/query` 端点与前端 `api/codegraph.js` 的 `searchCodegraph`（前端搜索走本地 `useMemo` 过滤，Agent 工具走 core `queryCodegraph`，两者都不经此端点）。

- **#7 死逻辑**：`codegraph.ts` 的 `walkFiles` 中 `name !== '.gitignore'` 例外永不生效（`.gitignore` 无扩展名本就不会被 `CODE_EXTS` 收录），简化为「隐藏目录一律跳过」。

## 验证
- `npm run build`（typecheck + 前端构建）通过；`npm test` 全绿（228 用例）。

## 关联
Refs #206 · 修复 #258（已合并）的 code review 项

🤖 Generated with [Claude Code](https://claude.com/claude-code)
