### PR TITLE
Support model switching in conversations

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1454,14 +1454,6 @@ select,
   flex-shrink: 0;
 }
 
-.header-model-label {
-  font-size: var(--f-xs);
-  color: var(--c-text-hint);
-  background: var(--c-surface-dim);
-  padding: 2px 8px;
-  border-radius: var(--r-pill);
-}
-
 .header-icon-btn {
   width: 34px;
   height: 34px;
@@ -2011,6 +2003,30 @@ select,
   color: var(--c-text-hint);
   margin-top: 4px;
   text-align: right;
+}
+
+.msg-meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+  margin-top: 6px;
+  color: var(--c-text-hint);
+}
+
+.msg-meta .msg-time {
+  margin-top: 0;
+  flex-shrink: 0;
+}
+
+.msg-model {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  line-height: 1.4;
 }
 
 .assistant-sections {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -219,6 +219,45 @@ export default function App() {
     } catch { /* 忽略损坏的旧数据 */ }
   }, [projectsLoading, setSelectedAgentModels, setAgentStrategy]);
 
+  // 刷新或切回历史 Agent 会话时，如果项目级选择为空，就用该会话上次运行的模型
+  // 恢复选择器状态。只对每个 active session 自动恢复一次，避免用户手动清空后被立刻填回。
+  const seededAgentModelsSessionRef = useRef(null);
+  useEffect(() => {
+    if (mode !== 'agent' || seededAgentModelsSessionRef.current === activeSession.id) {
+      return;
+    }
+    if (selectedAgentModels.length > 0) {
+      seededAgentModelsSessionRef.current = activeSession.id;
+      return;
+    }
+    const sessionModels = uniqueModelIds(
+      activeSession.modelsUsed?.length > 0
+        ? activeSession.modelsUsed
+        : activeSession.model
+          ? [activeSession.model]
+          : []
+    );
+    if (sessionModels.length === 0) {
+      return;
+    }
+    const validModels = modelsLoaded && availableModels.length > 0
+      ? sessionModels.filter(model => availableModels.some(item => item.id === model))
+      : sessionModels;
+    if (validModels.length > 0) {
+      setSelectedAgentModels(validModels);
+      seededAgentModelsSessionRef.current = activeSession.id;
+    }
+  }, [
+    activeSession.id,
+    activeSession.model,
+    activeSession.modelsUsed,
+    availableModels,
+    mode,
+    modelsLoaded,
+    selectedAgentModels.length,
+    setSelectedAgentModels,
+  ]);
+
   // 桌面通知权限：default = 未询问，granted = 已开，denied = 用户拒绝过。
   // SW 在 App 挂载时静默注册，权限请求必须由用户点击触发。
   const [notifyPerm, setNotifyPerm] = useState(() => notificationPermission());
@@ -262,7 +301,6 @@ export default function App() {
       });
   }, [setChatState]);
 
-  const selectedChatModelLabel = availableModels.find(item => item.id === chatModel)?.label || chatModel;
   const sessionLocked = streaming || agentRunning;
 
   // 在移动端/窄屏时，会话侧栏和 Agent 面板会改变页面主色块区域。
@@ -332,7 +370,18 @@ export default function App() {
           if (firstUser && firstUser.content === task) {
             const sessions = prev.sessions.map(session => {
               if (session.id !== prev.activeSessionId) return session;
+              const messages = session.messages.map(message => {
+                const isRunUser = message.role === 'user' && message.content === task;
+                const isPendingAssistant = message.role === 'assistant' && message.pending === 'run';
+                if (!isRunUser && !isPendingAssistant) return message;
+                return {
+                  ...message,
+                  ...(activeRunPrimaryModel && !message.model ? { model: activeRunPrimaryModel } : {}),
+                  ...(activeRunModels.length > 0 && !message.modelsUsed ? { modelsUsed: activeRunModels } : {}),
+                };
+              });
               return touchSession(session, {
+                messages,
                 ...(activeRunPrimaryModel ? { model: activeRunPrimaryModel } : {}),
                 ...(activeRunModels.length > 0 ? { modelsUsed: activeRunModels } : {}),
                 agentRunId: data.runId,
@@ -342,8 +391,8 @@ export default function App() {
           }
           const cleanSession = createSession({
             messages: [
-              { role: 'user', content: task, ts: data.startedAt || Date.now() },
-              { role: 'assistant', content: t('agent.running'), pending: 'run', ts: Date.now() },
+              { role: 'user', content: task, ts: data.startedAt || Date.now(), ...(activeRunPrimaryModel ? { model: activeRunPrimaryModel } : {}), ...(activeRunModels.length > 0 ? { modelsUsed: activeRunModels } : {}) },
+              { role: 'assistant', content: t('agent.running'), pending: 'run', ts: Date.now(), ...(activeRunPrimaryModel ? { model: activeRunPrimaryModel } : {}), ...(activeRunModels.length > 0 ? { modelsUsed: activeRunModels } : {}) },
             ],
             model: activeRunPrimaryModel,
             modelsUsed: activeRunModels,
@@ -432,14 +481,15 @@ export default function App() {
               if (event.type === 'done') {
                 setAgentRunning(false);
                 const modelsUsed = uniqueModelIds(event.meta?.models_used);
+                const primaryDoneModel = modelsUsed[0] || activeRunPrimaryModel;
                 updateActiveSession(session => {
                   const msgs = [...session.messages];
                   const idx = (() => { for (let i = msgs.length - 1; i >= 0; i--) { if (msgs[i].role === 'assistant' && msgs[i].pending === 'run') return i; } return -1; })();
                   if (idx >= 0) {
-                    msgs[idx] = { role: 'assistant', content: event.answer || t('agent.done') };
+                    msgs[idx] = { role: 'assistant', content: event.answer || t('agent.done'), ts: Date.now(), ...(primaryDoneModel ? { model: primaryDoneModel } : {}), ...(modelsUsed.length > 0 ? { modelsUsed } : {}) };
                   } else if (!msgs.some(m => m.role === 'assistant' && m.content === (event.answer || ''))) {
-                    msgs.push({ role: 'user', content: reconnectTaskRef.current || data.task || t('agent.taskFallback'), ts: data.startedAt || Date.now() });
-                    msgs.push({ role: 'assistant', content: event.answer || t('agent.done'), ts: Date.now() });
+                    msgs.push({ role: 'user', content: reconnectTaskRef.current || data.task || t('agent.taskFallback'), ts: data.startedAt || Date.now(), ...(primaryDoneModel ? { model: primaryDoneModel } : {}), ...(modelsUsed.length > 0 ? { modelsUsed } : {}) });
+                    msgs.push({ role: 'assistant', content: event.answer || t('agent.done'), ts: Date.now(), ...(primaryDoneModel ? { model: primaryDoneModel } : {}), ...(modelsUsed.length > 0 ? { modelsUsed } : {}) });
                   }
                   return touchSession(session, {
                     messages: msgs,
@@ -503,6 +553,7 @@ export default function App() {
         ? (terminal.answer || t('agent.done'))
         : t('agent.failed', { error: terminal.error || t('common.unknownError') });
       const modelsUsed = getTraceModels(events);
+      const primaryModel = modelsUsed[0] || null;
 
       setChatState(prev => {
         let changed = false;
@@ -517,9 +568,9 @@ export default function App() {
             }
           }
           if (idx >= 0) {
-            msgs[idx] = { role: 'assistant', content, ts: Date.now() };
+            msgs[idx] = { role: 'assistant', content, ts: Date.now(), ...(primaryModel ? { model: primaryModel } : {}), ...(modelsUsed.length > 0 ? { modelsUsed } : {}) };
           } else if (!msgs.some(m => m.role === 'assistant' && m.content === content)) {
-            msgs.push({ role: 'assistant', content, ts: Date.now() });
+            msgs.push({ role: 'assistant', content, ts: Date.now(), ...(primaryModel ? { model: primaryModel } : {}), ...(modelsUsed.length > 0 ? { modelsUsed } : {}) });
           } else {
             return session;
           }
@@ -831,7 +882,6 @@ export default function App() {
   );
   const modelSelect = (
     <ModelSelector
-      sessionStarted={sessionStarted}
       mode={mode}
       availableModels={availableModels}
       chatModel={chatModel}
@@ -963,9 +1013,6 @@ export default function App() {
             sessionTitle={getSessionTitle(messages)}
             sessionLocked={sessionLocked}
             messagesLength={messages.length}
-            sessionStarted={sessionStarted}
-            mode={mode}
-            selectedChatModelLabel={selectedChatModelLabel}
             modeSwitch={modeSwitch}
             modelSelect={modelSelect}
             onToggleSessions={() => setShowSessions(v => !v)}
@@ -1023,6 +1070,7 @@ export default function App() {
               renderMessageContent={props => <MessageContent {...props} />}
               renderCopyButton={props => <CopyButton {...props} />}
               hasThinkContent={hasThinkContent}
+              getModelLabel={modelId => availableModels.find(item => item.id === modelId)?.label || modelId}
               formatMsgTime={formatMsgTime}
             />
           )}

--- a/client/src/components/AppHeader.jsx
+++ b/client/src/components/AppHeader.jsx
@@ -2,15 +2,12 @@ import { Menu, Moon, Settings, Sun, Trash2 } from 'lucide-react';
 import { useTheme } from '../theme/ThemeProvider.jsx';
 import { useT } from '../i18n/I18nProvider.jsx';
 
-// 已开始会话后的顶部 header：左侧菜单/新建/标题，右侧模式切换/模型选择/标签/清空。
+// 已开始会话后的顶部 header：左侧菜单/新建/标题，右侧模式切换/模型选择/清空。
 // modeSwitch、modelSelect 由父组件传 slot 进来（同一控件在 hero 和 header 共用）。
 export function AppHeader({
   sessionTitle,
   sessionLocked,
   messagesLength,
-  sessionStarted,
-  mode,
-  selectedChatModelLabel,
   modeSwitch,
   modelSelect,
   onToggleSessions,
@@ -34,9 +31,6 @@ export function AppHeader({
       <div className="header-right">
         {modeSwitch}
         {modelSelect}
-        {sessionStarted && mode !== 'agent' && (
-          <span className="header-model-label">{selectedChatModelLabel}</span>
-        )}
         <button className="header-icon-btn" onClick={toggleTheme} title={t('appearance.toggleTheme')}>
           {resolvedTheme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
         </button>

--- a/client/src/components/ChatPane.jsx
+++ b/client/src/components/ChatPane.jsx
@@ -1,3 +1,16 @@
+function formatMessageModels(message, getModelLabel) {
+  const ids = Array.isArray(message.modelsUsed) && message.modelsUsed.length > 0
+    ? message.modelsUsed
+    : message.model
+      ? [message.model]
+      : [];
+  const labels = ids.map(id => getModelLabel?.(id) || id).filter(Boolean);
+  if (labels.length <= 2) {
+    return labels.join(' + ');
+  }
+  return `${labels.slice(0, 2).join(' + ')} +${labels.length - 2}`;
+}
+
 export function ChatPane({
   hidden,
   messages,
@@ -18,6 +31,7 @@ export function ChatPane({
   renderMessageContent,
   renderCopyButton,
   hasThinkContent,
+  getModelLabel,
   formatMsgTime,
 }) {
   return (
@@ -32,28 +46,36 @@ export function ChatPane({
       }}
     >
       <div className="messages">
-        {messages.map((message, index) => (
-          <div key={index} className={`bubble-row ${message.role}`}>
-            {message.role === 'assistant' && (
-              <>
-                <div className={`bubble assistant ${hasThinkContent(message.content) ? 'has-think' : ''}`}>
-                  {renderMessageContent({ role: 'assistant', content: message.content, showCursor: streaming && index === messages.length - 1 })}
-                  {message.ts && <div className="msg-time">{formatMsgTime(message.ts)}</div>}
-                </div>
-                {renderCopyButton({ text: message.content })}
-              </>
-            )}
-            {message.role === 'user' && (
-              <>
-                {renderCopyButton({ text: message.content })}
-                <div className="bubble user">
-                  {renderMessageContent({ role: 'user', content: message.content })}
-                  {message.ts && <div className="msg-time">{formatMsgTime(message.ts)}</div>}
-                </div>
-              </>
-            )}
-          </div>
-        ))}
+        {messages.map((message, index) => {
+          const messageModelLabel = message.role === 'assistant' ? formatMessageModels(message, getModelLabel) : '';
+          return (
+            <div key={index} className={`bubble-row ${message.role}`}>
+              {message.role === 'assistant' && (
+                <>
+                  <div className={`bubble assistant ${hasThinkContent(message.content) ? 'has-think' : ''}`}>
+                    {renderMessageContent({ role: 'assistant', content: message.content, showCursor: streaming && index === messages.length - 1 })}
+                    {(messageModelLabel || message.ts) && (
+                      <div className="msg-meta">
+                        {messageModelLabel && <span className="msg-model" title={messageModelLabel}>{messageModelLabel}</span>}
+                        {message.ts && <span className="msg-time">{formatMsgTime(message.ts)}</span>}
+                      </div>
+                    )}
+                  </div>
+                  {renderCopyButton({ text: message.content })}
+                </>
+              )}
+              {message.role === 'user' && (
+                <>
+                  {renderCopyButton({ text: message.content })}
+                  <div className="bubble user">
+                    {renderMessageContent({ role: 'user', content: message.content })}
+                    {message.ts && <div className="msg-time">{formatMsgTime(message.ts)}</div>}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
         <div ref={bottomRef} />
         <div className="input-area">
           <div className="input-card">

--- a/client/src/components/ModelSelector.jsx
+++ b/client/src/components/ModelSelector.jsx
@@ -292,10 +292,9 @@ function AgentModelDropdown({
 // - chat 模式：可搜索下拉
 // - agent 模式：多选下拉（搜索 + 多选 + 优先级排序 + race/vote 策略）
 //
-// 只在 sessionStarted=false 时渲染。组件自己判断这个条件，让 App
-// 那边可以无条件 <ModelSelector .../> 写成一行。
+// 会话开始后仍保留选择器，用于切换后续轮次使用的模型；
+// 运行中由 sessionLocked 禁用，避免误改当前请求。
 export function ModelSelector({
-  sessionStarted,
   mode,
   availableModels,
   chatModel,
@@ -306,8 +305,6 @@ export function ModelSelector({
   setAgentStrategy,
   sessionLocked,
 }) {
-  if (sessionStarted) return null;
-
   if (mode !== 'agent') {
     return (
       <div className="model-select-row">

--- a/client/src/hooks/useAgentTransport.js
+++ b/client/src/hooks/useAgentTransport.js
@@ -88,12 +88,15 @@ export function useAgentTransport({
     const runModels = selectedModels.length > 0 ? selectedModels : [chatModel];
     const primaryModel = runModels[0] || chatModel;
     lastAgentTaskRef.current = text;
-    const history = isRetry ? messages : [...messages, { role: 'user', content: text, ts: Date.now() }];
+    const now = Date.now();
+    const history = isRetry
+      ? messages
+      : [...messages, { role: 'user', content: text, ts: now, model: primaryModel, modelsUsed: runModels }];
 
     if (!isRetry) {
       updateSession(sessionId, session =>
         touchSession(session, {
-          messages: [...history, { role: 'assistant', content: t('agent.running'), pending: 'run', ts: Date.now() }],
+          messages: [...history, { role: 'assistant', content: t('agent.running'), pending: 'run', ts: now, model: primaryModel, modelsUsed: runModels }],
           model: primaryModel,
           modelsUsed: runModels,
           agentTrace: [],
@@ -110,7 +113,7 @@ export function useAgentTransport({
       updateSession(sessionId, session => {
         const msgs = [...session.messages];
         const stepInfo = cpStep ? t('agent.retryFromStep', { step: cpStep }) : '';
-        msgs.push({ role: 'assistant', content: t('agent.retrying', { step: stepInfo, task: text }), pending: 'run', ts: Date.now() });
+        msgs.push({ role: 'assistant', content: t('agent.retrying', { step: stepInfo, task: text }), pending: 'run', ts: Date.now(), model: primaryModel, modelsUsed: runModels });
         return touchSession(session, { messages: msgs, model: primaryModel, modelsUsed: runModels });
       });
     }
@@ -207,13 +210,15 @@ export function useAgentTransport({
             setAgentTrace(prev => {
               updateSession(sessionId, session => {
                 const nextMessages = [...session.messages];
+                const modelsUsed = getEventModels(event, runModels);
                 // 占位消息（pending:'run'）始终是最后一条助手消息，用结果替换它。
                 nextMessages[nextMessages.length - 1] = {
                   role: 'assistant',
                   content: event.answer || t('agent.done'),
                   ts: Date.now(),
+                  model: modelsUsed[0] || primaryModel,
+                  modelsUsed,
                 };
-                const modelsUsed = getEventModels(event, runModels);
                 return touchSession(session, {
                   messages: nextMessages,
                   model: modelsUsed[0] || primaryModel,
@@ -235,12 +240,14 @@ export function useAgentTransport({
             setAgentTrace(prev => {
               updateSession(sessionId, session => {
                 const nextMessages = [...session.messages];
+                const modelsUsed = getEventModels(event, runModels);
                 nextMessages[nextMessages.length - 1] = {
                   role: 'assistant',
                   content: t('agent.failed', { error: event.error || t('common.unknownError') }),
                   ts: Date.now(),
+                  model: modelsUsed[0] || primaryModel,
+                  modelsUsed,
                 };
-                const modelsUsed = getEventModels(event, runModels);
                 return touchSession(session, {
                   messages: nextMessages,
                   model: modelsUsed[0] || primaryModel,
@@ -267,6 +274,9 @@ export function useAgentTransport({
           nextMessages[nextMessages.length - 1] = {
             role: 'assistant',
             content: t('agent.requestFailed', { error: err.message, detail }),
+            ts: Date.now(),
+            model: primaryModel,
+            modelsUsed: runModels,
           };
 
           return touchSession(session, { messages: nextMessages });
@@ -283,13 +293,13 @@ export function useAgentTransport({
             const lastIdx = msgs.length - 1;
             if (lastIdx >= 0 && msgs[lastIdx].role === 'assistant' && msgs[lastIdx].pending === 'run') {
               const next = [...msgs];
-              if (doneEvent) {
-                next[lastIdx] = { role: 'assistant', content: doneEvent.answer || t('agent.done'), ts: Date.now() };
-              } else {
-                next[lastIdx] = { role: 'assistant', content: t('agent.failed', { error: errorEvent.error || t('agent.connectionLostShort') }), ts: Date.now() };
-              }
               const terminalEvent = doneEvent || errorEvent;
               const modelsUsed = getEventModels(terminalEvent, runModels);
+              if (doneEvent) {
+                next[lastIdx] = { role: 'assistant', content: doneEvent.answer || t('agent.done'), ts: Date.now(), model: modelsUsed[0] || primaryModel, modelsUsed };
+              } else {
+                next[lastIdx] = { role: 'assistant', content: t('agent.failed', { error: errorEvent.error || t('agent.connectionLostShort') }), ts: Date.now(), model: modelsUsed[0] || primaryModel, modelsUsed };
+              }
               return touchSession(session, {
                 messages: next,
                 model: modelsUsed[0] || primaryModel,
@@ -314,7 +324,7 @@ export function useAgentTransport({
             const lastIdx = msgs.length - 1;
             if (lastIdx >= 0 && msgs[lastIdx].role === 'assistant' && msgs[lastIdx].pending === 'run') {
               const next = [...msgs];
-              next[lastIdx] = { role: 'assistant', content: t('agent.connectionLost'), ts: Date.now() };
+              next[lastIdx] = { role: 'assistant', content: t('agent.connectionLost'), ts: Date.now(), model: primaryModel, modelsUsed: runModels };
               return touchSession(session, {
                 messages: next,
                 model: primaryModel,

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -23,6 +23,9 @@ function normalizeMessages(value) {
       role: item.role,
       content: item.content,
       ...(item.ts ? { ts: item.ts } : {}),
+      ...(typeof item.model === 'string' && item.model ? { model: item.model } : {}),
+      ...(Array.isArray(item.modelsUsed) ? { modelsUsed: normalizeModelIds(item.modelsUsed) } : {}),
+      ...(item.pending ? { pending: item.pending } : {}),
     }));
 }
 

--- a/client/src/hooks/useChatTransport.js
+++ b/client/src/hooks/useChatTransport.js
@@ -22,13 +22,15 @@ export function useChatTransport({
   const sendChatMessage = async text => {
     const sessionId = activeSession.id;
     const now = Date.now();
-    const userMsg = { role: 'user', content: text, ts: now };
+    const modelForTurn = chatModel;
+    const userMsg = { role: 'user', content: text, ts: now, model: modelForTurn };
     const history = [...messages, userMsg];
-    const apiMessages = history;
+    const apiMessages = history.map(message => ({ role: message.role, content: message.content }));
 
     updateSession(sessionId, session =>
       touchSession(session, {
-        messages: [...history, { role: 'assistant', content: '', ts: now }],
+        model: modelForTurn,
+        messages: [...history, { role: 'assistant', content: '', ts: now, model: modelForTurn }],
       })
     );
     setInput('');
@@ -40,7 +42,7 @@ export function useChatTransport({
     try {
       await streamChatCompletion({
         messages: apiMessages,
-        model: chatModel,
+        model: modelForTurn,
         projectId: activeSession.projectId ?? null,
         signal: controller.signal,
         onContent(content) {
@@ -48,8 +50,10 @@ export function useChatTransport({
             const nextMessages = [...session.messages];
             const lastMessage = nextMessages[nextMessages.length - 1] || { role: 'assistant', content: '' };
             nextMessages[nextMessages.length - 1] = {
+              ...lastMessage,
               role: 'assistant',
               content: (lastMessage.content || '') + content,
+              model: lastMessage.model || modelForTurn,
             };
 
             return touchSession(session, { messages: nextMessages });
@@ -64,6 +68,7 @@ export function useChatTransport({
           nextMessages[nextMessages.length - 1] = {
             ...lastMessage,
             content: `${lastMessage?.content || ''}${lastMessage?.content ? '\n\n' : ''}${t('chat.stopped')}`,
+            model: lastMessage?.model || modelForTurn,
           };
 
           return touchSession(session, { messages: nextMessages });
@@ -75,6 +80,7 @@ export function useChatTransport({
           nextMessages[nextMessages.length - 1] = {
             role: 'assistant',
             content: t('chat.requestFailed', { error: err.message, detail }),
+            model: modelForTurn,
           };
 
           return touchSession(session, { messages: nextMessages });


### PR DESCRIPTION
## Summary
- keep the model selector available after chat or agent conversations start so later turns can switch models
- persist per-message model metadata and display the model used by assistant responses
- restore agent model selection from the active session after refresh/reconnect

## Verification
- npm run build:client
- npm test