### PR TITLE
Polish settings and mobile controls

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=3" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="theme-color" content="#f5f5fa" />
     <title>sagent</title>
     <script>

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -121,6 +121,10 @@
   --c-code-inline: #c7254e;
   --c-input-bg: rgba(255, 255, 255, 0.72);
   --c-input-border: rgba(0, 0, 0, 0.06);
+  --c-settings-mask: rgba(20, 20, 31, 0.16);
+  --c-settings-glass: rgba(255, 255, 255, 0.52);
+  --c-settings-glass-border: rgba(255, 255, 255, 0.54);
+  --c-settings-glass-inner: rgba(255, 255, 255, 0.34);
 
   /* Think（推理）区配色 */
   --c-think-border: #dcd7fb;
@@ -258,6 +262,10 @@
   --c-code-inline: #f0859b;
   --c-input-bg: rgba(40, 40, 52, 0.72);
   --c-input-border: rgba(255, 255, 255, 0.08);
+  --c-settings-mask: rgba(0, 0, 0, 0.3);
+  --c-settings-glass: rgba(30, 30, 41, 0.48);
+  --c-settings-glass-border: rgba(255, 255, 255, 0.12);
+  --c-settings-glass-inner: rgba(42, 42, 54, 0.34);
 
   /* Think 区 */
   --c-think-border: #36304f;
@@ -444,6 +452,85 @@ select,
   gap: 8px;
   padding-top: 12px;
   border-top: 1px solid var(--c-border);
+}
+.hero-toolbar .mode-switch,
+.hero-toolbar .model-dropdown-trigger,
+.hero-toolbar .attach-btn,
+.hero-toolbar .send-btn {
+  height: 34px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  color: var(--c-text-secondary);
+  box-shadow: none;
+  transition: background var(--ease), border-color var(--ease), color var(--ease), transform var(--ease);
+}
+.hero-toolbar .mode-switch {
+  padding: 0;
+  overflow: hidden;
+}
+.hero-toolbar .mode-btn {
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 0;
+  color: var(--c-text-secondary);
+  font-size: var(--f-sm);
+}
+.hero-toolbar .mode-btn + .mode-btn {
+  border-left: 1px solid var(--c-border);
+}
+.hero-toolbar .mode-btn.active {
+  background: var(--c-primary-bg);
+  color: var(--c-primary);
+  box-shadow: none;
+  font-weight: 600;
+}
+.hero-toolbar .model-dropdown-trigger,
+.hero-toolbar .attach-btn,
+.hero-toolbar .send-btn {
+  padding: 0 12px;
+}
+.hero-toolbar .model-dropdown-trigger {
+  max-width: 230px;
+  gap: 6px;
+}
+.hero-toolbar .attach-btn {
+  font-size: var(--f-sm);
+}
+.hero-toolbar .send-btn.idle {
+  border-color: var(--c-primary);
+  background: var(--c-primary);
+  color: var(--c-on-accent);
+}
+.hero-toolbar .send-btn.stop {
+  border-color: var(--c-danger);
+  background: var(--c-surface);
+  color: var(--c-danger);
+}
+.hero-toolbar .mode-switch:hover,
+.hero-toolbar .model-dropdown-trigger:hover:not(:disabled),
+.hero-toolbar .attach-btn:hover:not(:disabled) {
+  border-color: var(--c-primary-light);
+  background: var(--c-primary-bg);
+  color: var(--c-primary);
+}
+.hero-toolbar .send-btn.idle:hover:not(:disabled) {
+  filter: brightness(0.96);
+}
+.hero-toolbar .send-btn.stop:hover:not(:disabled) {
+  background: var(--c-danger-bg);
+}
+.hero-toolbar .model-dropdown-trigger:disabled,
+.hero-toolbar .attach-btn:disabled,
+.hero-toolbar .send-btn:disabled,
+.hero-toolbar .mode-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.hero-toolbar .send-btn.idle:disabled {
+  border-color: var(--c-border);
+  background: var(--c-surface-dim);
+  color: var(--c-text-hint);
 }
 
 .suggestions-head {
@@ -1514,10 +1601,10 @@ select,
 .model-dropdown-trigger {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   height: 34px;
   padding: 0 8px;
-  max-width: 170px;
+  max-width: 220px;
   border-radius: var(--r-sm);
   border: 1px solid var(--c-border);
   background: var(--c-surface);
@@ -1537,8 +1624,32 @@ select,
 }
 
 .model-dropdown-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.model-dropdown-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.model-dropdown-provider {
+  flex: 0 0 auto;
+  max-width: 78px;
+  height: 18px;
+  padding: 0 6px;
+  border: 1px solid var(--c-primary-light);
+  border-radius: var(--r-pill);
+  background: var(--c-primary-bg);
+  color: var(--c-primary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: capitalize;
   white-space: nowrap;
 }
 
@@ -3298,6 +3409,14 @@ textarea:disabled {
   cursor: not-allowed;
 }
 
+@media (max-width: 768px) {
+  input:not([type="file"]):not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}
+
 .send-btn {
   flex-shrink: 0;
   height: 32px;
@@ -3345,6 +3464,9 @@ textarea:disabled {
   padding: 16px;
   background: var(--c-overlay);
 }
+.settings-mask {
+  background: var(--c-settings-mask);
+}
 
 .dialog {
   background: var(--c-surface);
@@ -3388,10 +3510,25 @@ textarea:disabled {
 
 /* ── Settings dialog ── */
 
-.settings-dialog { width: min(720px, 94vw); max-height: 86vh; overflow-y: auto; }
+/* 固定高度:切换分组时弹窗不再跳动;标题/底部按钮固定,内容区内部滚动 */
+.settings-dialog {
+  position: relative;
+  width: min(720px, 94vw);
+  height: min(540px, 86vh);
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--c-settings-glass-border);
+  background: var(--c-settings-glass);
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.42);
+  backdrop-filter: blur(22px) saturate(1.35);
+  -webkit-backdrop-filter: blur(22px) saturate(1.35);
+}
+.settings-dialog .dialog-title,
+.settings-dialog .dialog-actions { flex-shrink: 0; }
+.settings-dialog .dialog-title { padding-right: 40px; }
 
 /* 左导航 + 右内容两栏布局 */
-.settings-layout { display: flex; gap: 20px; }
+.settings-layout { display: flex; gap: 20px; flex: 1; min-height: 0; }
 .settings-nav {
   flex-shrink: 0;
   width: 132px;
@@ -3400,6 +3537,9 @@ textarea:disabled {
   gap: 2px;
 }
 .settings-nav-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   text-align: left;
   padding: 8px 12px;
   border: none;
@@ -3411,14 +3551,35 @@ textarea:disabled {
   transition: all 0.15s;
   white-space: nowrap;
 }
+.settings-nav-icon { flex-shrink: 0; opacity: 0.7; }
 .settings-nav-btn:hover { background: var(--c-surface-hover); }
 .settings-nav-btn.active { background: var(--c-primary-bg); color: var(--c-primary); font-weight: 600; }
-.settings-content { flex: 1; min-width: 0; }
+.settings-nav-btn.active .settings-nav-icon { opacity: 1; }
+.settings-content { flex: 1; min-width: 0; overflow-y: auto; }
 .settings-content .settings-section:last-child { margin-bottom: 0; }
-
-@media (max-width: 560px) {
-  .settings-layout { flex-direction: column; gap: 12px; }
-  .settings-nav { width: 100%; flex-direction: row; flex-wrap: wrap; }
+.settings-close-btn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--c-text-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.settings-close-btn:hover:not(:disabled) {
+  background: var(--c-surface-hover);
+  color: var(--c-text);
+}
+.settings-close-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.settings-dialog .dialog-actions {
+  justify-content: space-between;
 }
 
 .settings-section { margin-bottom: 20px; }
@@ -3426,17 +3587,53 @@ textarea:disabled {
 
 .settings-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px 16px; }
 .settings-field { display: flex; flex-direction: column; gap: 4px; font-size: var(--f-sm); color: var(--c-text-secondary); }
-.settings-field input[type="number"] {
-  height: 34px; padding: 0 10px; border: 1px solid var(--c-border);
-  border-radius: var(--r-sm); background: var(--c-surface); font-size: 14px; color: var(--c-text);
-}
 .settings-field-switch { flex-direction: row; align-items: center; justify-content: space-between; grid-column: 1 / -1; }
 .settings-field-switch input { width: 18px; height: 18px; }
+.settings-stepper {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) 34px;
+  height: 34px;
+  overflow: hidden;
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-sm);
+  background: var(--c-settings-glass-inner);
+}
+.settings-stepper-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: var(--c-settings-glass-inner);
+  color: var(--c-text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.settings-stepper-btn:hover:not(:disabled) {
+  background: var(--c-surface-hover);
+  color: var(--c-text);
+}
+.settings-stepper-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.settings-stepper-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  padding: 0 8px;
+  color: var(--c-text);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 .settings-keys { display: flex; flex-direction: column; gap: 8px; }
 .settings-key-row {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 8px 12px; border: 1px solid var(--c-border); border-radius: var(--r-sm); font-size: var(--f-sm);
+  padding: 8px 12px; border: 1px solid var(--c-border); border-radius: var(--r-sm); background: var(--c-settings-glass-inner); font-size: var(--f-sm);
 }
 .settings-key-provider { font-weight: 600; text-transform: capitalize; }
 .settings-key-status.on { color: var(--c-success); font-family: monospace; }
@@ -3452,13 +3649,14 @@ textarea:disabled {
   border-radius: var(--r-sm);
   overflow: hidden;
   flex-shrink: 0;
+  background: var(--c-settings-glass-inner);
 }
 .settings-segment-btn {
   height: 30px;
   padding: 0 12px;
   font-size: var(--f-sm);
   border: none;
-  background: var(--c-surface);
+  background: transparent;
   color: var(--c-text-secondary);
   cursor: pointer;
   transition: all 0.15s;
@@ -3467,6 +3665,44 @@ textarea:disabled {
 .settings-segment-btn:not(:last-child) { border-right: 1px solid var(--c-border); }
 .settings-segment-btn:hover:not(.active) { background: var(--c-surface-hover); }
 .settings-segment-btn.active { background: var(--c-primary); color: var(--c-on-accent); }
+
+@media (max-width: 560px) {
+  .settings-dialog {
+    width: calc(100vw - 16px);
+    height: calc(100dvh - 16px);
+    max-height: calc(100dvh - 16px);
+    padding: 16px;
+  }
+  .settings-layout { flex-direction: column; gap: 12px; }
+  .settings-nav {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+  .settings-nav-btn {
+    flex: 0 0 auto;
+    min-height: 36px;
+    padding: 8px 10px;
+  }
+  .settings-content { padding-right: 2px; }
+  .settings-grid { grid-template-columns: 1fr; }
+  .settings-field-switch {
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .settings-key-row {
+    align-items: flex-start;
+    gap: 6px;
+    flex-direction: column;
+  }
+  .settings-key-status { overflow-wrap: anywhere; }
+  .settings-dialog .dialog-actions {
+    justify-content: space-between;
+  }
+  .settings-dialog .dialog-btn { flex: 0 1 calc(50% - 4px); }
+}
 
 
 /* ── Attachments ── */
@@ -4234,6 +4470,27 @@ textarea:disabled {
 
   .model-select {
     max-width: 100px;
+  }
+
+  .model-dropdown {
+    position: static;
+  }
+
+  .model-dropdown-panel,
+  .agent-model-panel {
+    position: fixed;
+    left: 12px;
+    right: 12px;
+    top: auto;
+    bottom: calc(env(safe-area-inset-bottom) + 16px);
+    width: auto;
+    max-width: none;
+    max-height: min(70dvh, 520px);
+  }
+
+  .model-dropdown-list,
+  .agent-model-panel .model-tags {
+    max-height: min(48dvh, 360px);
   }
 
   .send-btn.stop {

--- a/client/src/components/ModelSelector.jsx
+++ b/client/src/components/ModelSelector.jsx
@@ -10,7 +10,7 @@ function filterModels(models, query) {
   );
 }
 
-// 浮层下拉的通用交互：点击外部关闭、ESC 关闭、打开时聚焦搜索框。
+// 浮层下拉的通用交互：点击外部关闭、ESC 关闭。
 // chat / agent 两种模型选择器共用这套逻辑。
 function useDropdown() {
   const [open, setOpen] = useState(false);
@@ -26,16 +26,12 @@ function useDropdown() {
     return () => document.removeEventListener('mousedown', onDocClick);
   }, [open]);
 
-  useEffect(() => {
-    if (open) inputRef.current?.focus();
-  }, [open]);
-
   return { open, setOpen, wrapRef, inputRef };
 }
 
 // chat 模式：可搜索的下拉。供应商接口可能返回上百个模型，原生 <select> 没法选，
 // 这里做成「点击展开 → 输入过滤 → 点选」的浮层。
-function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLocked }) {
+function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLocked, currentProvider }) {
   const t = useT();
   const { open, setOpen, wrapRef, inputRef } = useDropdown();
   const [query, setQuery] = useState('');
@@ -58,7 +54,14 @@ function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLo
         disabled={sessionLocked}
         title={t('modelSelector.switchModel')}
       >
-        <span className="model-dropdown-label">{selectedLabel}</span>
+        <span className="model-dropdown-main">
+          {currentProvider && (
+            <span className="model-dropdown-provider" title={t('modelSelector.providerTitle', { provider: currentProvider })}>
+              {currentProvider}
+            </span>
+          )}
+          <span className="model-dropdown-label">{selectedLabel}</span>
+        </span>
         <ChevronDown size={14} />
       </button>
       {open && (
@@ -105,6 +108,7 @@ function AgentModelDropdown({
   agentStrategy,
   setAgentStrategy,
   sessionLocked,
+  currentProvider,
 }) {
   const t = useT();
   const { open, setOpen, wrapRef, inputRef } = useDropdown();
@@ -144,9 +148,11 @@ function AgentModelDropdown({
   const visibleItems = [...selectedItems, ...filteredUnselected];
 
   const count = selectedAgentModels.length;
-  const triggerLabel = count > 0
-    ? t('modelSelector.selectedCount', { count })
-    : t('modelSelector.selectModels');
+  const triggerLabel = count === 1
+    ? (selectedItems[0]?.label || selectedAgentModels[0])
+    : count > 1
+      ? t('modelSelector.selectedCount', { count })
+      : t('modelSelector.selectModels');
 
   const renderTag = item => {
     const isSelected = selectedSet.has(item.id);
@@ -181,7 +187,14 @@ function AgentModelDropdown({
         disabled={sessionLocked}
         title={t('modelSelector.switchModel')}
       >
-        <span className="model-dropdown-label">{triggerLabel}</span>
+        <span className="model-dropdown-main">
+          {currentProvider && (
+            <span className="model-dropdown-provider" title={t('modelSelector.providerTitle', { provider: currentProvider })}>
+              {currentProvider}
+            </span>
+          )}
+          <span className="model-dropdown-label">{triggerLabel}</span>
+        </span>
         <ChevronDown size={14} />
       </button>
       {open && (
@@ -243,23 +256,17 @@ export function ModelSelector({
   sessionLocked,
   currentProvider,
 }) {
-  const t = useT();
-
   if (sessionStarted) return null;
-
-  const providerBadge = currentProvider
-    ? <span className="provider-badge" title={t('modelSelector.providerTitle', { provider: currentProvider })}>{currentProvider}</span>
-    : null;
 
   if (mode !== 'agent') {
     return (
       <div className="model-select-row">
-        {providerBadge}
         <ChatModelDropdown
           availableModels={availableModels}
           chatModel={chatModel}
           setChatModel={setChatModel}
           sessionLocked={sessionLocked}
+          currentProvider={currentProvider}
         />
       </div>
     );
@@ -267,7 +274,6 @@ export function ModelSelector({
 
   return (
     <div className="model-select-row">
-      {providerBadge}
       <AgentModelDropdown
         availableModels={availableModels}
         selectedAgentModels={selectedAgentModels}
@@ -275,6 +281,7 @@ export function ModelSelector({
         agentStrategy={agentStrategy}
         setAgentStrategy={setAgentStrategy}
         sessionLocked={sessionLocked}
+        currentProvider={currentProvider}
       />
     </div>
   );

--- a/client/src/components/dialogs/SettingsDialog.jsx
+++ b/client/src/components/dialogs/SettingsDialog.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Palette, SlidersHorizontal, Brain, KeyRound, X, Minus, Plus } from 'lucide-react';
 import { fetchConfig, saveConfig, resetConfig } from '../../api/config.js';
 import { useTheme } from '../../theme/ThemeProvider.jsx';
 import { useI18n, useT } from '../../i18n/I18nProvider.jsx';
@@ -15,6 +16,17 @@ const AGENT_FIELDS = [
   { key: 'maxParallelResultChars', labelKey: 'settings.maxParallelResultChars' },
 ];
 
+const NUMBER_FIELD_LIMITS = {
+  maxSteps: { min: 1, max: 512, step: 1 },
+  modelTimeoutSec: { min: 1, max: 3600, step: 5 },
+  staggerDelaySec: { min: 0, max: 120, step: 1 },
+  batchSize: { min: 1, max: 32, step: 1 },
+  maxHistorySteps: { min: 1, max: 200, step: 1 },
+  maxResultChars: { min: 100, max: 200000, step: 1000 },
+  maxParallelResultChars: { min: 100, max: 1000000, step: 1000 },
+  memoryMaxEntries: { min: 1, max: 1000, step: 1 },
+};
+
 const THEME_OPTIONS = [
   { value: 'light', labelKey: 'appearance.theme.light' },
   { value: 'dark', labelKey: 'appearance.theme.dark' },
@@ -23,10 +35,10 @@ const THEME_OPTIONS = [
 
 // 设置分组：左侧导航 → 右侧内容。
 const GROUPS = [
-  { id: 'appearance', labelKey: 'settings.group.appearance' },
-  { id: 'agent', labelKey: 'settings.group.agent' },
-  { id: 'memory', labelKey: 'settings.group.memory' },
-  { id: 'apiKeys', labelKey: 'settings.group.apiKeys' },
+  { id: 'appearance', labelKey: 'settings.group.appearance', Icon: Palette },
+  { id: 'agent', labelKey: 'settings.group.agent', Icon: SlidersHorizontal },
+  { id: 'memory', labelKey: 'settings.group.memory', Icon: Brain },
+  { id: 'apiKeys', labelKey: 'settings.group.apiKeys', Icon: KeyRound },
 ];
 
 // 设置面板：左导航分组 + 右内容。
@@ -62,6 +74,19 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
     setSaved(false);
   };
 
+  const clampNumberField = (key, value) => {
+    const limit = NUMBER_FIELD_LIMITS[key];
+    if (!limit) return value;
+    return Math.min(limit.max, Math.max(limit.min, value));
+  };
+
+  const stepNumberField = (key, direction) => {
+    const limit = NUMBER_FIELD_LIMITS[key];
+    const current = Number(agent[key]);
+    const base = Number.isFinite(current) ? current : limit.min;
+    setField(key, clampNumberField(key, base + direction * limit.step));
+  };
+
   const handleSave = async () => {
     setSaving(true);
     setError('');
@@ -90,16 +115,41 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
     }
   };
 
-  const numberField = (key, labelKey) => (
-    <label key={key} className="settings-field">
-      <span>{t(labelKey)}</span>
-      <input
-        type="number"
-        value={agent[key]}
-        onChange={e => setField(key, e.target.value === '' ? '' : Number(e.target.value))}
-      />
-    </label>
-  );
+  const numberField = (key, labelKey) => {
+    const limit = NUMBER_FIELD_LIMITS[key];
+    const value = Number(agent[key]);
+    const displayValue = Number.isFinite(value) ? value : limit.min;
+    return (
+      <div key={key} className="settings-field">
+        <span>{t(labelKey)}</span>
+        <div className="settings-stepper">
+          <button
+            type="button"
+            className="settings-stepper-btn"
+            onClick={() => stepNumberField(key, -1)}
+            disabled={displayValue <= limit.min}
+            aria-label={`${t(labelKey)} -`}
+            title={`${t(labelKey)} -`}
+          >
+            <Minus size={16} strokeWidth={2} />
+          </button>
+          <span className="settings-stepper-value">
+            {displayValue.toLocaleString(locale === 'zh' ? 'zh-CN' : 'en-US')}
+          </span>
+          <button
+            type="button"
+            className="settings-stepper-btn"
+            onClick={() => stepNumberField(key, 1)}
+            disabled={displayValue >= limit.max}
+            aria-label={`${t(labelKey)} +`}
+            title={`${t(labelKey)} +`}
+          >
+            <Plus size={16} strokeWidth={2} />
+          </button>
+        </div>
+      </div>
+    );
+  };
 
   // 需要后端配置的分组在未加载/加载失败时给出占位。
   const renderBackendGuard = () => {
@@ -211,8 +261,18 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
   const showSaveBar = activeGroup === 'agent' || activeGroup === 'memory' || activeGroup === 'apiKeys';
 
   return (
-    <div className="dialog-mask" onClick={onClose}>
+    <div className="dialog-mask settings-mask" onClick={onClose}>
       <div className="dialog settings-dialog" onClick={e => e.stopPropagation()}>
+        <button
+          type="button"
+          className="settings-close-btn"
+          onClick={onClose}
+          disabled={saving}
+          aria-label={t('common.close')}
+          title={t('common.close')}
+        >
+          <X size={18} strokeWidth={2} />
+        </button>
         <p className="dialog-title">{t('settings.title')}</p>
 
         <div className="settings-layout">
@@ -223,6 +283,7 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
                 className={`settings-nav-btn${activeGroup === g.id ? ' active' : ''}`}
                 onClick={() => setActiveGroup(g.id)}
               >
+                <g.Icon size={16} strokeWidth={2} className="settings-nav-icon" />
                 {t(g.labelKey)}
               </button>
             ))}
@@ -235,15 +296,12 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
           </div>
         </div>
 
-        <div className="dialog-actions">
-          <button className="dialog-btn cancel" onClick={onClose} disabled={saving}>{t('common.close')}</button>
-          {showSaveBar && (
-            <>
-              <button className="dialog-btn" onClick={handleReset} disabled={loading || saving || !agent}>{t('common.resetDefault')}</button>
-              <button className="dialog-btn primary" onClick={handleSave} disabled={loading || saving || !agent}>{t('common.save')}</button>
-            </>
-          )}
-        </div>
+        {showSaveBar && (
+          <div className="dialog-actions">
+            <button type="button" className="dialog-btn" onClick={handleReset} disabled={loading || saving || !agent}>{t('common.resetDefault')}</button>
+            <button type="button" className="dialog-btn primary" onClick={handleSave} disabled={loading || saving || !agent}>{t('common.save')}</button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- polish the settings dialog layout with mobile-friendly navigation, glass styling, icon tabs, top-right close, and stepper controls
- unify hero toolbar button styling and fold provider context into the model selector
- improve mobile behavior for viewport scaling and model selector popover sizing/focus

## Test
- npm run build