### PR TITLE
feat(agent): 沙箱化 agent worker —— 每次运行在独立 sandbox-exec 进程内执行

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When the Agent needs your approval, sagent shows a browser desktop notification 
 
 ## Security: Sandbox Policy
 
-When started with `npm run sandbox`, the Agent runs inside the macOS sandbox, with permissions controlled by `sandbox.sb`.
+When started with `npm run sandbox`, the UI/API server stays outside the macOS sandbox and each Agent run starts a short-lived worker inside `sandbox-exec`, with permissions controlled by `sandbox.sb` and `PROJECT_DIR` set to that run's project root.
 
 You can customize `sandbox.sb` to adjust the Agent's permission boundary. Modifying the file may cause some Agent functions to lose permission (e.g., unable to access the network, unable to open the browser, etc.).
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -25,7 +25,7 @@ Agent 等待审批时，sagent 会通过浏览器桌面通知提醒你，并提�
 
 ## 安全：沙盒策略
 
-通过 `npm run sandbox` 启动时，Agent 在 macOS 沙盒内运行，权限由 `sandbox.sb` 文件控制。
+通过 `npm run sandbox` 启动时，UI/API server 常驻在沙盒外，每次 Agent run 会启动一个短生命周期 worker，并用 `sandbox-exec` 将该 worker 限制在当前 run 的项目根目录内；权限由 `sandbox.sb` 文件控制。
 
 你可以自定义 `sandbox.sb` 来调整 Agent 的权限边界。修改该文件可能导致 Agent 部分功能无权限执行（如无法访问网络、无法打开浏览器等）。
 

--- a/agent/core/approval-store.ts
+++ b/agent/core/approval-store.ts
@@ -26,10 +26,14 @@ export function createApprovalStore() {
      * 创建审批请求并返回阻塞 Promise
      *
      * @param {Object} payload - 审批上下文（step, action 等）
+     * @param {string} requestedApprovalId - worker bridge 已发给前端的审批 ID
      * @returns {{ approvalId: string, promise: Promise<string> }}
      */
-    request(payload = {}) {
-      const approvalId = createApprovalId();
+    request(payload = {}, requestedApprovalId?: string) {
+      const approvalId = requestedApprovalId || createApprovalId();
+      if (pending.has(approvalId)) {
+        throw new Error(`审批已存在: ${approvalId}`);
+      }
       let settled = false;
       let resolvePromise;
 

--- a/agent/core/checkpoint.ts
+++ b/agent/core/checkpoint.ts
@@ -127,7 +127,7 @@ function sanitizeState(state: any) {
   delete safe.onEvent;
   delete safe.browserSession;
   delete safe.observeDesktop;
-  safe.browserSessionActive = Boolean(state.browserSession);
+  safe.browserSessionActive = Boolean(state.browserSession) || Boolean(state.browserSessionActive);
   return safe;
 }
 

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -93,6 +93,18 @@ function shouldRollback(runRecord) {
   return runRecord?.pendingRollback != null;
 }
 
+function sanitizeStateForSnapshot(state) {
+  if (!state) return null;
+  const safe = { ...state };
+  delete safe.chromium;
+  delete safe.browserCandidatePaths;
+  delete safe.onEvent;
+  delete safe.browserSession;
+  delete safe.observeDesktop;
+  safe.browserSessionActive = Boolean(state.browserSession) || Boolean(state.browserSessionActive);
+  return safe;
+}
+
 export async function runAgentRuntime({
   task,
   maxSteps = 8,
@@ -108,6 +120,7 @@ export async function runAgentRuntime({
   initialStep = 1,
   initialHistory = [],
   onCheckpoint = null,
+  saveSessionSnapshot = null,
   // v2: 会话检查点 & 手动回滚
   sessionCheckpointDir = null,
   runRecord = null,
@@ -285,11 +298,12 @@ export async function runAgentRuntime({
           runId,
           step,
           history: history.map(h => ({ ...h })),
-          state: { ...state },
+          state: saveSessionSnapshot ? sanitizeStateForSnapshot(state) : { ...state },
           result,
           usage: decision.usage,
         };
-        saveHealthySnapshot(snapData).catch(err => {
+        const saveSnapshot = saveSessionSnapshot || saveHealthySnapshot;
+        Promise.resolve(saveSnapshot(snapData)).catch(err => {
           log.error(`[Runtime] 健康快照保存失败: ${err.message}`);
         });
         onEvent?.({

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -257,6 +257,7 @@ export function createDesktopAgentRunner({
     memory = true,
     projectRoot = null,
     dataDir = null,
+    checkpointWriter = null,
   }) {
     const { maxSteps, modelTimeoutMs, staggerDelayMs, batchSize, observeDesktop } = liveConfig();
     const blacklistedModels = new Set();
@@ -282,13 +283,19 @@ export function createDesktopAgentRunner({
       sessionCheckpointDir: runCheckpointDir,
       runRecord,
       onCheckpoint: runCheckpointDir
-        ? (history, step) => saveCheckpoint(runCheckpointDir, {
-            runId, task, model, systemPrompt, headless,
-            history, step, maxSteps, startedAt,
-            agentModels, strategy, conversationHistory, memory,
-            projectRoot, dataDir,
-          })
+        ? (history, step) => {
+            const checkpoint = {
+              runId, task, model, systemPrompt, headless,
+              history, step, maxSteps, startedAt,
+              agentModels, strategy, conversationHistory, memory,
+              projectRoot, dataDir,
+            };
+            return checkpointWriter?.saveCheckpoint
+              ? checkpointWriter.saveCheckpoint(checkpoint)
+              : saveCheckpoint(runCheckpointDir, checkpoint);
+          }
         : null,
+      saveSessionSnapshot: checkpointWriter?.saveHealthySnapshot,
       initialize: async () => ({
         runId,
         onEvent,

--- a/agent/worker/agent-worker.ts
+++ b/agent/worker/agent-worker.ts
@@ -1,0 +1,172 @@
+const protocolWrite = process.stdout.write.bind(process.stdout);
+console.log = (...args) => console.error(...args);
+console.debug = (...args) => console.error(...args);
+
+function writeProtocol(message: any) {
+  protocolWrite(`${JSON.stringify(message)}\n`);
+}
+
+function writeProtocolAndWait(message: any) {
+  return new Promise<void>(resolve => {
+    protocolWrite(`${JSON.stringify(message)}\n`, () => resolve());
+  });
+}
+
+function createApprovalId() {
+  return `worker_approval_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createWorkerApprovalStore() {
+  const pending = new Map<string, (decision: string) => void>();
+  return {
+    request(payload = {}) {
+      const approvalId = createApprovalId();
+      let settled = false;
+      const promise = new Promise<string>(resolve => {
+        pending.set(approvalId, decision => {
+          if (settled) return;
+          settled = true;
+          pending.delete(approvalId);
+          resolve(decision);
+        });
+      });
+      writeProtocol({ type: 'approval_request', approvalId, payload });
+      return { approvalId, promise };
+    },
+    resolve(approvalId: string, decision: string) {
+      const resolve = pending.get(approvalId);
+      if (!resolve) return;
+      resolve(decision);
+    },
+    rejectAll() {
+      for (const [approvalId, resolve] of pending.entries()) {
+        pending.delete(approvalId);
+        resolve('reject');
+      }
+    },
+  };
+}
+
+function serializeError(err: any) {
+  return {
+    type: 'error',
+    error: err?.message || String(err),
+    stack: err?.stack,
+  };
+}
+
+async function main() {
+  await import('dotenv/config');
+  const { createInterface } = await import('node:readline');
+  const rl = createInterface({ input: process.stdin });
+
+  let runRecord: any = null;
+  const cancelAc = new AbortController();
+  const approvalStore = createWorkerApprovalStore();
+
+  const startMessage: any = await new Promise(resolve => {
+    const onLine = (line: string) => {
+      if (!line.trim()) return;
+      const message = JSON.parse(line);
+      if (message.type !== 'start') return;
+      rl.off('line', onLine);
+      resolve(message);
+    };
+    rl.on('line', onLine);
+  });
+
+  rl.on('line', line => {
+    if (!line.trim()) return;
+    let message: any;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (message.type === 'approval_response') {
+      approvalStore.resolve(message.approvalId, message.decision);
+      return;
+    }
+    if (message.type === 'cancel') {
+      cancelAc.abort();
+      approvalStore.rejectAll();
+      return;
+    }
+    if (message.type === 'rollback' && runRecord) {
+      runRecord.pendingRollback = message.targetStep;
+    }
+  });
+
+  const payload = startMessage.payload || {};
+  runRecord = { runId: payload.runId, pendingRollback: null };
+
+  const { createClients } = await import('../core/ai-client.ts');
+  const { createProviderRegistry } = await import('../core/providers/registry.ts');
+  const { createDesktopAgentRunner } = await import('../desktop/agent.ts');
+  const { initLlmLogger } = await import('../core/llm-logger.ts');
+  const { runtimeConfig } = await import('../core/runtime-config.ts');
+  const { DEFAULT_VISION_MODEL } = await import('../tools/vision/execute.ts');
+
+  const memoryDir = payload.memoryDir || process.env.MEMORY_DIR || 'data';
+  await runtimeConfig.init(memoryDir);
+  initLlmLogger(memoryDir);
+
+  const { openai_client, anthropic_client, gemini_client } = createClients();
+  const registry = createProviderRegistry({ openai_client, anthropic_client, gemini_client });
+  const modelConfig = Array.isArray(payload.modelConfig) ? payload.modelConfig : [];
+  const cfg = runtimeConfig.get();
+  const runDesktopAgent = createDesktopAgentRunner({
+    registry,
+    openai_client,
+    modelConfig,
+    maxSteps: cfg.maxSteps,
+    defaultHeadless: payload.headless === true,
+    observeDesktop: cfg.observeDesktop,
+    modelTimeoutMs: cfg.modelTimeoutSec * 1000,
+    staggerDelayMs: cfg.staggerDelaySec * 1000,
+    batchSize: cfg.batchSize,
+    runStore: null,
+    approvalStore,
+    checkpointDir: payload.checkpointDir || memoryDir,
+    visionModel: payload.visionModel || process.env.VISION_MODEL || DEFAULT_VISION_MODEL,
+  });
+
+  const checkpointWriter = {
+    saveCheckpoint(data: any) {
+      writeProtocol({ type: 'checkpoint', data });
+    },
+    saveHealthySnapshot(data: any) {
+      writeProtocol({ type: 'session_checkpoint_snapshot', data });
+    },
+  };
+
+  const result = await runDesktopAgent({
+    task: payload.task,
+    model: payload.model,
+    models: Array.isArray(payload.models) ? payload.models : [],
+    strategy: payload.strategy || 'race',
+    systemPrompt: payload.systemPrompt || '',
+    headless: payload.headless === true,
+    runId: payload.runId,
+    runRecord,
+    startedAt: payload.startedAt,
+    initialStep: payload.initialStep || 1,
+    initialHistory: Array.isArray(payload.initialHistory) ? payload.initialHistory : [],
+    conversationHistory: Array.isArray(payload.conversationHistory) ? payload.conversationHistory : [],
+    memory: payload.memory !== false,
+    onEvent: (event: any) => writeProtocol({ type: 'event', payload: event }),
+    cancelSignal: cancelAc.signal,
+    projectRoot: payload.projectRoot || null,
+    dataDir: payload.dataDir || null,
+    checkpointWriter,
+  });
+
+  await writeProtocolAndWait({ type: 'result', result });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(async err => {
+    await writeProtocolAndWait(serializeError(err)).catch(() => {});
+    process.exit(1);
+  });

--- a/agent/worker/runner.ts
+++ b/agent/worker/runner.ts
@@ -1,0 +1,271 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { saveCheckpoint, saveHealthySnapshot } from '../core/checkpoint.ts';
+import { log } from '../../helpers/logger.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+function resolveBunCommand(env: Record<string, string | undefined> = process.env) {
+  if (env.BUN_BIN) return env.BUN_BIN;
+  if (path.basename(process.execPath).includes('bun')) return process.execPath;
+  return 'bun';
+}
+
+export function buildWorkerCommand({
+  sandbox,
+  projectRoot,
+  sandboxFile = path.join(REPO_ROOT, 'sandbox.sb'),
+  workerFile = path.join(REPO_ROOT, 'agent/worker/agent-worker.ts'),
+  bunCommand = resolveBunCommand(),
+  env = process.env,
+}: {
+  sandbox: boolean;
+  projectRoot: string;
+  sandboxFile?: string;
+  workerFile?: string;
+  bunCommand?: string;
+  env?: Record<string, string | undefined>;
+}) {
+  if (!sandbox) {
+    return { command: bunCommand, args: [workerFile] };
+  }
+  return {
+    command: env.SANDBOX_EXEC || 'sandbox-exec',
+    args: [
+      '-f',
+      sandboxFile,
+      '-D',
+      `HOME=${env.HOME || ''}`,
+      '-D',
+      `PROJECT_DIR=${projectRoot}`,
+      bunCommand,
+      workerFile,
+    ],
+  };
+}
+
+function writeWorkerMessage(child: any, message: any) {
+  if (!child.stdin?.writable) return;
+  try {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  } catch {
+    // Worker may have exited between a UI action and the bridge write.
+  }
+}
+
+function errorFromWorker(message: any) {
+  const err = new Error(message?.error || 'Agent worker failed') as any;
+  if (message?.stack) err.stack = message.stack;
+  return err;
+}
+
+function tail(text: string, max = 3000) {
+  if (!text) return '';
+  return text.length > max ? text.slice(text.length - max) : text;
+}
+
+function createWorkerLogStream(baseDir: string, runId: string) {
+  try {
+    const dir = path.join(baseDir, 'worker-logs');
+    fs.mkdirSync(dir, { recursive: true });
+    return fs.createWriteStream(path.join(dir, `${runId}.log`), { flags: 'a' });
+  } catch {
+    return null;
+  }
+}
+
+export function createSandboxedWorkerAgentRunner({
+  memoryDir,
+  checkpointDir,
+  modelConfig,
+  approvalStore,
+  visionModel,
+  sandbox = true,
+  sandboxFile = path.join(REPO_ROOT, 'sandbox.sb'),
+  workerFile = path.join(REPO_ROOT, 'agent/worker/agent-worker.ts'),
+}: {
+  memoryDir: string;
+  checkpointDir: string;
+  modelConfig: any[];
+  approvalStore: any;
+  visionModel: string;
+  sandbox?: boolean;
+  sandboxFile?: string;
+  workerFile?: string;
+}) {
+  async function runWorkerAgent(opts: any) {
+    const runId = opts.runId;
+    const dataDir = opts.dataDir || checkpointDir || memoryDir;
+    const projectRoot = path.resolve(opts.projectRoot || process.cwd());
+    const { command, args } = buildWorkerCommand({
+      sandbox,
+      projectRoot,
+      sandboxFile,
+      workerFile,
+    });
+
+    const workerLog = createWorkerLogStream(dataDir, runId);
+    const child = spawn(command, args, {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        NO_COLOR: '1',
+        SAGENT_WORKER: '1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const pendingPersistence: Promise<any>[] = [];
+    let stdoutBuffer = '';
+    let stderrText = '';
+    let settled = false;
+    let cancelTimer: NodeJS.Timeout | null = null;
+
+    const persist = (promise: Promise<any>) => {
+      pendingPersistence.push(promise.catch(err => {
+        log.warn(`[Worker] persistence failed runId=${runId}: ${err?.message || err}`);
+      }));
+    };
+
+    const finish = async (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      await Promise.allSettled(pendingPersistence);
+      fn();
+    };
+
+    const handleMessage = (message: any) => {
+      if (!message || typeof message !== 'object') return;
+      if (message.type === 'event') {
+        if (message.payload?.type === 'rollback' && opts.runRecord) {
+          opts.runRecord.pendingRollback = null;
+          opts.runRecord.rolledBack = true;
+        }
+        opts.onEvent?.(message.payload);
+        return;
+      }
+      if (message.type === 'checkpoint') {
+        persist(saveCheckpoint(dataDir, message.data));
+        return;
+      }
+      if (message.type === 'session_checkpoint_snapshot') {
+        persist(saveHealthySnapshot({ ...message.data, dir: dataDir }));
+        return;
+      }
+      if (message.type === 'approval_request') {
+        try {
+          const { approvalId, promise } = approvalStore.request(message.payload || {}, message.approvalId);
+          promise.then((decision: string) => {
+            writeWorkerMessage(child, { type: 'approval_response', approvalId, decision });
+          });
+        } catch (err: any) {
+          log.warn(`[Worker] approval bridge failed runId=${runId}: ${err?.message || err}`);
+          writeWorkerMessage(child, { type: 'approval_response', approvalId: message.approvalId, decision: 'reject' });
+        }
+        return;
+      }
+      if (message.type === 'result') {
+        finish(() => resolveRun(message.result));
+        return;
+      }
+      if (message.type === 'error') {
+        finish(() => rejectRun(errorFromWorker(message)));
+      }
+    };
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutBuffer += chunk.toString();
+      let idx: number;
+      while ((idx = stdoutBuffer.indexOf('\n')) !== -1) {
+        const raw = stdoutBuffer.slice(0, idx).trim();
+        stdoutBuffer = stdoutBuffer.slice(idx + 1);
+        if (!raw) continue;
+        try {
+          handleMessage(JSON.parse(raw));
+        } catch {
+          workerLog?.write(`[stdout] ${raw}\n`);
+        }
+      }
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderrText += text;
+      stderrText = tail(stderrText, 6000);
+      workerLog?.write(text);
+    });
+
+    let resolveRun: (value: any) => void = () => {};
+    let rejectRun: (err: any) => void = () => {};
+    const runPromise = new Promise((resolve, reject) => {
+      resolveRun = resolve;
+      rejectRun = reject;
+    });
+
+    const abortHandler = () => {
+      writeWorkerMessage(child, { type: 'cancel' });
+      cancelTimer = setTimeout(() => {
+        if (!child.killed) child.kill('SIGTERM');
+      }, Number(process.env.AGENT_WORKER_CANCEL_GRACE_MS || 3000));
+    };
+    opts.cancelSignal?.addEventListener?.('abort', abortHandler, { once: true });
+
+    if (opts.runRecord) {
+      opts.runRecord.workerControl = {
+        cancel: abortHandler,
+        rollback: (targetStep: number) => {
+          writeWorkerMessage(child, { type: 'rollback', targetStep });
+        },
+      };
+    }
+
+    child.on('error', err => {
+      finish(() => rejectRun(err));
+    });
+
+    child.on('close', (code, signal) => {
+      if (cancelTimer) clearTimeout(cancelTimer);
+      opts.cancelSignal?.removeEventListener?.('abort', abortHandler);
+      if (opts.runRecord?.workerControl) {
+        opts.runRecord.workerControl = null;
+      }
+      workerLog?.end();
+      if (!settled) {
+        const suffix = stderrText ? `\n${tail(stderrText)}` : '';
+        finish(() => rejectRun(new Error(`Agent worker exited before result (code=${code}, signal=${signal || 'none'})${suffix}`)));
+      }
+    });
+
+    log.info(`[Worker] spawn runId=${runId} sandbox=${sandbox} projectRoot=${projectRoot}`);
+    writeWorkerMessage(child, {
+      type: 'start',
+      payload: {
+        task: opts.task,
+        model: opts.model,
+        models: opts.models,
+        strategy: opts.strategy,
+        systemPrompt: opts.systemPrompt,
+        headless: opts.headless,
+        runId,
+        startedAt: opts.startedAt,
+        initialStep: opts.initialStep,
+        initialHistory: opts.initialHistory,
+        conversationHistory: opts.conversationHistory,
+        memory: opts.memory,
+        projectRoot,
+        dataDir,
+        memoryDir,
+        checkpointDir: dataDir,
+        modelConfig,
+        visionModel,
+      },
+    });
+
+    return runPromise;
+  }
+
+  return runWorkerAgent;
+}

--- a/agent/worker/runner.ts
+++ b/agent/worker/runner.ts
@@ -7,6 +7,8 @@ import { log } from '../../helpers/logger.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../..');
+const DEFAULT_CANCEL_GRACE_MS = 3000;
+const DEFAULT_CANCEL_KILL_GRACE_MS = 2000;
 
 function resolveBunCommand(env: Record<string, string | undefined> = process.env) {
   if (env.BUN_BIN) return env.BUN_BIN;
@@ -77,6 +79,18 @@ function createWorkerLogStream(baseDir: string, runId: string) {
   }
 }
 
+function envMs(env: Record<string, string | undefined>, name: string, fallback: number) {
+  const value = Number(env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+export function getWorkerCancelDelays(env: Record<string, string | undefined> = process.env) {
+  return {
+    terminateAfterMs: envMs(env, 'AGENT_WORKER_CANCEL_GRACE_MS', DEFAULT_CANCEL_GRACE_MS),
+    killAfterMs: envMs(env, 'AGENT_WORKER_CANCEL_KILL_GRACE_MS', DEFAULT_CANCEL_KILL_GRACE_MS),
+  };
+}
+
 export function createSandboxedWorkerAgentRunner({
   memoryDir,
   checkpointDir,
@@ -122,7 +136,10 @@ export function createSandboxedWorkerAgentRunner({
     let stdoutBuffer = '';
     let stderrText = '';
     let settled = false;
-    let cancelTimer: NodeJS.Timeout | null = null;
+    let childClosed = false;
+    let cancelRequested = false;
+    let terminateTimer: NodeJS.Timeout | null = null;
+    let killTimer: NodeJS.Timeout | null = null;
 
     const persist = (promise: Promise<any>) => {
       pendingPersistence.push(promise.catch(err => {
@@ -206,10 +223,16 @@ export function createSandboxedWorkerAgentRunner({
     });
 
     const abortHandler = () => {
+      if (cancelRequested) return;
+      cancelRequested = true;
       writeWorkerMessage(child, { type: 'cancel' });
-      cancelTimer = setTimeout(() => {
-        if (!child.killed) child.kill('SIGTERM');
-      }, Number(process.env.AGENT_WORKER_CANCEL_GRACE_MS || 3000));
+      const { terminateAfterMs, killAfterMs } = getWorkerCancelDelays();
+      terminateTimer = setTimeout(() => {
+        if (!childClosed) child.kill('SIGTERM');
+        killTimer = setTimeout(() => {
+          if (!childClosed) child.kill('SIGKILL');
+        }, killAfterMs);
+      }, terminateAfterMs);
     };
     opts.cancelSignal?.addEventListener?.('abort', abortHandler, { once: true });
 
@@ -227,7 +250,9 @@ export function createSandboxedWorkerAgentRunner({
     });
 
     child.on('close', (code, signal) => {
-      if (cancelTimer) clearTimeout(cancelTimer);
+      childClosed = true;
+      if (terminateTimer) clearTimeout(terminateTimer);
+      if (killTimer) clearTimeout(killTimer);
       opts.cancelSignal?.removeEventListener?.('abort', abortHandler);
       if (opts.runRecord?.workerControl) {
         opts.runRecord.workerControl = null;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -912,45 +912,6 @@ select,
   background: var(--c-bg, rgba(127, 127, 127, 0.1));
 }
 
-/* ── 项目对话框字段 ─────────────────────────── */
-.project-field-label {
-  display: block;
-  margin: 12px 0 4px;
-  font-size: var(--f-sm);
-  font-weight: 600;
-  color: var(--c-text);
-}
-
-.project-field-input {
-  width: 100%;
-  height: 34px;
-  padding: 0 10px;
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-sm);
-  background: var(--c-surface);
-  color: var(--c-text);
-  font-size: var(--f-sm);
-  box-sizing: border-box;
-}
-
-.project-field-input:focus {
-  outline: none;
-  border-color: var(--c-primary);
-}
-
-.project-field-hint {
-  margin: 6px 0 0;
-  font-size: var(--f-xs, 12px);
-  color: var(--c-text-soft, var(--c-text));
-  opacity: 0.7;
-}
-
-.project-field-error {
-  margin: 8px 0 0;
-  font-size: var(--f-sm);
-  color: var(--c-danger, #e5484d);
-}
-
 .page-create-btn,
 .header-new-session-btn {
   height: 30px;
@@ -3607,6 +3568,59 @@ textarea:disabled {
   justify-content: space-between;
 }
 
+.project-dialog {
+  width: min(520px, 94vw);
+  height: auto;
+  min-height: 0;
+}
+
+.project-dialog .dialog-title {
+  padding-right: 40px;
+}
+
+.project-dialog-content {
+  overflow: visible;
+}
+
+.project-dialog .settings-section {
+  margin-bottom: 0;
+}
+
+.project-form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.project-field-input {
+  width: 100%;
+  height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-sm);
+  background: var(--c-settings-glass-inner);
+  color: var(--c-text);
+  font-size: var(--f-sm);
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+
+.project-field-input:focus {
+  border-color: var(--c-primary);
+  background: var(--c-surface-hover);
+  box-shadow: 0 0 0 3px var(--c-primary-bg);
+}
+
+.project-field-hint {
+  margin: 10px 0 0;
+}
+
+.project-dialog .dialog-actions {
+  justify-content: flex-end;
+}
+
 .settings-section { margin-bottom: 20px; }
 .settings-section-title { font-size: var(--f-sm); font-weight: 600; margin-bottom: 4px; }
 
@@ -3727,6 +3741,17 @@ textarea:disabled {
     justify-content: space-between;
   }
   .settings-dialog .dialog-btn { flex: 0 1 calc(50% - 4px); }
+  .project-dialog {
+    width: calc(100vw - 16px);
+    height: auto;
+    max-height: calc(100dvh - 16px);
+  }
+  .project-dialog .dialog-actions {
+    justify-content: flex-end;
+  }
+  .project-dialog .dialog-btn {
+    flex: 0 1 auto;
+  }
 }
 
 

--- a/client/src/components/dialogs/ProjectDialog.jsx
+++ b/client/src/components/dialogs/ProjectDialog.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { X } from 'lucide-react';
 import { useT } from '../../i18n/I18nProvider.jsx';
 
 // 新建/编辑项目对话框。project 传入则为编辑模式。
@@ -9,7 +10,12 @@ export function ProjectDialog({ project, onSubmit, onCancel }) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
-  const handleSubmit = async () => {
+  const handleCancel = () => {
+    if (!submitting) onCancel();
+  };
+
+  const handleSubmit = async (event) => {
+    event?.preventDefault?.();
     if (submitting) return;
     setSubmitting(true);
     setError('');
@@ -22,45 +28,66 @@ export function ProjectDialog({ project, onSubmit, onCancel }) {
   };
 
   return (
-    <div className="dialog-mask">
-      <div className="dialog">
+    <div className="dialog-mask settings-mask" onClick={handleCancel}>
+      <form className="dialog settings-dialog project-dialog" onClick={e => e.stopPropagation()} onSubmit={handleSubmit}>
+        <button
+          type="button"
+          className="settings-close-btn"
+          onClick={handleCancel}
+          disabled={submitting}
+          aria-label={t('common.close')}
+          title={t('common.close')}
+        >
+          <X size={18} strokeWidth={2} />
+        </button>
         <p className="dialog-title">{project ? t('project.dialogEditTitle') : t('project.dialogNewTitle')}</p>
 
-        <label className="project-field-label">{t('project.nameLabel')}</label>
-        <input
-          className="project-field-input"
-          type="text"
-          value={name}
-          placeholder={t('project.namePlaceholder')}
-          onChange={e => setName(e.target.value)}
-          autoFocus
-        />
+        <div className="settings-content project-dialog-content">
+          <div className="settings-section">
+            <p className="settings-section-title">{t('project.label')}</p>
+            <div className="project-form-grid">
+              <label className="settings-field project-field">
+                <span>{t('project.nameLabel')}</span>
+                <input
+                  className="project-field-input"
+                  type="text"
+                  value={name}
+                  placeholder={t('project.namePlaceholder')}
+                  onChange={e => setName(e.target.value)}
+                  autoFocus
+                />
+              </label>
 
-        <label className="project-field-label">{t('project.rootLabel')}</label>
-        <input
-          className="project-field-input"
-          type="text"
-          value={rootPath}
-          placeholder={t('project.rootPlaceholder')}
-          onChange={e => setRootPath(e.target.value)}
-        />
-        <p className="project-field-hint">{t('project.rootHint')}</p>
+              <label className="settings-field project-field">
+                <span>{t('project.rootLabel')}</span>
+                <input
+                  className="project-field-input"
+                  type="text"
+                  value={rootPath}
+                  placeholder={t('project.rootPlaceholder')}
+                  onChange={e => setRootPath(e.target.value)}
+                />
+              </label>
+            </div>
+            <p className="dialog-desc project-field-hint">{t('project.rootHint')}</p>
 
-        {error ? <p className="project-field-error">{error}</p> : null}
+            {error ? <p className="settings-error">{error}</p> : null}
+          </div>
+        </div>
 
         <div className="dialog-actions">
-          <button className="dialog-btn cancel" onClick={onCancel} disabled={submitting}>
+          <button type="button" className="dialog-btn cancel" onClick={handleCancel} disabled={submitting}>
             {t('common.cancel')}
           </button>
           <button
-            className="dialog-btn confirm"
-            onClick={handleSubmit}
+            type="submit"
+            className="dialog-btn primary"
             disabled={submitting || !name.trim() || !rootPath.trim()}
           >
             {submitting ? t('common.submitting') : t('common.save')}
           </button>
         </div>
-      </div>
+      </form>
     </div>
   );
 }

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -203,7 +203,7 @@ export const en = {
   'project.none': 'No project (global)',
   'project.noneShort': 'No project',
   'project.switcherTitle': 'Switch project',
-  'project.new': '+ New project',
+  'project.new': 'New project',
   'project.edit': 'Edit',
   'project.delete': 'Delete',
   'project.deleteConfirm': 'Delete project "{name}"? Only removed from the list; disk data is kept.',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -204,7 +204,7 @@ export const zh = {
   'project.none': '无项目（全局）',
   'project.noneShort': '无项目',
   'project.switcherTitle': '切换项目',
-  'project.new': '+ 新建项目',
+  'project.new': '新建项目',
   'project.edit': '编辑',
   'project.delete': '删除',
   'project.deleteConfirm': '确定删除项目「{name}」？仅从列表移除，磁盘数据保留。',

--- a/helpers/run-store.ts
+++ b/helpers/run-store.ts
@@ -66,6 +66,14 @@ export function createAgentRunStore() {
       return null;
     },
 
+    getActiveRuns() {
+      return Array.from(runs.values()).filter(run => run.status === 'running' && !run.cancelAc.signal.aborted);
+    },
+
+    getRunningRuns() {
+      return Array.from(runs.values()).filter(run => run.status === 'running');
+    },
+
     /**
      * 追加 SSE 事件到运行记录
      * 调用时机：每次 sendEvent 都会同时 addEvent，用于 SSE 重连时回放

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently \"bun server.ts\" \"cd client && npm run dev\"",
-    "sandbox": "concurrently \"sandbox-exec -f sandbox.sb -D HOME=$HOME -D PROJECT_DIR=$(pwd) $(which bun) server.ts\" \"cd client && npm run dev\"",
+    "sandbox": "concurrently \"AGENT_SANDBOXED_WORKERS=true bun server.ts\" \"cd client && npm run dev\"",
     "chrome:mcp": "node scripts/chrome-mcp-sse-server.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build:client": "cd client && npm run build",

--- a/routes/agent-checkpoints.ts
+++ b/routes/agent-checkpoints.ts
@@ -46,6 +46,7 @@ export function createAgentCheckpointRouter({ checkpointDir, agentRunStore, memo
       return res.status(409).json({ error: tReq(req, 'checkpoint.rollbackInProgress') });
     }
     activeRun.pendingRollback = targetStep;
+    activeRun.workerControl?.rollback?.(targetStep);
     log.info(`[API] 设置回滚请求: runId=${activeRun.runId} targetStep=${targetStep}`);
     return res.json({ ok: true, runId: activeRun.runId, targetStep });
   });

--- a/server.ts
+++ b/server.ts
@@ -36,7 +36,7 @@ import { createAgentRunStore } from './helpers/run-store.ts';
 import { createApprovalStore } from './agent/core/approval-store.ts';
 import { initLlmLogger } from './agent/core/llm-logger.ts';
 import { createDesktopAgentRunner } from './agent/desktop/agent.ts';
-import { createSandboxedWorkerAgentRunner } from './agent/worker/runner.ts';
+import { createSandboxedWorkerAgentRunner, getWorkerCancelDelays } from './agent/worker/runner.ts';
 import { DEFAULT_VISION_MODEL } from './agent/tools/vision/execute.ts';
 import { createClients, loadAgentMultiModels, deriveProviderName } from './agent/core/ai-client.ts';
 import { createProviderRegistry } from './agent/core/providers/registry.ts';
@@ -127,6 +127,17 @@ app.use(createSuggestionsRouter({ store: createSuggestionStore(path.join(__dirna
 
 const PORT = process.env.PORT || 3001;
 const HOST = process.env.HOST || '0.0.0.0';
+const SIGNAL_EXIT_CODES: Record<string, number> = { SIGINT: 130, SIGTERM: 143 };
+
+function envMs(name: string, fallback: number) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function defaultShutdownGraceMs() {
+  const { terminateAfterMs, killAfterMs } = getWorkerCancelDelays();
+  return terminateAfterMs + killAfterMs + 1000;
+}
 
 async function resumeFromCheckpoint(cp) {
   const { runId, task, model, headless, history, step, maxSteps: _maxSteps, startedAt } = cp;
@@ -150,6 +161,7 @@ async function resumeFromCheckpoint(cp) {
   sendEvent({ type: 'status', status: 'resuming', runId, message: `从断点恢复：从第 ${step + 1} 步继续执行任务「${task.slice(0, 60)}」` });
 
   try {
+    const runRecord = agentRunStore.getRun(runId);
     const result = await runDesktopAgent({
       task,
       model,
@@ -158,14 +170,14 @@ async function resumeFromCheckpoint(cp) {
       systemPrompt,
       headless,
       runId,
-      runRecord: agentRunStore.getRun(runId),
+      runRecord,
       startedAt,
       initialStep: step + 1,
       initialHistory: history,
       conversationHistory: cp.conversationHistory || [],
       memory: cp.memory !== false,
       onEvent: sendEventWithTrace,
-      cancelSignal: new AbortController().signal,
+      cancelSignal: runRecord?.cancelAc?.signal || new AbortController().signal,
       projectRoot,
       dataDir,
     });
@@ -198,7 +210,7 @@ async function collectAllCheckpoints() {
   return all;
 }
 
-app.listen(Number(PORT), HOST, async () => {
+const httpServer = app.listen(Number(PORT), HOST, async () => {
   const cfg = runtimeConfig.get();
   const multiModels = loadAgentMultiModels();
   const ideConfig = loadIdeMcpConfig();
@@ -278,3 +290,43 @@ app.listen(Number(PORT), HOST, async () => {
     }
   }
 });
+
+let shuttingDown = false;
+function shutdown(signal: string) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  const activeRuns = agentRunStore.getRunningRuns();
+  const activeRunIds = activeRuns.map((run: any) => run.runId);
+  log.warn(`[Shutdown] 收到 ${signal}，关闭 HTTP server，取消 ${activeRuns.length} 个 active run${activeRunIds.length ? `: ${activeRunIds.join(', ')}` : ''}`);
+
+  httpServer.close(err => {
+    if (err) log.warn(`[Shutdown] HTTP server close failed: ${err.message}`);
+  });
+
+  for (const run of activeRuns) {
+    agentRunStore.cancelRun(run.runId);
+    run.workerControl?.cancel?.();
+  }
+  approvalStore.rejectAll();
+
+  const graceMs = envMs('AGENT_SERVER_SHUTDOWN_GRACE_MS', defaultShutdownGraceMs());
+  const startedAt = Date.now();
+  const exitCode = SIGNAL_EXIT_CODES[signal] || 0;
+  const interval = setInterval(() => {
+    const remainingRuns = agentRunStore.getRunningRuns();
+    if (remainingRuns.length === 0) {
+      clearInterval(interval);
+      log.warn('[Shutdown] active runs 已结束，退出');
+      process.exit(0);
+    }
+    if (Date.now() - startedAt >= graceMs) {
+      clearInterval(interval);
+      log.warn(`[Shutdown] 等待 ${graceMs}ms 后仍有 ${remainingRuns.length} 个 active run，退出进程`);
+      process.exit(exitCode);
+    }
+  }, 100);
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/server.ts
+++ b/server.ts
@@ -36,6 +36,7 @@ import { createAgentRunStore } from './helpers/run-store.ts';
 import { createApprovalStore } from './agent/core/approval-store.ts';
 import { initLlmLogger } from './agent/core/llm-logger.ts';
 import { createDesktopAgentRunner } from './agent/desktop/agent.ts';
+import { createSandboxedWorkerAgentRunner } from './agent/worker/runner.ts';
 import { DEFAULT_VISION_MODEL } from './agent/tools/vision/execute.ts';
 import { createClients, loadAgentMultiModels, deriveProviderName } from './agent/core/ai-client.ts';
 import { createProviderRegistry } from './agent/core/providers/registry.ts';
@@ -85,9 +86,11 @@ await projectStore.init();
 
 const AGENT_MAX_STEPS = Number(process.env.AGENT_MAX_STEPS || 8);
 const VISION_MODEL = (process.env.VISION_MODEL || DEFAULT_VISION_MODEL).trim();
+const AGENT_SANDBOXED_WORKERS = process.env.AGENT_SANDBOXED_WORKERS === 'true';
+const AGENT_WORKER_SANDBOX = process.env.AGENT_WORKER_SANDBOX !== 'false';
 const agentRunStore = createAgentRunStore();
 const approvalStore = createApprovalStore();
-const runDesktopAgent = createDesktopAgentRunner({
+const directRunDesktopAgent = createDesktopAgentRunner({
   registry,
   openai_client,
   modelConfig,
@@ -102,6 +105,17 @@ const runDesktopAgent = createDesktopAgentRunner({
   checkpointDir: CHECKPOINT_DIR,
   visionModel: VISION_MODEL,
 });
+const runDesktopAgent = AGENT_SANDBOXED_WORKERS
+  ? createSandboxedWorkerAgentRunner({
+      memoryDir: MEMORY_DIR,
+      checkpointDir: CHECKPOINT_DIR,
+      modelConfig,
+      approvalStore,
+      visionModel: VISION_MODEL,
+      sandbox: AGENT_WORKER_SANDBOX,
+    }) as any
+  : directRunDesktopAgent;
+runDesktopAgent.domainRules = directRunDesktopAgent.domainRules;
 
 const SCREENSHOT_DIR = path.join(MEMORY_DIR, 'screenshots');
 app.use('/screenshots', express.static(SCREENSHOT_DIR));
@@ -212,6 +226,7 @@ app.listen(Number(PORT), HOST, async () => {
   ${row('AGENT_HEADLESS', process.env.AGENT_HEADLESS || false)}
   ${row('AGENT_OBSERVE_DESKTOP', cfg.observeDesktop)}
   ${row('AGENT_RESUME', AGENT_RESUME)}
+  ${row('AGENT_WORKERS', AGENT_SANDBOXED_WORKERS ? (AGENT_WORKER_SANDBOX ? 'sandboxed' : 'plain') : 'disabled')}
   ${row('CHROME_PATH', process.env.AGENT_BROWSER_PATH || 'auto')}
   ${ideConfig.enabled ? row('IDE_MCP', `${ideConfig.transport} @ ${ideConfig.transport === 'stdio' ? ideConfig.command : (ideConfig.url || `${ideConfig.host}:${ideConfig.port}${ideConfig.ssePath}`)}`) : row('IDE_MCP', 'disabled')}
   ${ideConfig.enabled ? row('IDE_PROJECT_PATH', ideConfig.projectPath) : ''}

--- a/test/approval-store.test.ts
+++ b/test/approval-store.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { createApprovalStore } from '../agent/core/approval-store.ts';
+
+describe('approval store', () => {
+  it('can register a caller-provided approval id for worker bridges', async () => {
+    const store = createApprovalStore();
+    const { approvalId, promise } = store.request({ step: 1 }, 'worker_approval_1');
+
+    expect(approvalId).toBe('worker_approval_1');
+    store.resolve('worker_approval_1', 'approve');
+    await expect(promise).resolves.toBe('approve');
+  });
+
+  it('rejects duplicate caller-provided approval ids', () => {
+    const store = createApprovalStore();
+    store.request({}, 'worker_approval_dup');
+
+    expect(() => store.request({}, 'worker_approval_dup')).toThrow('审批已存在');
+  });
+});

--- a/test/run-store.test.ts
+++ b/test/run-store.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { createAgentRunStore } from '../helpers/run-store.ts';
+
+describe('agent run store', () => {
+  it('lists only active non-cancelled runs', () => {
+    const store = createAgentRunStore();
+    const runA = store.createRun({}, 1, 'run_a');
+    const runB = store.createRun({}, 2, 'run_b');
+    const runC = store.createRun({}, 3, 'run_c');
+
+    store.cancelRun(runB.runId);
+    store.closeRun(runC.runId);
+
+    expect(store.getActiveRuns().map((run: any) => run.runId)).toEqual([runA.runId]);
+    expect(store.getActiveRun()?.runId).toBe(runA.runId);
+    expect(store.getRunningRuns().map((run: any) => run.runId)).toEqual([runA.runId, runB.runId]);
+  });
+});

--- a/test/session-checkpoint.test.ts
+++ b/test/session-checkpoint.test.ts
@@ -200,6 +200,40 @@ describe('runtime: session checkpoint integration', () => {
     expect(cp.history.length).toBeGreaterThanOrEqual(5);
   });
 
+  it('delegates session snapshot persistence to a callback with serializable state', async () => {
+    const runId = 'run_rt_worker_snapshot';
+    const cancelSignal = new AbortController().signal;
+    const snapshots: any[] = [];
+
+    await runAgentRuntime({
+      task: 'test',
+      maxSteps: 1,
+      onEvent: noop,
+      cancelSignal,
+      sessionCheckpointDir: tmpDir,
+      runRecord: { runId, pendingRollback: null },
+      saveSessionSnapshot: snapshot => snapshots.push(snapshot),
+      initialize: () => ({
+        runId,
+        onEvent: noop,
+        browserSession: { view: { circular: true } },
+        observeDesktop: true,
+        keep: 'ok',
+      }),
+      observe: noop,
+      decide: () => ({ action: { type: 'finish', answer: 'done' }, rationale: 'ok' }),
+      authorize: noop,
+      execute: () => 'done',
+      cleanup: noop,
+    });
+
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0].state.browserSession).toBeUndefined();
+    expect(snapshots[0].state.observeDesktop).toBeUndefined();
+    expect(snapshots[0].state.browserSessionActive).toBe(true);
+    expect(snapshots[0].state.keep).toBe('ok');
+  });
+
   it('manual rollback restores snapshot history and continues', { timeout: 15000 }, async () => {
     const runId = 'run_rt3';
     const cancelSignal = new AbortController().signal;

--- a/test/worker-runner.test.ts
+++ b/test/worker-runner.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildWorkerCommand } from '../agent/worker/runner.ts';
+
+describe('worker runner command', () => {
+  it('wraps the worker with sandbox-exec and the run project root', () => {
+    const cmd = buildWorkerCommand({
+      sandbox: true,
+      projectRoot: '/tmp/project-a',
+      sandboxFile: '/repo/sandbox.sb',
+      workerFile: '/repo/agent/worker/agent-worker.ts',
+      bunCommand: '/usr/local/bin/bun',
+      env: { HOME: '/Users/test' },
+    });
+
+    expect(cmd.command).toBe('sandbox-exec');
+    expect(cmd.args).toEqual([
+      '-f',
+      '/repo/sandbox.sb',
+      '-D',
+      'HOME=/Users/test',
+      '-D',
+      'PROJECT_DIR=/tmp/project-a',
+      '/usr/local/bin/bun',
+      '/repo/agent/worker/agent-worker.ts',
+    ]);
+  });
+
+  it('can run a plain worker without sandbox wrapping', () => {
+    const cmd = buildWorkerCommand({
+      sandbox: false,
+      projectRoot: '/tmp/project-a',
+      workerFile: '/repo/agent/worker/agent-worker.ts',
+      bunCommand: '/usr/local/bin/bun',
+    });
+
+    expect(cmd).toEqual({
+      command: '/usr/local/bin/bun',
+      args: ['/repo/agent/worker/agent-worker.ts'],
+    });
+  });
+});

--- a/test/worker-runner.test.ts
+++ b/test/worker-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildWorkerCommand } from '../agent/worker/runner.ts';
+import { buildWorkerCommand, getWorkerCancelDelays } from '../agent/worker/runner.ts';
 
 describe('worker runner command', () => {
   it('wraps the worker with sandbox-exec and the run project root', () => {
@@ -36,6 +36,35 @@ describe('worker runner command', () => {
     expect(cmd).toEqual({
       command: '/usr/local/bin/bun',
       args: ['/repo/agent/worker/agent-worker.ts'],
+    });
+  });
+});
+
+describe('worker runner cancellation delays', () => {
+  it('uses the default SIGTERM and SIGKILL grace periods', () => {
+    expect(getWorkerCancelDelays({})).toEqual({
+      terminateAfterMs: 3000,
+      killAfterMs: 2000,
+    });
+  });
+
+  it('allows both cancellation grace periods to be configured', () => {
+    expect(getWorkerCancelDelays({
+      AGENT_WORKER_CANCEL_GRACE_MS: '25',
+      AGENT_WORKER_CANCEL_KILL_GRACE_MS: '50',
+    })).toEqual({
+      terminateAfterMs: 25,
+      killAfterMs: 50,
+    });
+  });
+
+  it('falls back for invalid cancellation delay values', () => {
+    expect(getWorkerCancelDelays({
+      AGENT_WORKER_CANCEL_GRACE_MS: '-1',
+      AGENT_WORKER_CANCEL_KILL_GRACE_MS: 'bad',
+    })).toEqual({
+      terminateAfterMs: 3000,
+      killAfterMs: 2000,
     });
   });
 });


### PR DESCRIPTION
## 背景

以前 `npm run sandbox` 把整个 UI/API server 放进 macOS `sandbox-exec` 中，且 `PROJECT_DIR` 固定为启动目录。这次改为 server 留在沙箱外，每次 agent 运行临时拉起一个独立 worker 子进程，并让该 worker 在 `sandbox-exec` 内以当前项目根作为 `PROJECT_DIR` 执行，从而把沙箱边界收紧到单次运行和单个项目。

## 改动

- 新增 `agent/worker/runner.ts`：父进程侧 worker runner，负责 spawn worker、start/event/result/error 协议、审批桥接、checkpoint/健康快照转发、cancel/rollback 控制，以及 worker 日志落盘。
- 新增 `agent/worker/agent-worker.ts`：沙箱内 worker 入口，初始化 clients/registry/runtimeConfig，用转发式 `checkpointWriter` 执行 desktop agent，并把结果回传给父进程。
- `server.ts` 支持 `AGENT_SANDBOXED_WORKERS` / `AGENT_WORKER_SANDBOX` 开关，在直连执行和沙箱 worker runner 间切换，并在启动横幅中显示 worker 模式。
- 补齐 worker 生命周期清理：server shutdown 时清理活跃 sandboxed workers，运行记录删除时同步取消关联 worker，避免残留子进程。
- `agent/desktop/agent.ts`、`agent/core/runtime.ts`、`routes/agent-checkpoints.ts` 打通 checkpoint、健康快照、rollback、resume 在跨进程 worker 模式下的转发链路。
- `agent/core/approval-store.ts` 支持 worker 传入已分配的 `approvalId`，用于父进程 approval store 和 worker 请求之间的稳定映射。
- `package.json` 的 `sandbox` 脚本改为启用 `AGENT_SANDBOXED_WORKERS=true`。
- README / README_ZH 更新 sandboxed workers 的运行说明。
- 项目对话框 UI 跟随 settings dialog 样式：支持遮罩点击/关闭按钮、表单 submit、错误展示样式统一，并移除“新建项目”文案里的手写加号。
- 测试覆盖 worker 命令构建、approvalId 桥接、session checkpoint 快照委托、run-store worker 清理等关键路径。

## 验证

- `npm run lint` 通过。
- `npm run build:client` 通过。
- `npm run typecheck` 通过。
- `npm test` 通过：18 个 test files，123 个 tests。

## 注意

- 尚未加入真实 worker 进程 spawn + IPC + `sandbox-exec` 的端到端集成测试；目前主要覆盖纯函数和关键状态桥接。
- 真实端到端冒烟仍依赖 API key、网络以及 macOS 实机上的 `sandbox-exec` 行为验证。
