### PR TITLE
Add file info action and planner retry

### DIFF
--- a/agent/core/action-types.ts
+++ b/agent/core/action-types.ts
@@ -27,6 +27,7 @@ export const ACTION_TYPE_TO_TOOL = {
   image_analyze: 'vision',
   // fs
   list_dir: 'fs',
+  get_file_info: 'fs',
   read_file: 'fs',
   write_file: 'fs',
   search_files: 'fs',

--- a/agent/core/planner.ts
+++ b/agent/core/planner.ts
@@ -24,9 +24,9 @@ export function createJsonPlanner({
   maxTokens = 16000,
   buildMessages,
   normalizeDecision,
-  buildParserError,
+  buildParserError = null,
 }) {
-  return async ({ model, signal, ...context }) => {
+  return async ({ model, signal = null, ...context }) => {
     const messages = buildMessages(context);
 
     logLlmRequest(model, messages);
@@ -63,57 +63,47 @@ export function createJsonPlanner({
     const parsed = parser(response);
 
     if (!parsed.parseFailed) {
-      const result = normalizeDecision(parsed, context);
-      return { ...result, usage: parsed.usage, reasoning: parsed.reasoning || null };
+      try {
+        const result = normalizeDecision(parsed, context);
+        return { ...result, usage: parsed.usage, reasoning: parsed.reasoning || null };
+      } catch (normalizeErr: any) {
+        log.warn(`[Planner] 动作校验失败，重试: ${normalizeErr.message}`);
+        const retryResult = await retryWithHint({
+          client,
+          model,
+          parser,
+          messages,
+          content: parsed.rawContent,
+          usage: parsed.usage,
+          context,
+          createOpts: { temperature, top_p: topP, max_tokens: maxTokens },
+          reqOpts,
+          normalizeDecision,
+          hint: `你的上一次 JSON 动作无法执行：${normalizeErr.message}。请只使用系统提示中列出的工具和动作名，不要编造工具/动作名。输出一个新的有效 JSON 动作。`,
+        });
+        if (retryResult) return retryResult;
+        throw normalizeErr;
+      }
     }
 
     // Parse failed — retry with hint
     const content = parsed.rawContent;
     log.warn(`[Planner] 输出无法解析，重试: ${cleanText(content, 120)}`);
 
-    const retryMessages = [...messages, {
-      role: 'assistant',
+    const retryResult = await retryWithHint({
+      client,
+      model,
+      parser,
+      messages,
       content,
-    }, {
-      role: 'user',
-      content: '你的上一次输出不是有效的 JSON 动作。请只输出一个 JSON 对象，格式如 {"rationale":"...","action":{"tool":"...","type":"...",...}} 或 {"type":"finish","answer":"..."}。不要输出任何解释文字。',
-    }];
-
-    try {
-      const retryOpts = {
-        model,
-        temperature,
-        top_p: topP,
-        max_tokens: maxTokens,
-        messages: retryMessages,
-      };
-
-      const retryContext = {
-        operation: 'desktop.plan',
-        phase: 'parser-retry',
-        provider: 'openai-compatible',
-        model,
-        step: context.step,
-        message_count: retryMessages.length,
-        max_tokens: maxTokens,
-      };
-      const retryResponse = await retryAsync(() => client.chat.completions.create(retryOpts, reqOpts), undefined, retryContext, { retryRateLimit: false });
-      const retryParsed = parser(retryResponse);
-
-      if (!retryParsed.parseFailed) {
-        const result = normalizeDecision(retryParsed, context);
-        return { ...result, usage: retryParsed.usage || parsed.usage, reasoning: retryParsed.reasoning || null };
-      }
-    } catch (retryErr) {
-      logLlmError(model, retryErr, {
-        operation: 'desktop.plan',
-        phase: 'parser-retry',
-        provider: 'openai-compatible',
-        model,
-        step: context.step,
-      });
-      log.warn(`[Planner] 重试也失败: ${retryErr.message}`);
-    }
+      usage: parsed.usage,
+      context,
+      createOpts: { temperature, top_p: topP, max_tokens: maxTokens },
+      reqOpts,
+      normalizeDecision,
+      hint: '你的上一次输出不是有效的 JSON 动作。请只输出一个 JSON 对象，格式如 {"rationale":"...","action":{"tool":"...","type":"...",...}} 或 {"type":"finish","answer":"..."}。不要输出任何解释文字。',
+    });
+    if (retryResult) return retryResult;
 
     const msg =
       typeof buildParserError === 'function'
@@ -121,4 +111,62 @@ export function createJsonPlanner({
         : '模型动作解析失败';
     throw new Error(`${msg}; 原始输出=${safeJson(cleanText(content, 10240))}`);
   };
+}
+
+async function retryWithHint({
+  client,
+  model,
+  parser,
+  messages,
+  content,
+  usage,
+  context,
+  createOpts,
+  reqOpts,
+  normalizeDecision,
+  hint,
+}) {
+  const retryMessages = [...messages, {
+    role: 'assistant',
+    content,
+  }, {
+    role: 'user',
+    content: hint,
+  }];
+
+  try {
+    const retryOpts = {
+      model,
+      ...createOpts,
+      messages: retryMessages,
+    };
+
+    const retryContext = {
+      operation: 'desktop.plan',
+      phase: 'parser-retry',
+      provider: 'openai-compatible',
+      model,
+      step: context.step,
+      message_count: retryMessages.length,
+      max_tokens: createOpts.max_tokens,
+    };
+    const retryResponse = await retryAsync(() => client.chat.completions.create(retryOpts, reqOpts), undefined, retryContext, { retryRateLimit: false });
+    const retryParsed = parser(retryResponse);
+
+    if (!retryParsed.parseFailed) {
+      const result = normalizeDecision(retryParsed, context);
+      return { ...result, usage: retryParsed.usage || usage, reasoning: retryParsed.reasoning || null };
+    }
+  } catch (retryErr) {
+    logLlmError(model, retryErr, {
+      operation: 'desktop.plan',
+      phase: 'parser-retry',
+      provider: 'openai-compatible',
+      model,
+      step: context.step,
+    });
+    log.warn(`[Planner] 重试也失败: ${retryErr.message}`);
+  }
+
+  return null;
 }

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -153,6 +153,7 @@ export function buildNvidiaTaskMessages({
         '{"rationale":"打开网页","action":{"tool":"browser","type":"navigate","url":"https://example.com"}}',
         '{"rationale":"点击网页元素","action":{"tool":"browser","type":"click","elementId":"3"}}',
         '{"rationale":"读取目录","action":{"tool":"fs","type":"list_dir","path":"."}}',
+        '{"rationale":"查看文件大小和修改时间","action":{"tool":"fs","type":"get_file_info","path":"README.md"}}',
         '{"rationale":"读取文件","action":{"tool":"fs","type":"read_file","path":"README.md"}}',
         '{"rationale":"写文件","action":{"tool":"fs","type":"write_file","path":"notes.txt","content":"内容","append":false}}',
         '{"rationale":"搜索文件内容","action":{"tool":"fs","type":"search_files","query":"关键词","path":".","include":"*.js"}}',

--- a/agent/core/schemas.ts
+++ b/agent/core/schemas.ts
@@ -174,6 +174,14 @@ function normalizeFsAction(type, action) {
     };
   }
 
+  if (type === 'get_file_info') {
+    return {
+      tool: 'fs',
+      type,
+      path: normalizePath(action.path),
+    };
+  }
+
   if (type === 'read_file') {
     return {
       tool: 'fs',

--- a/agent/core/tool-definitions.ts
+++ b/agent/core/tool-definitions.ts
@@ -95,6 +95,17 @@ export function createModelTools() {
       },
     },
     {
+      name: 'get_file_info',
+      description: '读取文件或目录的元数据（类型、大小、修改时间），不读取文件内容。适合先判断大文件大小或确认路径是否存在。',
+      input_schema: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: '文件或目录路径' },
+        },
+        required: ['path'],
+      },
+    },
+    {
       name: 'write_file',
       description: '写入或追加文件',
       input_schema: {

--- a/agent/policy/classify.ts
+++ b/agent/policy/classify.ts
@@ -133,7 +133,7 @@ export function classifyAgentAction(action) {
     };
   }
 
-  if (tool === 'fs' && ['list_dir', 'read_file', 'search_files'].includes(type)) {
+  if (tool === 'fs' && ['list_dir', 'get_file_info', 'read_file', 'search_files'].includes(type)) {
     return {
       level: 'safe',
       reason: '只读文件系统操作',

--- a/agent/tools/fs/execute.ts
+++ b/agent/tools/fs/execute.ts
@@ -22,6 +22,17 @@ function formatFileType(dirent) {
   return 'file';
 }
 
+function formatStatsType(stats) {
+  if (stats.isDirectory()) return 'dir';
+  if (stats.isFile()) return 'file';
+  if (stats.isSymbolicLink()) return 'symlink';
+  if (stats.isBlockDevice()) return 'block_device';
+  if (stats.isCharacterDevice()) return 'character_device';
+  if (stats.isFIFO()) return 'fifo';
+  if (stats.isSocket()) return 'socket';
+  return 'other';
+}
+
 function assertWithinSandbox(targetPath, sandboxPath) {
   const normalized = path.normalize(targetPath);
   const sandbox = path.normalize(sandboxPath);
@@ -62,6 +73,22 @@ export async function executeFsAction(action, opts: { cwd?: string | null } = {}
     return summary
       ? `目录 ${targetPath} 包含:\n${summary}`
       : `目录 ${targetPath} 为空`;
+  }
+
+  if (action.type === 'get_file_info') {
+    const targetPath = resolveInputPath(action.path, baseCwd);
+    assertSafePath(targetPath);
+    const stats = await fs.lstat(targetPath);
+    const info = {
+      path: targetPath,
+      type: formatStatsType(stats),
+      sizeBytes: stats.size,
+      modifiedAt: stats.mtime.toISOString(),
+      createdAt: stats.birthtime.toISOString(),
+      mode: stats.mode.toString(8),
+      symlink: stats.isSymbolicLink(),
+    };
+    return `文件信息:\n${JSON.stringify(info, null, 2)}`;
   }
 
   if (action.type === 'read_file') {

--- a/test/fs-tool.test.ts
+++ b/test/fs-tool.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createModelTools } from '../agent/core/tool-definitions.ts';
+import { normalizeDesktopAgentDecision } from '../agent/core/schemas.ts';
+import { classifyAgentAction } from '../agent/policy/classify.ts';
+import { executeFsAction } from '../agent/tools/fs/execute.ts';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-fs-tool-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('FS tool exposure', () => {
+  it('exposes get_file_info in model tools', () => {
+    const names = createModelTools().map(tool => tool.name);
+
+    expect(names).toContain('get_file_info');
+  });
+});
+
+describe('FS action normalization', () => {
+  it('normalizes get_file_info payloads', () => {
+    const result = normalizeDesktopAgentDecision({
+      action: {
+        type: 'get_file_info',
+        path: ' README.md ',
+      },
+    });
+
+    expect(result.action).toEqual({
+      tool: 'fs',
+      type: 'get_file_info',
+      path: 'README.md',
+    });
+  });
+});
+
+describe('FS policy classification', () => {
+  it('treats get_file_info as safe', () => {
+    const result = classifyAgentAction({
+      tool: 'fs',
+      type: 'get_file_info',
+      path: 'README.md',
+    });
+
+    expect(result.level).toBe('safe');
+  });
+});
+
+describe('FS action execution', () => {
+  it('returns metadata without reading file content', async () => {
+    const filePath = path.join(tmpDir, 'sample.txt');
+    await fs.writeFile(filePath, 'secret content', 'utf8');
+
+    const result = await executeFsAction({ type: 'get_file_info', path: 'sample.txt' }, { cwd: tmpDir });
+    const info = JSON.parse(result.replace(/^文件信息:\n/, ''));
+
+    expect(info.path).toBe(filePath);
+    expect(info.type).toBe('file');
+    expect(info.sizeBytes).toBe(14);
+    expect(info.modifiedAt).toEqual(expect.any(String));
+    expect(result).not.toContain('secret content');
+  });
+});

--- a/test/planner.test.ts
+++ b/test/planner.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createJsonPlanner } from '../agent/core/planner.ts';
+import { normalizeDesktopAgentDecision } from '../agent/core/schemas.ts';
+
+function completion(content: unknown) {
+  return {
+    choices: [
+      {
+        message: {
+          content: typeof content === 'string' ? content : JSON.stringify(content),
+        },
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+describe('createJsonPlanner', () => {
+  it('retries once when a valid JSON action fails normalization', async () => {
+    const create = vi.fn()
+      .mockResolvedValueOnce(completion({
+        rationale: '查看文件大小',
+        action: { tool: 'fs', type: 'made_up_file_info', path: 'README.md' },
+      }))
+      .mockResolvedValueOnce(completion({
+        rationale: '改用可用动作',
+        action: { tool: 'fs', type: 'get_file_info', path: 'README.md' },
+      }));
+
+    const planner = createJsonPlanner({
+      client: { chat: { completions: { create } } },
+      buildMessages: () => [{ role: 'user', content: 'inspect file' }],
+      normalizeDecision: normalizeDesktopAgentDecision,
+    });
+
+    const result = await planner({
+      model: 'deepseek-ai/deepseek-v4-flash',
+      task: 'inspect file',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(result.action).toEqual({
+      tool: 'fs',
+      type: 'get_file_info',
+      path: 'README.md',
+    });
+    expect(create.mock.calls[1][0].messages.at(-1).content).toContain('不要编造工具/动作名');
+  });
+});


### PR DESCRIPTION
Summary:
- Add fs.get_file_info for file and directory metadata without reading content.
- Expose and normalize the new action, classify it as read-only safe, and add it to agent prompts.
- Retry planner decisions once when a valid JSON action fails normalization, with guidance to use supported action names.

Tests:
- npm run typecheck
- npm test