### PR TITLE
Fix reasoning content preservation

### DIFF
--- a/agent/core/nvidia-response-parsers.ts
+++ b/agent/core/nvidia-response-parsers.ts
@@ -5,7 +5,7 @@
  *   - 有些用标准 tool_calls（理论上支持，实际很少触发）
  *   - 有些把 JSON 放在 content 字段里（Nemotron, Kimi, Qwen, MiniMax）
  *   - MiniMax 有时用自定义 [TOOL_CALL] 块或 XML 格式
- *   - Nemotron/Kimi 有 reasoning 字段记录思维链
+ *   - 部分推理模型有 reasoning/reasoning_content 字段记录推理过程
  *
  * 工厂 createModelResponseParser(model) 根据模型 ID 返回对应的解析器，
  * 每个解析器按配置的策略链依次尝试解析，第一个命中即返回。
@@ -33,6 +33,13 @@ function tryParseJsonObject(value) {
   } catch {
     return null;
   }
+}
+
+function getReasoningText(message) {
+  for (const value of [message?.reasoning_content, message?.reasoning]) {
+    if (typeof value === 'string' && value.trim()) return value;
+  }
+  return null;
 }
 
 function extractFirstJsonObject(source) {
@@ -316,7 +323,6 @@ const DEFAULT_CONFIG = {
 export function createModelResponseParser(model) {
   const config = MODEL_CONFIGS[model] || DEFAULT_CONFIG;
   const chain = config.chain.map(name => STRATEGIES[name]);
-  const extractReasoning = config.extractReasoning || false;
 
   return function parseResponse(response) {
     // 个别 OpenAI 兼容供应商的部分模型返回的响应体
@@ -333,9 +339,7 @@ export function createModelResponseParser(model) {
     const message = response?.choices?.[0]?.message;
     const content = getMessageText(message?.content);
     const usage = response?.usage || null;
-    const reasoning = extractReasoning
-      ? (message?.reasoning || message?.reasoning_content || null)
-      : null;
+    const reasoning = getReasoningText(message);
 
     for (const strategy of chain) {
       const result = strategy(message, content);

--- a/agent/core/providers/openai-compat.ts
+++ b/agent/core/providers/openai-compat.ts
@@ -29,6 +29,93 @@ import type {
   SummarizeOpts,
 } from './types.ts';
 
+const REASONING_HEADER = '[推理过程]';
+
+function getReasoningText(source: any, { trim = true } = {}) {
+  for (const value of [source?.reasoning_content, source?.reasoning]) {
+    if (typeof value === 'string' && value.trim()) {
+      return trim ? value.trim() : value;
+    }
+  }
+  return '';
+}
+
+function mergeReasoningIntoMessage(message: any) {
+  const reasoning = getReasoningText(message);
+  if (!reasoning || !message || typeof message !== 'object') return message;
+  if (message.content != null && typeof message.content !== 'string') return message;
+
+  const content = typeof message.content === 'string' ? message.content : '';
+  if (content.startsWith(REASONING_HEADER)) return message;
+
+  const mergedContent = content.trim()
+    ? `${REASONING_HEADER}\n${reasoning}\n\n${content}`
+    : `${REASONING_HEADER}\n${reasoning}`;
+
+  return { ...message, content: mergedContent };
+}
+
+function preserveReasoningContent(response: any) {
+  if (!Array.isArray(response?.choices)) return response;
+  return {
+    ...response,
+    choices: response.choices.map((choice: any) => (
+      choice?.message
+        ? { ...choice, message: mergeReasoningIntoMessage(choice.message) }
+        : choice
+    )),
+  };
+}
+
+type ReasoningStreamState = {
+  sawReasoning: boolean;
+  startedContent: boolean;
+};
+
+function mergeReasoningIntoStreamChunk(chunk: any, states: Map<number, ReasoningStreamState>) {
+  if (!Array.isArray(chunk?.choices)) return chunk;
+
+  let changed = false;
+  const choices = chunk.choices.map((choice: any, offset: number) => {
+    const delta = choice?.delta;
+    if (!delta || typeof delta !== 'object') return choice;
+
+    const reasoning = getReasoningText(delta, { trim: false });
+    const content = typeof delta.content === 'string' ? delta.content : '';
+    const index = typeof choice.index === 'number' ? choice.index : offset;
+    const state = states.get(index) || { sawReasoning: false, startedContent: false };
+    let nextContent: string | null = null;
+
+    if (reasoning) {
+      nextContent = `${state.sawReasoning ? '' : `${REASONING_HEADER}\n`}${reasoning}`;
+      state.sawReasoning = true;
+      if (content) {
+        nextContent += `${state.startedContent ? '' : '\n\n'}${content}`;
+        state.startedContent = true;
+      }
+    } else if (content) {
+      if (state.sawReasoning && !state.startedContent) {
+        nextContent = `\n\n${content}`;
+      }
+      state.startedContent = true;
+    }
+
+    states.set(index, state);
+    if (nextContent === null) return choice;
+    changed = true;
+    return { ...choice, delta: { ...delta, content: nextContent } };
+  });
+
+  return changed ? { ...chunk, choices } : chunk;
+}
+
+async function* preserveReasoningContentStream(stream: AsyncIterable<any>) {
+  const states = new Map<number, ReasoningStreamState>();
+  for await (const chunk of stream) {
+    yield mergeReasoningIntoStreamChunk(chunk, states);
+  }
+}
+
 export function createOpenAICompatProvider(client: any): LLMProvider {
   const createStreamingCompletion = createStreamingCompletionFactory(client);
 
@@ -70,18 +157,20 @@ export function createOpenAICompatProvider(client: any): LLMProvider {
     },
 
     async completionJson(opts: CompletionOpts) {
-      const { model, messages, temperature, top_p, max_tokens } = opts;
-      return client.chat.completions.create({ model, messages, temperature, top_p, max_tokens });
+      const { model, messages, temperature, top_p, max_tokens, preserveReasoningContent: shouldPreserveReasoning } = opts;
+      const response = await client.chat.completions.create({ model, messages, temperature, top_p, max_tokens });
+      return shouldPreserveReasoning ? preserveReasoningContent(response) : response;
     },
 
     async completionStream(opts: CompletionStreamOpts) {
-      const { model, messages, temperature, top_p, max_tokens, res } = opts;
+      const { model, messages, temperature, top_p, max_tokens, preserveReasoningContent: shouldPreserveReasoning, res } = opts;
       const completion = await createStreamingCompletion(
         { model, messages, temperature, top_p, max_tokens },
         { includeUsage: true }
       );
       initSse(res);
-      for await (const chunk of completion) {
+      const stream = shouldPreserveReasoning ? preserveReasoningContentStream(completion) : completion;
+      for await (const chunk of stream) {
         writeSse(res, chunk);
       }
       writeSseDone(res);

--- a/agent/core/providers/types.ts
+++ b/agent/core/providers/types.ts
@@ -49,6 +49,7 @@ export interface CompletionOpts {
   temperature: number;
   top_p: number;
   max_tokens: number;
+  preserveReasoningContent?: boolean;
 }
 
 export interface CompletionStreamOpts extends CompletionOpts {

--- a/routes/completions.ts
+++ b/routes/completions.ts
@@ -50,9 +50,9 @@ export function createCompletionsRouter({ registry, modelConfig }: { registry: P
       const provider = registry.resolve(model, modelConfig);
 
       if (!stream) {
-        return res.json(await provider.completionJson({ model, messages, temperature, top_p, max_tokens }));
+        return res.json(await provider.completionJson({ model, messages, temperature, top_p, max_tokens, preserveReasoningContent: true }));
       }
-      return await provider.completionStream({ model, messages, temperature, top_p, max_tokens, res });
+      return await provider.completionStream({ model, messages, temperature, top_p, max_tokens, preserveReasoningContent: true, res });
     } catch (err: any) {
       log.error('API error:', err);
 

--- a/test/nvidia-response-parsers.test.ts
+++ b/test/nvidia-response-parsers.test.ts
@@ -8,6 +8,13 @@ function wrap(content: string) {
   };
 }
 
+function wrapWithReasoning(content: string, reasoningContent: string) {
+  return {
+    choices: [{ message: { content, reasoning_content: reasoningContent } }],
+    usage: null,
+  };
+}
+
 describe('nvidia response parsers: tryTextFinish guard', () => {
   it('rejects broken-JSON action wrapped in ```json fences instead of treating it as finish', () => {
     const parse = createModelResponseParser('z-ai/glm-5.1');
@@ -41,5 +48,16 @@ describe('nvidia response parsers: tryTextFinish guard', () => {
     const result = parse(wrap(content));
     expect(result?.action?.type).toBe('finish');
     expect(result?.action?.answer).toContain('杭州');
+  });
+
+  it('preserves reasoning_content for default parser models', () => {
+    const parse = createModelResponseParser('deepseek-reasoner');
+    const result = parse(wrapWithReasoning(
+      JSON.stringify({ rationale: '继续执行', action: { type: 'finish', answer: '完成' } }),
+      '先判断下一步'
+    ));
+
+    expect(result?.reasoning).toBe('先判断下一步');
+    expect(result?.action?.type).toBe('finish');
   });
 });

--- a/test/openai-compat-provider.test.ts
+++ b/test/openai-compat-provider.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createOpenAICompatProvider } from '../agent/core/providers/openai-compat.ts';
+
+function createMockRes() {
+  return {
+    headers: new Map<string, string>(),
+    writes: [] as string[],
+    ended: false,
+    setHeader(name: string, value: string) {
+      this.headers.set(name, value);
+    },
+    flushHeaders: vi.fn(),
+    write(payload: string) {
+      this.writes.push(payload);
+    },
+    end() {
+      this.ended = true;
+    },
+  };
+}
+
+async function* streamChunks(chunks: any[]) {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+describe('OpenAICompatProvider reasoning content preservation', () => {
+  it('prepends reasoning_content to non-streaming chat completion content when requested', async () => {
+    const create = vi.fn().mockResolvedValue({
+      id: 'chatcmpl-test',
+      choices: [{
+        index: 0,
+        message: {
+          role: 'assistant',
+          reasoning_content: '先分析问题',
+          content: '最终回答',
+        },
+        finish_reason: 'stop',
+      }],
+    });
+    const provider = createOpenAICompatProvider({
+      chat: { completions: { create } },
+      models: { list: vi.fn() },
+    });
+
+    const response = await provider.completionJson({
+      model: 'deepseek-reasoner',
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 1,
+      top_p: 1,
+      max_tokens: 100,
+      preserveReasoningContent: true,
+    });
+
+    expect(response.choices[0].message.content).toBe('[推理过程]\n先分析问题\n\n最终回答');
+  });
+
+  it('leaves structured internal completion content unchanged by default', async () => {
+    const create = vi.fn().mockResolvedValue({
+      choices: [{
+        message: {
+          reasoning_content: '内部推理',
+          content: '{"ok":true}',
+        },
+      }],
+    });
+    const provider = createOpenAICompatProvider({
+      chat: { completions: { create } },
+      models: { list: vi.fn() },
+    });
+
+    const response = await provider.completionJson({
+      model: 'deepseek-reasoner',
+      messages: [{ role: 'user', content: 'json' }],
+      temperature: 0.1,
+      top_p: 1,
+      max_tokens: 100,
+    });
+
+    expect(response.choices[0].message.content).toBe('{"ok":true}');
+  });
+
+  it('streams reasoning_content as normal content with a reasoning header', async () => {
+    const create = vi.fn().mockResolvedValue(streamChunks([
+      { choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }] },
+      { choices: [{ index: 0, delta: { reasoning_content: '先想' }, finish_reason: null }] },
+      { choices: [{ index: 0, delta: { reasoning_content: '清楚' }, finish_reason: null }] },
+      { choices: [{ index: 0, delta: { content: '最终' }, finish_reason: null }] },
+      { choices: [{ index: 0, delta: { content: '回答' }, finish_reason: null }] },
+      { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+    ]));
+    const provider = createOpenAICompatProvider({
+      chat: { completions: { create } },
+      models: { list: vi.fn() },
+    });
+    const res = createMockRes();
+
+    await provider.completionStream({
+      model: 'deepseek-reasoner',
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 1,
+      top_p: 1,
+      max_tokens: 100,
+      preserveReasoningContent: true,
+      res: res as any,
+    });
+
+    const payloads = res.writes
+      .filter(line => line.startsWith('data: {'))
+      .map(line => JSON.parse(line.slice('data: '.length)).choices[0].delta.content)
+      .filter(Boolean)
+      .join('');
+
+    expect(payloads).toBe('[推理过程]\n先想清楚\n\n最终回答');
+    expect(res.writes.at(-1)).toBe('data: [DONE]\n\n');
+    expect(res.ended).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve reasoning_content/reasoning in OpenAI-compatible chat completion responses
- stream reasoning_content as visible content with a reasoning header
- keep internal structured completion calls unchanged by default
- preserve planner reasoning fields for default parser models

## Tests
- npm test -- test/openai-compat-provider.test.ts test/nvidia-response-parsers.test.ts
- npm run typecheck
- npm run lint
- npm test

Closes #46