### PR TITLE
fix(ui): agent 模型/策略按项目存储,切项目不再串用

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -27,7 +27,7 @@ import { HeroScreen } from './components/HeroScreen.jsx';
 import { useAgentRun } from './hooks/useAgentRun.js';
 import { createSession, getSessionTitle, normalizeChatState, touchSession, useChatSessions } from './hooks/useChatSessions.js';
 import { useProjects } from './hooks/useProjects.js';
-import { booleanStorage, jsonStorage, usePersistentState } from './hooks/usePersistentState.js';
+import { booleanStorage, usePersistentState, useProjectScopedState } from './hooks/usePersistentState.js';
 import { useResponsiveLayout } from './hooks/useResponsiveLayout.js';
 import { useThemeColorSync } from './hooks/useThemeColorSync.js';
 import { useTheme } from './theme/ThemeProvider.jsx';
@@ -51,6 +51,9 @@ import {
 import { formatMsgTime } from './utils/format.js';
 import { shuffled } from './utils/random.js';
 import { hasThinkContent } from './utils/markdown.js';
+
+// 稳定的空数组:作为 useProjectScopedState 的 initialValue,scope 缺省时返回同一引用,避免无谓重渲染。
+const EMPTY_AGENT_MODELS = [];
 
 // 把已上传的附件拼到任务文本中。
 // 单独成段 [附件] 块,让 LLM 容易识别;对图片显式提示 image_analyze 工具,
@@ -170,9 +173,9 @@ export default function App() {
     dockedBreakpoint: DOCKED_LAYOUT_BREAKPOINT,
     panelSizeKey: PANEL_SIZE_KEY,
   });
-  // Agent 的模型集合、策略、headless、memory 目前是“应用级偏好”，
-  // 不跟随 chat session 存储；chat session 只保存单模型对话所用的 model。
-  const [selectedAgentModels, setSelectedAgentModels] = usePersistentState('agent_models', [], jsonStorage);
+  // Agent 的多模型选择与策略「按项目」存储:useProjectScopedState 内部按 activeProjectId 分桶,
+  // 切项目时派生值自动跟着变。chat 单模型走 session(本身已按项目过滤);memory 仍是应用级偏好。
+  const [selectedAgentModels, setSelectedAgentModels] = useProjectScopedState('agent_models_by_project', activeProjectId, EMPTY_AGENT_MODELS);
   // Filter out models no longer available
   useEffect(() => {
     if (!modelsLoaded) {
@@ -188,7 +191,33 @@ export default function App() {
       }
     }
   }, [availableModels, modelsLoaded, selectedAgentModels, setSelectedAgentModels]);
-  const [agentStrategy, setAgentStrategy] = usePersistentState('agent_strategy', 'race');
+  const [agentStrategy, setAgentStrategy] = useProjectScopedState('agent_strategy_by_project', activeProjectId, 'race');
+
+  // 一次性迁移:历史版本 agent 模型/策略是全局存储(所有项目共用一份),现改为按项目存。
+  // 等项目就绪(projectsLoading=false,此时 activeProjectId 已是后端真实值)后跑一次,
+  // 把旧的全局选择迁移到「当前项目」名下,再删旧 key;其余项目从空开始。
+  const agentPrefsMigratedRef = useRef(false);
+  useEffect(() => {
+    if (projectsLoading || agentPrefsMigratedRef.current) return;
+    agentPrefsMigratedRef.current = true;
+    try {
+      const legacy = localStorage.getItem('agent_models');
+      if (legacy != null) {
+        const parsed = JSON.parse(legacy);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          setSelectedAgentModels(prev => (prev.length ? prev : parsed));
+        }
+        localStorage.removeItem('agent_models');
+      }
+    } catch { /* 忽略损坏的旧数据 */ }
+    try {
+      const legacy = localStorage.getItem('agent_strategy');
+      if (legacy != null) {
+        setAgentStrategy(prev => (prev && prev !== 'race' ? prev : legacy));
+        localStorage.removeItem('agent_strategy');
+      }
+    } catch { /* 忽略损坏的旧数据 */ }
+  }, [projectsLoading, setSelectedAgentModels, setAgentStrategy]);
 
   // 桌面通知权限：default = 未询问，granted = 已开，denied = 用户拒绝过。
   // SW 在 App 挂载时静默注册，权限请求必须由用户点击触发。

--- a/client/src/hooks/usePersistentState.js
+++ b/client/src/hooks/usePersistentState.js
@@ -50,3 +50,24 @@ export function usePersistentState(
 
   return [value, setPersistentValue];
 }
+
+const PROJECT_GLOBAL_SCOPE = '__global__';
+const EMPTY_SCOPE_MAP = {};
+
+// 按项目分桶的持久化状态:整份 { [projectId]: value } 存在单个 localStorage key 里,
+// 当前值在渲染时按 projectId 派生。activeProjectId 变化时(activateProject 原地更新、
+// App 不重挂载)派生值自动跟着切——这正好绕开 usePersistentState「只在挂载时读一次」的限制。
+// initialValue 建议传模块级常量,scope 缺省时返回它,保证引用稳定。
+export function useProjectScopedState(baseKey, projectId, initialValue) {
+  const [map, setMap] = usePersistentState(baseKey, EMPTY_SCOPE_MAP, jsonStorage);
+  const scope = projectId == null ? PROJECT_GLOBAL_SCOPE : projectId;
+  const value = scope in map ? map[scope] : resolveInitialValue(initialValue);
+  const setScopedValue = useCallback(updater => {
+    setMap(previousMap => {
+      const current = scope in previousMap ? previousMap[scope] : resolveInitialValue(initialValue);
+      const nextValue = typeof updater === 'function' ? updater(current) : updater;
+      return { ...previousMap, [scope]: nextValue };
+    });
+  }, [scope, setMap, initialValue]);
+  return [value, setScopedValue];
+}


### PR DESCRIPTION
## 问题

在项目 A 里选了两个模型(agent 多模型),切到项目 B(之前只用一个)后,B 里显示的还是 A 的两个模型——模型选择没有跟着项目走。

## 根因

- `selectedAgentModels`(agent 多模型)和 `agentStrategy`(race/vote 策略)存在**全局 localStorage key**(`agent_models` / `agent_strategy`),与项目无关。
- `usePersistentState` 只在挂载时读一次 localStorage;`activateProject` 是原地状态更新、App 不重挂载,所以切项目不会重读。
- 对比:chat 单模型 `chatModel` 来自 `activeSession.model`,session 带 `projectId` 并按项目过滤 → 本来就跟着项目走,不受影响。

## 改动

- **新增 `useProjectScopedState`**(`hooks/usePersistentState.js`):整份 `{ [projectId]: value }` 存在单个 key 里,当前值在渲染时按 `activeProjectId` 派生。切项目时派生值自动跟着变,天然支持原地切换。
- **`App.jsx`**:`selectedAgentModels` / `agentStrategy` 改用按项目存储(新 key `agent_models_by_project` / `agent_strategy_by_project`,避免与旧键类型冲突)。
- **一次性迁移**:等项目就绪后,把旧的全局选择迁移到「**当前激活项目**」名下,再删除旧 key;其余项目从空开始。幂等(`ref` 守卫 + 非默认值不覆盖)。

> 范围:仅多模型 + 策略按项目隔离;`mode`(chat/agent)、`agentMemory`(记忆开关)维持应用级偏好。

## 验证

- `npm run lint`:0 error(仅剩一条与本次无关的既有 `abortRef` warning)。
- `npm run build`:通过。
- 逐路径代码走查:切项目派生、迁移时机(`projectsLoading` 翻 false 时 `activeProjectId` 已就绪)、setter 引用稳定性均确认无误。
- 建议合并前手动回归:A 选 2 模型 → 切 B(空)→ 切回 A(仍是 2)→ 刷新仍按项目保留;升级后旧全局选择落到当前项目、旧 key 被清除。