### PR TITLE
Fix approval dialog restore after reconnect

### DIFF
--- a/agent/core/approval-store.ts
+++ b/agent/core/approval-store.ts
@@ -17,6 +17,14 @@ function createApprovalId() {
   return `approval_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function serializeApproval(approval: any) {
+  const payload = approval.payload && typeof approval.payload === 'object' ? approval.payload : {};
+  return {
+    ...payload,
+    approvalId: approval.approvalId,
+  };
+}
+
 export function createApprovalStore() {
   /** @type {Map<string, {approvalId: string, payload: Object, resolve: Function}>} approvalId → 审批记录 */
   const pending = new Map();
@@ -69,6 +77,16 @@ export function createApprovalStore() {
       pending.delete(approvalId);
       approval.resolve(decision);
       return approval.payload;
+    },
+
+    listPendingForRun(runId: string) {
+      return [...pending.values()]
+        .map(serializeApproval)
+        .filter(approval => approval.runId === runId);
+    },
+
+    getPendingForRun(runId: string) {
+      return this.listPendingForRun(runId)[0] || null;
     },
 
     /** 拒绝所有待审批（取消/关闭运行时调用） */

--- a/agent/policy/approvals.ts
+++ b/agent/policy/approvals.ts
@@ -45,13 +45,17 @@ export function createAgentAuthorizer({
       };
     }
 
-    const { approvalId, promise } = approvalStore.request({
-      step: context.step,
-      action,
-    });
-
     const isQuestion = action.type === 'ask_user';
     const eventType = isQuestion ? 'question_required' : 'approval_required';
+    const message = isQuestion ? action.question : policy.reason;
+
+    const { approvalId, promise } = approvalStore.request({
+      type: eventType,
+      runId,
+      step: context.step,
+      action,
+      message,
+    });
 
     onEvent?.({
       type: eventType,
@@ -59,7 +63,7 @@ export function createAgentAuthorizer({
       approvalId,
       step: context.step,
       action,
-      message: isQuestion ? action.question : policy.reason,
+      message,
     });
 
     const decision = await promise;

--- a/agent/worker/runner.ts
+++ b/agent/worker/runner.ts
@@ -174,7 +174,10 @@ export function createSandboxedWorkerAgentRunner({
       }
       if (message.type === 'approval_request') {
         try {
-          const { approvalId, promise } = approvalStore.request(message.payload || {}, message.approvalId);
+          const { approvalId, promise } = approvalStore.request({
+            ...(message.payload || {}),
+            runId,
+          }, message.approvalId);
           promise.then((decision: string) => {
             writeWorkerMessage(child, { type: 'approval_response', approvalId, decision });
           });

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -3526,9 +3526,25 @@ textarea:disabled {
 .dialog-desc { font-size: var(--f-sm); line-height: 1.6; color: var(--c-text-muted); margin-bottom: 20px; }
 .dialog-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 20px; }
 
-.approval-dialog { width: min(520px, 94vw); }
+.approval-dialog {
+  width: min(520px, 94vw);
+  max-height: min(720px, 88vh);
+  display: flex;
+  flex-direction: column;
+}
 .approval-eyebrow { margin-bottom: 8px; font-size: var(--f-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--c-warning-text); }
-.approval-json { margin-top: 0; }
+.approval-message {
+  max-height: 96px;
+  overflow-y: auto;
+  margin-bottom: 12px;
+}
+.approval-dialog .approval-json {
+  margin-top: 0;
+  flex: 1 1 auto;
+  max-height: min(320px, 40vh);
+  overflow-y: auto;
+}
+.approval-dialog .dialog-actions { flex-shrink: 0; }
 .approval-confirm { min-width: 84px; }
 
 .dialog-btn {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -292,6 +292,17 @@ export default function App() {
       });
     };
 
+    const restorePendingEvent = event => {
+      if (!event || typeof event !== 'object') return;
+      if (event.type === 'approval_required') {
+        approvalRequestRef.current = { ...event, resolve: () => {} };
+        setPendingApproval(event);
+      } else if (event.type === 'question_required') {
+        questionRequestRef.current = { ...event, resolve: () => {} };
+        setPendingQuestion(event);
+      }
+    };
+
     (async () => {
       try {
         const res = await apiFetch('/api/agent/active', { signal: controller.signal });
@@ -307,6 +318,8 @@ export default function App() {
         agentRunIdRef.current = data.runId;
         setMode('agent');
         agentAbortRef.current = controller;
+        restorePendingEvent(data.pendingApproval);
+        restorePendingEvent(data.pendingQuestion);
 
         // 刷新重连时，如果当前会话看起来不是这次 Agent 任务对应的会话，
         // 就临时创建一个“占位会话”承接运行态，避免把其他历史会话的消息替换掉。

--- a/client/src/components/dialogs/ApprovalDialog.jsx
+++ b/client/src/components/dialogs/ApprovalDialog.jsx
@@ -5,14 +5,15 @@ export function ApprovalDialog({ approval, submitting, onApprove, onReject }) {
   if (!approval) {
     return null;
   }
+  const actionJson = JSON.stringify(approval.action, null, 2);
 
   return (
     <div className="dialog-mask">
       <div className="dialog approval-dialog">
         <p className="approval-eyebrow">{t('approval.eyebrow')}</p>
         <p className="dialog-title">{t('approval.title', { step: approval.step })}</p>
-        <p className="dialog-desc">{approval.message}</p>
-        <pre className="agent-json approval-json">{JSON.stringify(approval.action, null, 2)}</pre>
+        <p className="dialog-desc approval-message">{approval.message}</p>
+        <pre className="agent-json approval-json">{actionJson}</pre>
         <div className="dialog-actions">
           <button className="dialog-btn cancel" onClick={onReject} disabled={submitting}>
             {t('approval.reject')}

--- a/routes/agent-run-control.ts
+++ b/routes/agent-run-control.ts
@@ -5,6 +5,17 @@ import { readTraceEvents } from '../helpers/trace-store.ts';
 import { log } from '../helpers/logger.ts';
 import { tReq } from '../helpers/i18n.ts';
 
+function pendingApprovalState(approvalStore: any, runId: string) {
+  const pending = typeof approvalStore.listPendingForRun === 'function'
+    ? approvalStore.listPendingForRun(runId)
+    : [];
+  return {
+    pendingApproval: pending.find((item: any) => item.type === 'approval_required') || null,
+    pendingQuestion: pending.find((item: any) => item.type === 'question_required') || null,
+    pendingEvents: pending,
+  };
+}
+
 export function createAgentRunControlRouter({ agentRunStore, approvalStore, checkpointDir, memoryDir }: AgentRouterContext) {
   const router = Router();
 
@@ -36,6 +47,7 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
     if (!run) {
       return res.json({ active: false });
     }
+    const pending = pendingApprovalState(approvalStore, run.runId);
     return res.json({
       active: true,
       runId: run.runId,
@@ -43,6 +55,8 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
       model: run.meta?.model,
       task: run.meta?.task,
       meta: run.meta,
+      pendingApproval: pending.pendingApproval,
+      pendingQuestion: pending.pendingQuestion,
     });
   });
 
@@ -83,6 +97,11 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
       agentModels: run.meta?.agentModels,
       task: run.meta?.task,
     })}\n\n`);
+
+    const pending = pendingApprovalState(approvalStore, run.runId);
+    for (const event of pending.pendingEvents) {
+      res.write(`data: ${JSON.stringify(event)}\n\n`);
+    }
 
     let writer = null;
     if (run.status === 'running' && !run.cancelAc.signal.aborted) {

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -30,6 +30,8 @@ const mockRegistry: any = {
 
 let tmpDir;
 let app;
+let agentRunStore;
+let approvalStore;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-api-test-'));
@@ -39,8 +41,8 @@ beforeEach(async () => {
   const { runtimeConfig } = await import('../agent/core/runtime-config.js');
   const { createProjectStore } = await import('../agent/core/project-store.js');
 
-  const agentRunStore = createAgentRunStore();
-  const approvalStore = createApprovalStore();
+  agentRunStore = createAgentRunStore();
+  approvalStore = createApprovalStore();
   // 空注册表 → resolveRunPaths 回退到 tmpDir/process.cwd()，与无项目态一致。
   const projectStore = createProjectStore(tmpDir);
   await projectStore.init();
@@ -116,6 +118,75 @@ describe('GET /api/agent/memory', () => {
     expect(res.body.conversation).toHaveLength(1);
     expect(res.body.conversation[0].task).toBe('test');
     expect(res.body.projectKnowledge).toBeDefined();
+  });
+});
+
+describe('GET /api/agent/active', () => {
+  it('returns pending approval details for a reconnected run', async () => {
+    const run = agentRunStore.createRun({
+      model: 'test-model',
+      task: 'needs approval',
+    });
+    approvalStore.request({
+      type: 'approval_required',
+      runId: run.runId,
+      step: 3,
+      action: { tool: 'terminal', type: 'run', command: 'npm test' },
+      message: '命令需要确认',
+    }, 'approval_reconnect_1');
+
+    const res = await request(app).get('/api/agent/active');
+    expect(res.status).toBe(200);
+    expect(res.body.active).toBe(true);
+    expect(res.body.runId).toBe(run.runId);
+    expect(res.body.pendingApproval).toMatchObject({
+      type: 'approval_required',
+      runId: run.runId,
+      approvalId: 'approval_reconnect_1',
+      step: 3,
+      message: '命令需要确认',
+      action: { tool: 'terminal', type: 'run', command: 'npm test' },
+    });
+    expect(res.body.pendingQuestion).toBeNull();
+
+    approvalStore.rejectAll();
+  });
+});
+
+describe('GET /api/agent/stream/:runId', () => {
+  it('replays pending approval details for reconnect streams', async () => {
+    const run = agentRunStore.createRun({
+      model: 'test-model',
+      task: 'needs stream approval',
+    });
+    approvalStore.request({
+      type: 'approval_required',
+      runId: run.runId,
+      step: 4,
+      action: { tool: 'fs', type: 'write_file', path: 'out.txt' },
+      message: '文件写入需要确认',
+    }, 'approval_stream_1');
+    run.status = 'done';
+
+    const res = await request(app)
+      .get(`/api/agent/stream/${run.runId}`)
+      .buffer(true)
+      .parse((response, callback) => {
+        let body = '';
+        response.setEncoding('utf8');
+        response.on('data', chunk => {
+          body += chunk;
+        });
+        response.on('end', () => callback(null, body));
+      });
+
+    expect(res.status).toBe(200);
+    const responseText = typeof res.text === 'string' ? res.text : String(res.body || '');
+    expect(responseText).toContain('"type":"approval_required"');
+    expect(responseText).toContain('"approvalId":"approval_stream_1"');
+    expect(responseText).toContain('"message":"文件写入需要确认"');
+
+    approvalStore.rejectAll();
   });
 });
 

--- a/test/approval-store.test.ts
+++ b/test/approval-store.test.ts
@@ -17,4 +17,34 @@ describe('approval store', () => {
 
     expect(() => store.request({}, 'worker_approval_dup')).toThrow('审批已存在');
   });
+
+  it('lists pending approvals for an active run', () => {
+    const store = createApprovalStore();
+    store.request({
+      type: 'approval_required',
+      runId: 'run_abc_123',
+      step: 2,
+      action: { tool: 'terminal', type: 'run', command: 'npm test' },
+      message: '需要确认',
+    }, 'approval_pending_1');
+    store.request({
+      type: 'approval_required',
+      runId: 'run_other_456',
+      step: 1,
+      action: { tool: 'fs', type: 'write_file' },
+      message: 'other',
+    }, 'approval_pending_2');
+
+    expect(store.listPendingForRun('run_abc_123')).toEqual([
+      {
+        type: 'approval_required',
+        runId: 'run_abc_123',
+        approvalId: 'approval_pending_1',
+        step: 2,
+        action: { tool: 'terminal', type: 'run', command: 'npm test' },
+        message: '需要确认',
+      },
+    ]);
+    expect(store.getPendingForRun('run_abc_123')?.approvalId).toBe('approval_pending_1');
+  });
 });


### PR DESCRIPTION
## Summary
- Fixes #274
- persist active pending approval/question state by run id
- return pending approval/question from /api/agent/active and reconnect streams
- restore pending approval/question dialogs during frontend reconnect
- constrain approval dialog content so long action payloads stay scrollable

## Verification
- npm test -- test/approval-store.test.ts test/agent-api.test.ts
- npm test
- npm run typecheck
- npm run build:client
- git diff --check