### PR TITLE
Fix sandbox LLM log writes

### DIFF
--- a/agent/core/llm-logger.ts
+++ b/agent/core/llm-logger.ts
@@ -41,8 +41,8 @@ async function flushLog(filePath, lines) {
   try {
     await mkdir(filePath.slice(0, filePath.lastIndexOf('/')), { recursive: true });
     await appendFile(filePath, lines.join('\n') + '\n');
-  } catch {
-    // best effort
+  } catch (err: any) {
+    log.warn(`[LLM] 日志写入失败 file=${filePath}: ${err?.message || err}`);
   }
 }
 

--- a/agent/worker/runner.ts
+++ b/agent/worker/runner.ts
@@ -19,6 +19,7 @@ function resolveBunCommand(env: Record<string, string | undefined> = process.env
 export function buildWorkerCommand({
   sandbox,
   projectRoot,
+  memoryDir,
   sandboxFile = path.join(REPO_ROOT, 'sandbox.sb'),
   workerFile = path.join(REPO_ROOT, 'agent/worker/agent-worker.ts'),
   bunCommand = resolveBunCommand(),
@@ -26,6 +27,7 @@ export function buildWorkerCommand({
 }: {
   sandbox: boolean;
   projectRoot: string;
+  memoryDir?: string;
   sandboxFile?: string;
   workerFile?: string;
   bunCommand?: string;
@@ -43,6 +45,8 @@ export function buildWorkerCommand({
       `HOME=${env.HOME || ''}`,
       '-D',
       `PROJECT_DIR=${projectRoot}`,
+      '-D',
+      `MEMORY_DIR=${memoryDir || path.join(REPO_ROOT, 'data')}`,
       bunCommand,
       workerFile,
     ],
@@ -117,6 +121,7 @@ export function createSandboxedWorkerAgentRunner({
     const { command, args } = buildWorkerCommand({
       sandbox,
       projectRoot,
+      memoryDir,
       sandboxFile,
       workerFile,
     });

--- a/sandbox.sb
+++ b/sandbox.sb
@@ -39,6 +39,10 @@
 (allow file-write*
   (subpath (param "PROJECT_DIR")))
 
+;; ── Sagent 全局数据目录写入（LLM 日志、运行时配置等）────
+(allow file-write*
+  (subpath (param "MEMORY_DIR")))
+
 ;; ── Bun.WebView 临时目录 & Socket ──────────────
 (allow file-read* file-write*
   (subpath "/private/var/folders"))

--- a/test/worker-runner.test.ts
+++ b/test/worker-runner.test.ts
@@ -6,6 +6,7 @@ describe('worker runner command', () => {
     const cmd = buildWorkerCommand({
       sandbox: true,
       projectRoot: '/tmp/project-a',
+      memoryDir: '/repo/data',
       sandboxFile: '/repo/sandbox.sb',
       workerFile: '/repo/agent/worker/agent-worker.ts',
       bunCommand: '/usr/local/bin/bun',
@@ -20,6 +21,8 @@ describe('worker runner command', () => {
       'HOME=/Users/test',
       '-D',
       'PROJECT_DIR=/tmp/project-a',
+      '-D',
+      'MEMORY_DIR=/repo/data',
       '/usr/local/bin/bun',
       '/repo/agent/worker/agent-worker.ts',
     ]);


### PR DESCRIPTION
## Summary
- pass MEMORY_DIR into sandboxed worker sandbox parameters
- allow sandbox workers to write Sagent global data logs
- warn when LLM log writes fail instead of swallowing errors

## Verification
- npm test -- test/worker-runner.test.ts
- npm run typecheck
- git diff --check
- sandbox-exec logger probe wrote llm-logs JSONL under /private/tmp