### PR TITLE
feat(ui): 模型下拉按供应商分组,供应商标签显示选中模型来源

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1707,6 +1707,22 @@ select,
   overflow-y: auto;
   padding: 4px;
 }
+.model-provider-group + .model-provider-group {
+  margin-top: 6px;
+}
+.model-provider-heading {
+  padding: 6px 8px 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--c-text-muted);
+}
+.model-provider-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
 
 .model-dropdown-option {
   display: flex;
@@ -1749,9 +1765,8 @@ select,
 
 .model-tags {
   display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  align-items: center;
+  flex-direction: column;
+  gap: 8px;
   max-height: 160px;
   overflow-y: auto;
 }
@@ -1760,6 +1775,8 @@ select,
   display: inline-flex;
   align-items: center;
   gap: 0;
+  max-width: 100%;
+  min-width: 0;
   border-radius: var(--r-sm);
 }
 
@@ -1770,6 +1787,9 @@ select,
 }
 
 .model-tag {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
   height: 30px;
   padding: 0 10px;
   border-radius: var(--r-sm);
@@ -1781,6 +1801,11 @@ select,
   outline: none;
   transition: all 0.15s;
   white-space: nowrap;
+}
+.model-tag-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .model-tag:hover {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -236,11 +236,6 @@ export default function App() {
   const selectedChatModelLabel = availableModels.find(item => item.id === chatModel)?.label || chatModel;
   const sessionLocked = streaming || agentRunning;
 
-  // 当前供应商：取当前选中模型的 provider 字段（agent 模式看首个选中模型，否则看 chatModel）。
-  // provider 来自后端 /api/models，已反映真实 baseURL 推断出的供应商名。
-  const activeModelId = mode === 'agent' && selectedAgentModels.length > 0 ? selectedAgentModels[0] : chatModel;
-  const currentProvider = availableModels.find(item => item.id === activeModelId)?.provider || null;
-
   // 在移动端/窄屏时，会话侧栏和 Agent 面板会改变页面主色块区域。
   // 同步 <meta name="theme-color"> 是为了让浏览器地址栏颜色也跟着切换。
   const { resolvedTheme } = useTheme();
@@ -800,7 +795,6 @@ export default function App() {
       agentStrategy={agentStrategy}
       setAgentStrategy={setAgentStrategy}
       sessionLocked={sessionLocked}
-      currentProvider={currentProvider}
     />
   );
   const sendButton = (

--- a/client/src/components/ModelSelector.jsx
+++ b/client/src/components/ModelSelector.jsx
@@ -6,7 +6,37 @@ function filterModels(models, query) {
   const q = query.trim().toLowerCase();
   if (!q) return models;
   return models.filter(m =>
-    m.id.toLowerCase().includes(q) || (m.label && m.label.toLowerCase().includes(q))
+    m.id.toLowerCase().includes(q)
+      || (m.label && m.label.toLowerCase().includes(q))
+      || (m.provider && m.provider.toLowerCase().includes(q))
+  );
+}
+
+function providerOf(model) {
+  return model?.provider || 'unknown';
+}
+
+function groupByProvider(models) {
+  const groups = [];
+  const byName = new Map();
+  for (const model of models) {
+    const provider = providerOf(model);
+    if (!byName.has(provider)) {
+      const group = { provider, models: [] };
+      byName.set(provider, group);
+      groups.push(group);
+    }
+    byName.get(provider).models.push(model);
+  }
+  return groups;
+}
+
+function ProviderPill({ provider }) {
+  if (!provider) return null;
+  return (
+    <span className="model-dropdown-provider" title={provider}>
+      {provider}
+    </span>
   );
 }
 
@@ -31,7 +61,7 @@ function useDropdown() {
 
 // chat 模式：可搜索的下拉。供应商接口可能返回上百个模型，原生 <select> 没法选，
 // 这里做成「点击展开 → 输入过滤 → 点选」的浮层。
-function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLocked, currentProvider }) {
+function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLocked }) {
   const t = useT();
   const { open, setOpen, wrapRef, inputRef } = useDropdown();
   const [query, setQuery] = useState('');
@@ -39,6 +69,7 @@ function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLo
   const selected = availableModels.find(m => m.id === chatModel);
   const selectedLabel = selected?.label || chatModel || t('modelSelector.selectModel');
   const filtered = useMemo(() => filterModels(availableModels, query), [availableModels, query]);
+  const grouped = useMemo(() => groupByProvider(filtered), [filtered]);
 
   const openPanel = () => {
     setQuery('');
@@ -55,11 +86,7 @@ function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLo
         title={t('modelSelector.switchModel')}
       >
         <span className="model-dropdown-main">
-          {currentProvider && (
-            <span className="model-dropdown-provider" title={t('modelSelector.providerTitle', { provider: currentProvider })}>
-              {currentProvider}
-            </span>
-          )}
+          <ProviderPill provider={selected?.provider} />
           <span className="model-dropdown-label">{selectedLabel}</span>
         </span>
         <ChevronDown size={14} />
@@ -79,17 +106,22 @@ function ChatModelDropdown({ availableModels, chatModel, setChatModel, sessionLo
           </div>
           <div className="model-dropdown-list">
             {filtered.length === 0 && <div className="model-dropdown-empty">{t('modelSelector.noMatch')}</div>}
-            {filtered.map(item => (
-              <button
-                type="button"
-                key={item.id}
-                className={`model-dropdown-option ${item.id === chatModel ? 'selected' : ''}`}
-                onClick={() => { setChatModel(item.id); setOpen(false); }}
-                title={item.id}
-              >
-                <span className="model-dropdown-option-label">{item.label}</span>
-                {item.id === chatModel && <Check size={13} />}
-              </button>
+            {grouped.map(group => (
+              <div key={group.provider} className="model-provider-group">
+                <div className="model-provider-heading">{group.provider}</div>
+                {group.models.map(item => (
+                  <button
+                    type="button"
+                    key={item.id}
+                    className={`model-dropdown-option ${item.id === chatModel ? 'selected' : ''}`}
+                    onClick={() => { setChatModel(item.id); setOpen(false); }}
+                    title={item.id}
+                  >
+                    <span className="model-dropdown-option-label">{item.label}</span>
+                    {item.id === chatModel && <Check size={13} />}
+                  </button>
+                ))}
+              </div>
             ))}
           </div>
         </div>
@@ -108,7 +140,6 @@ function AgentModelDropdown({
   agentStrategy,
   setAgentStrategy,
   sessionLocked,
-  currentProvider,
 }) {
   const t = useT();
   const { open, setOpen, wrapRef, inputRef } = useDropdown();
@@ -136,18 +167,24 @@ function AgentModelDropdown({
   };
 
   // 已选模型始终置顶且不受搜索影响，避免选中后被过滤掉看不到。
-  const q = query.trim().toLowerCase();
   const selectedSet = new Set(selectedAgentModels);
   const selectedItems = selectedAgentModels
     .map(id => availableModels.find(m => m.id === id))
     .filter(Boolean);
   const unselectedItems = availableModels.filter(m => !selectedSet.has(m.id));
-  const filteredUnselected = q
-    ? unselectedItems.filter(m => m.id.toLowerCase().includes(q) || (m.label && m.label.toLowerCase().includes(q)))
-    : unselectedItems;
+  const filteredUnselected = filterModels(unselectedItems, query);
   const visibleItems = [...selectedItems, ...filteredUnselected];
+  // visibleItems 每次渲染都是新数组,手动 useMemo 反而被 React Compiler 拒绝优化;
+  // 这里直接调用,交给编译器自动 memo(与 ChatModelDropdown 不同——那边依赖的是已 memo 的 filtered)。
+  const grouped = groupByProvider(visibleItems);
 
   const count = selectedAgentModels.length;
+  const selectedProviders = [...new Set(selectedItems.map(providerOf))];
+  const triggerProvider = count === 0
+    ? null
+    : selectedProviders.length === 1
+      ? selectedProviders[0]
+      : t('modelSelector.providerCount', { count: selectedProviders.length });
   const triggerLabel = count === 1
     ? (selectedItems[0]?.label || selectedAgentModels[0])
     : count > 1
@@ -165,7 +202,7 @@ function AgentModelDropdown({
           disabled={sessionLocked}
           title={isSelected ? t('modelSelector.deselect') : t('modelSelector.selectConcurrent')}
         >
-          {item.label}
+          <span className="model-tag-label">{item.label}</span>
         </button>
         {isSelected && selectedAgentModels.length > 1 && (
           <span className="model-tag-order">
@@ -188,11 +225,7 @@ function AgentModelDropdown({
         title={t('modelSelector.switchModel')}
       >
         <span className="model-dropdown-main">
-          {currentProvider && (
-            <span className="model-dropdown-provider" title={t('modelSelector.providerTitle', { provider: currentProvider })}>
-              {currentProvider}
-            </span>
-          )}
+          <ProviderPill provider={triggerProvider} />
           <span className="model-dropdown-label">{triggerLabel}</span>
         </span>
         <ChevronDown size={14} />
@@ -213,7 +246,14 @@ function AgentModelDropdown({
           </div>
           <div className="model-tags">
             {visibleItems.length === 0 && <span className="model-tags-empty">{t('modelSelector.noMatch')}</span>}
-            {visibleItems.map(renderTag)}
+            {grouped.map(group => (
+              <div key={group.provider} className="model-provider-group">
+                <div className="model-provider-heading">{group.provider}</div>
+                <div className="model-provider-tags">
+                  {group.models.map(renderTag)}
+                </div>
+              </div>
+            ))}
           </div>
           {selectedAgentModels.length > 1 && (
             <div className="strategy-toggle">
@@ -254,7 +294,6 @@ export function ModelSelector({
   agentStrategy,
   setAgentStrategy,
   sessionLocked,
-  currentProvider,
 }) {
   if (sessionStarted) return null;
 
@@ -266,7 +305,6 @@ export function ModelSelector({
           chatModel={chatModel}
           setChatModel={setChatModel}
           sessionLocked={sessionLocked}
-          currentProvider={currentProvider}
         />
       </div>
     );
@@ -281,7 +319,6 @@ export function ModelSelector({
         agentStrategy={agentStrategy}
         setAgentStrategy={setAgentStrategy}
         sessionLocked={sessionLocked}
-        currentProvider={currentProvider}
       />
     </div>
   );

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -305,6 +305,7 @@ export const en = {
   'modelSelector.selectModel': 'Select model',
   'modelSelector.selectModels': 'Select models',
   'modelSelector.selectedCount': '{count} models selected',
+  'modelSelector.providerCount': '{count} providers',
   'modelSelector.switchModel': 'Switch model',
   'modelSelector.searchPlaceholder': 'Search models…',
   'modelSelector.noMatch': 'No matching models',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -306,6 +306,7 @@ export const zh = {
   'modelSelector.selectModel': '选择模型',
   'modelSelector.selectModels': '选择模型',
   'modelSelector.selectedCount': '已选 {count} 个模型',
+  'modelSelector.providerCount': '{count} 个供应商',
   'modelSelector.switchModel': '切换模型',
   'modelSelector.searchPlaceholder': '搜索模型…',
   'modelSelector.noMatch': '无匹配模型',


### PR DESCRIPTION
## 改动

模型选择器(chat / agent 两种下拉)的供应商展示与分组优化。

### 列表分组
- `ChatModelDropdown` 与 `AgentModelDropdown` 的模型列表均**按 provider 分组**,每组带分组标题。
- 供应商接口可能返回上百个模型,分组后更易定位。

### 触发器供应商标签
- 触发按钮上的供应商标签改为显示**当前选中模型自身的 provider**:
  - chat 模式:选中模型的 provider。
  - agent 模式:单一供应商时显示其名;多供应商时显示「N 个供应商 / N providers」。
- 不再依赖 `App.jsx` 计算并透传的全局 `currentProvider`,该冗余逻辑与 prop 一并移除。

### 搜索
- 过滤支持匹配 **provider 名**(原来只匹配 id / label)。

### 样式 & 文案
- `.model-tags` 改纵向布局,标签文本溢出省略(`model-tag-label`),窄屏不再被挤变形。
- 新增分组标题样式 `.model-provider-*`。
- 新增 i18n 文案 `modelSelector.providerCount`(zh / en)。

## 验证
- `npm run lint`:0 error(仅剩一条与本次无关的既有 `abortRef` warning)。
- `npm run build`:通过。