### PR TITLE
docs: split configuration from readme

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,251 @@
+# 配置说明
+
+sagent 的配置分两层：
+
+- `.env`：后端启动时读取，管理 API Key、供应商地址、服务端口、MCP 连接、沙盒和默认 Agent 行为。修改后通常需要重启后端。
+- `data/runtime-config.json`：由前端设置页生成，保存 Agent 行为参数的覆盖值。它会覆盖 `.env` 默认值，并在下一次 Agent 任务生效；点击「恢复默认」会清空该文件。
+
+如果设置了 `MEMORY_DIR`，`runtime-config.json`、记忆、trace、checkpoint、上传文件都会写到这个目录下。
+
+## 最小可用配置
+
+```bash
+cp .env.example .env
+```
+
+至少填一个模型供应商 Key：
+
+```bash
+NVIDIA_API_KEY=nvapi-...
+# 或
+GEMINI_API_KEY=...
+```
+
+然后启动：
+
+```bash
+npm run sandbox
+```
+
+## API Key 与模型供应商
+
+| 变量 | 说明 | 默认值 / 备注 |
+| --- | --- | --- |
+| `NVIDIA_API_KEY` | OpenAI 兼容供应商 Key。变量名沿用 NVIDIA，但可配合 `NVIDIA_BASE_URL` 指向其他 OpenAI 兼容服务。 | 与 `GEMINI_API_KEY` 至少填一个 |
+| `NVIDIA_BASE_URL` | OpenAI 兼容接口地址。 | `https://integrate.api.nvidia.com/v1` |
+| `GEMINI_API_KEY` | Google Gemini 原生 SDK Key。 | 配置后 Gemini 模型会出现在模型列表 |
+| `VISION_MODEL` | `image_analyze` 工具使用的视觉模型。 | 使用代码中的默认视觉模型 |
+| `AGENT_MULTI_MODELS` | 默认多模型列表，逗号分隔。前端仍可按次选择和排序模型。 | 空 |
+| `MODELS` | 旧模型列表变量。 | 已废弃，不再生效；模型列表启动时从供应商接口拉取 |
+
+启动时会向已配置供应商拉取模型列表。至少一家供应商成功即可启动；全部失败时，后端会退出并打印失败原因。
+
+## 服务与存储
+
+| 变量 | 说明 | 默认值 / 备注 |
+| --- | --- | --- |
+| `PORT` | 后端监听端口。开发模式下前端 Vite 仍是 `5173`，并代理到后端。 | `3001`；Docker 镜像内为 `5173` |
+| `HOST` | 后端监听地址。 | `0.0.0.0` |
+| `MEMORY_DIR` | 本地数据目录，保存记忆、trace、checkpoint、截图、上传文件、运行时配置。 | `data`；Docker 中为 `/app/data` |
+| `HOST_PORT` | `docker compose` 映射到宿主机的端口。 | `5173` |
+| `LOG_LEVEL` | 日志等级。 | `info`，可选 `debug` / `info` / `warn` / `error` |
+
+不要提交真实 `.env`。如果 `data/runtime-config.json` 只包含个人偏好，也建议不要提交。
+
+## Agent 行为参数
+
+这些变量作为默认值写在 `.env` 中；前端设置页保存后，会被 `runtime-config.json` 覆盖。
+
+| 变量 | 前端字段 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `AGENT_MAX_STEPS` | `maxSteps` | `8` | 单次 Agent 任务最大步数 |
+| `AGENT_MODEL_TIMEOUT` | `modelTimeoutSec` | `90` | 单模型单步超时秒数 |
+| `AGENT_STAGGER_DELAY` | `staggerDelaySec` | `5` | 多模型竞速批次间隔秒数 |
+| `AGENT_BATCH_SIZE` | `batchSize` | `1` | 每批启动的模型数量 |
+| `AGENT_OBSERVE_DESKTOP` | `observeDesktop` | `false` | 是否在 Agent 循环中观测 macOS 桌面状态 |
+| `AGENT_MAX_HISTORY_STEPS` | `maxHistorySteps` | `20` | 发送给模型的最大历史步数 |
+| `AGENT_MAX_RESULT_CHARS` | `maxResultChars` | `8000` | 每步结果写入上下文时保留的最大字符数 |
+| `AGENT_MAX_PARALLEL_RESULT_CHARS` | `maxParallelResultChars` | `32000` | 并行模型结果写入上下文时的最大字符数 |
+| `AGENT_MEMORY_MAX_ENTRIES` | `memoryMaxEntries` | `20` | 对话记忆触发压缩的记录数阈值 |
+
+前端设置页不会管理 API Key。Key 仍只从 `.env` 读取，修改后需要重启后端。
+
+## Checkpoint 与恢复
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `AGENT_RESUME` | `true` | 后端重启时是否恢复未完成的 Agent 任务。设置为 `false` 会在启动时清理残留 checkpoint |
+
+checkpoint 写在 `{MEMORY_DIR}/checkpoints/`。任务正常完成后会自动清理。
+
+## 沙盒与 worker
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `AGENT_SANDBOXED_WORKERS` | `false` | `npm run sandbox` 会自动设为 `true`，让每次 Agent run 进入 worker |
+| `AGENT_WORKER_SANDBOX` | `true` | worker 内是否继续使用 macOS `sandbox-exec` |
+| `AGENT_HEADLESS` | `false` | 兼容旧配置；当前 WebView 后端会忽略该值 |
+| `AGENT_WORKER_CANCEL_GRACE_MS` | 内置值 | 取消 run 后等待 worker 正常结束的时间 |
+| `AGENT_WORKER_CANCEL_KILL_GRACE_MS` | 内置值 | 强制结束 worker 前的额外等待时间 |
+| `AGENT_SERVER_SHUTDOWN_GRACE_MS` | 内置值 | 服务退出时等待 worker 清理的时间 |
+
+沙盒权限由 [sandbox.sb](sandbox.sb) 控制。调整该文件可能导致网络、浏览器、文件系统等能力失效或放宽。
+
+## JetBrains IDE MCP
+
+启用后，Agent 会增加两个工具：
+
+- `ide_list_tools`：列出 IDE 当前暴露的 MCP 工具。
+- `ide_call_tool`：按工具名调用 IDE MCP 工具。
+
+推荐先在 JetBrains IDE 中打开 `Settings | Tools | MCP Server`，启用后复制 SSE 或 stdio 配置。
+
+SSE 示例：
+
+```bash
+IDE_MCP_ENABLED=true
+IDE_MCP_TRANSPORT=sse
+IDE_MCP_URL=http://127.0.0.1:6365/sse
+IDE_PROJECT_PATH=/path/to/project
+```
+
+也可以拆成 host/port/path：
+
+```bash
+IDE_MCP_ENABLED=true
+IDE_MCP_TRANSPORT=sse
+IDE_MCP_HOST=127.0.0.1
+IDE_MCP_PORT=6365
+IDE_MCP_SSE_PATH=/sse
+IDE_PROJECT_PATH=/path/to/project
+```
+
+stdio 示例：
+
+```bash
+IDE_MCP_ENABLED=true
+IDE_MCP_TRANSPORT=stdio
+IDE_MCP_COMMAND=npx
+IDE_MCP_ARGS=["-y","@jetbrains/mcp-proxy"]
+IDE_PROJECT_PATH=/path/to/project
+```
+
+可用变量：
+
+| 变量 | 说明 |
+| --- | --- |
+| `IDE_MCP_ENABLED` | 显式启用 IDE MCP |
+| `IDE_MCP_TRANSPORT` | `sse` 或 `stdio` |
+| `IDE_MCP_URL` / `IDE_MCP_SSE_URL` | SSE 完整地址，优先级高于 host/port/path |
+| `IDE_MCP_MESSAGES_URL` | MCP messages endpoint，IDE 提供时再填 |
+| `IDE_MCP_HOST` | SSE host |
+| `IDE_MCP_PORT` | SSE port |
+| `IDE_MCP_SSE_PATH` | SSE path |
+| `IDE_PROJECT_PATH` / `IDE_MCP_PROJECT_PATH` | 默认项目路径 |
+| `IDE_MCP_CWD` | stdio transport 的工作目录 |
+| `IDE_MCP_COMMAND` | stdio command |
+| `IDE_MCP_ARGS` | stdio args，JSON 数组或可解析字符串 |
+
+如果 IDE 显示的地址或端口与示例不同，以 IDE 复制出来的配置为准。
+
+## Chrome DevTools MCP
+
+启用后，Agent 会增加：
+
+- `chrome_list_tools`：刷新或查看 Chrome MCP 工具列表。
+- `chrome_call_tool`：调用 Chrome DevTools MCP 工具。
+
+sandbox 模式下推荐另开一个非 sandbox 终端启动 bridge：
+
+```bash
+npm run chrome:mcp
+```
+
+然后在 `.env` 中配置：
+
+```bash
+CHROME_MCP_ENABLED=true
+CHROME_MCP_TRANSPORT=sse
+CHROME_MCP_HOST=127.0.0.1
+CHROME_MCP_PORT=3099
+CHROME_MCP_SSE_PATH=/sse
+```
+
+可用变量：
+
+| 变量 | 说明 |
+| --- | --- |
+| `CHROME_MCP_ENABLED` | 显式启用 Chrome MCP |
+| `CHROME_MCP_TRANSPORT` | 当前使用 SSE |
+| `CHROME_MCP_URL` | SSE 完整地址，优先级高于 host/port/path |
+| `CHROME_MCP_MESSAGES_URL` | MCP messages endpoint，服务提供时再填 |
+| `CHROME_MCP_HOST` | SSE host，默认 `127.0.0.1` |
+| `CHROME_MCP_PORT` | SSE port，默认 `3099` |
+| `CHROME_MCP_SSE_PATH` | SSE path，默认 `/sse` |
+| `CHROME_MCP_KEEP_OPEN` | 设为 `true` 时，Agent run 结束后保留 MCP SSE client |
+| `CHROME_MCP_KEEP_TABS` | 设为 `true` 时，Agent run 结束后保留本次打开的 Chrome tab |
+| `CHROME_MCP_NAVIGATE_TIMEOUT_MS` | `navigate_page` 默认超时，默认 `25000` |
+| `CHROME_MCP_TOOL_TIMEOUT_MS` | Chrome MCP 工具调用超时，默认 `60000` |
+
+bridge 自身也支持这些变量：
+
+| 变量 | 说明 |
+| --- | --- |
+| `CHROME_MCP_BRIDGE_HOST` | bridge 监听 host，默认 `127.0.0.1` |
+| `CHROME_MCP_BRIDGE_PORT` | bridge 监听 port，默认 `3099` |
+| `CHROME_MCP_BRIDGE_COMMAND` | bridge 启动的 MCP 命令，默认 `chrome-devtools-mcp` |
+| `CHROME_MCP_BRIDGE_ARGS` | 追加传给 bridge command 的参数 |
+
+## Docker 配置
+
+`docker-compose.yml` 会读取 `.env`，并把容器内数据目录挂到 `./data-docker`。
+
+常用方式：
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+修改宿主机端口：
+
+```bash
+HOST_PORT=8080 docker compose up --build
+```
+
+手动运行时需要传入 env file 和数据卷：
+
+```bash
+docker run --env-file .env -p 5173:5173 -v "$(pwd)/data-docker:/app/data" sagent:local
+```
+
+## 常见配置组合
+
+仅使用 OpenAI 兼容供应商：
+
+```bash
+NVIDIA_API_KEY=your-key
+NVIDIA_BASE_URL=https://your-compatible-endpoint/v1
+```
+
+仅使用 Gemini：
+
+```bash
+GEMINI_API_KEY=your-key
+```
+
+开启断点恢复和较长任务：
+
+```bash
+AGENT_RESUME=true
+AGENT_MAX_STEPS=64
+AGENT_MODEL_TIMEOUT=120
+```
+
+开启多模型竞速默认列表：
+
+```bash
+AGENT_MULTI_MODELS=moonshotai/kimi-k2.5,qwen/qwen3.5-397b-a17b
+AGENT_BATCH_SIZE=2
+AGENT_STAGGER_DELAY=1
+```

--- a/README.md
+++ b/README.md
@@ -1,148 +1,126 @@
 <div align="center">
   <img src="client/public/favicon.svg" width="64" height="64" alt="sagent logo">
   <h1>sagent</h1>
-  <p>Multi-model AI chat + desktop Agent with browser automation, file operations, terminal commands, macOS control, and JetBrains IDE MCP support.</p>
+  <p>A local AI workspace for multi-model chat and desktop Agent runs.</p>
 </div>
 
-> **macOS only.** The Agent needs to control the local browser and system, currently tested on Mac only.
+> sagent is built around macOS desktop automation. The web UI and API can be packaged with Docker, but the full Agent experience depends on macOS, Bun 1.3+ `Bun.WebView`, and local system permissions.
 >
-> Browser automation uses Bun 1.3+ `Bun.WebView`, which runs on the system WebKit backend on macOS.
+> Chinese documentation: [README_ZH.md](README_ZH.md)
 >
-> 🌐 **中文版**: [README_ZH.md](README_ZH.md)
+> Environment variables and runtime settings: [CONFIGURATION.md](CONFIGURATION.md)
+
+## Overview
+
+sagent combines a React web UI, a Bun/Express backend, and a tool-using Agent runtime. It can chat with multiple model providers, run desktop automation, operate files and terminals, inspect browser pages, call JetBrains IDE MCP tools, and preserve project memory between sessions.
+
+The project is designed for local use: you choose a project workspace, start an Agent task, approve sensitive operations, and watch each step stream back into the UI.
+
+## Highlights
+
+- Multi-model chat and Agent mode with race or vote strategies.
+- macOS desktop control, screenshots, browser automation, and optional Chrome DevTools MCP integration.
+- File, terminal, search, vision, IDE MCP, and browser tools behind an approval-aware runtime.
+- Sandboxed Agent workers when launched with `npm run sandbox`.
+- Project-scoped memory, traces, uploads, checkpoints, and run recovery.
+- Mobile-friendly progress view for devices on the same LAN.
+- Smoke tests and trace files for validating Agent behavior after changes.
+
+## Requirements
+
+- macOS for full desktop Agent capabilities.
+- Bun 1.3+.
+- Node.js and npm for installing dependencies and building the React client.
+- At least one model provider API key. See [CONFIGURATION.md](CONFIGURATION.md).
+- A Chromium-based browser is recommended for approval notifications with inline buttons.
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/longxiazy/sagent && cd sagent
-cp .env.example .env  # Fill in your API Key
-npm install && cd client && npm install && cd ..
-npm run sandbox       # Requires Bun 1.3+
+git clone https://github.com/longxiazy/sagent
+cd sagent
+cp .env.example .env
+npm install
+cd client && npm install && cd ..
+npm run sandbox
 ```
 
-Open http://localhost:5173
+Edit `.env` before starting if you have not added an API key yet. Open http://localhost:5173 when the dev server is ready.
 
-When the Agent needs your approval, sagent shows a browser desktop notification with **Allow / Reject** buttons (Chromium-based browsers). The first time the Agent requests approval you'll see a banner — click **Enable desktop notifications** and the browser will prompt for permission. On Safari/Firefox the notification still pops but without inline buttons — clicking it focuses sagent so you can decide in the side panel.
+`npm run sandbox` starts the UI/API server normally and runs each Agent task in a short-lived macOS sandboxed worker. Use `npm run dev` only when you intentionally want the non-sandboxed development mode.
 
 ## Docker
 
-The Docker image builds the frontend and runs the backend with Bun. It is useful for sharing the server/UI package. Agent features that depend on the macOS desktop, system WebView, or controlling a host browser are still best run natively with `npm run sandbox`.
+Docker builds the frontend and serves the UI/API from one Bun process. It is useful for sharing the server/UI package, but desktop automation, system WebView access, and host browser control are still best run natively on macOS.
 
 ```bash
 cp .env.example .env
-# Fill NVIDIA_API_KEY or GEMINI_API_KEY in .env
 docker compose up --build
 ```
 
-Open http://localhost:5173
+Open http://localhost:5173.
 
-Manual build/run:
+Manual build and run:
 
 ```bash
 docker build -t sagent:local .
 docker run --env-file .env -p 5173:5173 -v "$(pwd)/data-docker:/app/data" sagent:local
 ```
 
-## Security: Sandbox Policy
+## Agent Safety
 
-When started with `npm run sandbox`, the UI/API server stays outside the macOS sandbox and each Agent run starts a short-lived worker inside `sandbox-exec`, with permissions controlled by `sandbox.sb` and `PROJECT_DIR` set to that run's project root.
+When the Agent needs approval, sagent shows an in-app approval panel and a browser desktop notification. Chromium-based browsers support inline Allow/Reject buttons; Safari and Firefox still show the notification, and clicking it returns focus to sagent.
 
-You can customize `sandbox.sb` to adjust the Agent's permission boundary. Modifying the file may cause some Agent functions to lose permission (e.g., unable to access the network, unable to open the browser, etc.).
-
-Dangerous operations (deleting files, installing packages, executing terminal commands) will pop up a confirmation dialog — the Agent cannot proceed without your approval.
+Dangerous operations such as deleting files, installing packages, or executing terminal commands require explicit approval. The sandbox boundary is controlled by [sandbox.sb](sandbox.sb) when running with `npm run sandbox`.
 
 ## Multi-Device View
 
-Other devices on the LAN (phone, iPad) can open `http://<Mac-IP>:5173` to view the Agent's execution progress in real time.
+Devices on the same LAN can open `http://<Mac-IP>:5173` to watch the active Agent run in real time.
 
-- **Agent running**: Other devices can only watch the agent execution flow; the chat area is empty until the agent completes
-- **Chat history**: Each device is independent; history is not shared
-- **Only one Agent at a time**: New requests will receive a 409 error
+- While an Agent run is active, secondary devices show the execution flow and receive the final result when it completes.
+- Chat history is local to each browser/device.
+- Only one Agent run can execute at a time; additional requests receive a 409 response.
 
-## Configuration
+## Core Workflows
 
-Edit `.env`:
+### Multi-Model Agent
 
-```bash
-# API Keys (fill at least one)
-NVIDIA_API_KEY=nvapi-...  # MiniMax, Kimi, Qwen, GLM, DeepSeek, etc.
-GEMINI_API_KEY=...
+Agent mode can call multiple models for each step. In race mode, the first valid result wins and the remaining requests are cancelled. In vote mode, all selected models run and the result is aggregated. The UI lets you select models, reorder priority, and switch strategies per run.
 
-# Agent behavior (optional)
-AGENT_MAX_STEPS=128            # Max steps per task, default 8
-AGENT_MODEL_TIMEOUT=30         # Per-model timeout in seconds
-AGENT_MAX_HISTORY_STEPS=20     # Max history steps sent to LLM (prevents context overflow)
-AGENT_MAX_RESULT_CHARS=1000    # Max chars per step result in history
-AGENT_MEMORY_MAX_ENTRIES=20    # Memory compaction threshold
-AGENT_RESUME=true              # Auto-resume interrupted tasks after backend restart
+### Checkpoint Recovery
 
-# Multi-model race (optional)
-AGENT_STAGGER_DELAY=3          # Delay between batches in seconds
-AGENT_BATCH_SIZE=2             # Models launched per batch
-# AGENT_MULTI_MODELS=moonshotai/kimi-k2.5,qwen/qwen3.5-397b-a17b
+Each completed Agent step is written to `data/checkpoints/`. If the backend restarts and recovery is enabled, sagent restores the last run state and continues from the next step. Completed runs clean up their checkpoints automatically.
 
-# JetBrains IDE MCP (optional)
-IDE_MCP_ENABLED=true
-IDE_MCP_TRANSPORT=sse
-IDE_MCP_URL=http://127.0.0.1:6365/sse
-IDE_PROJECT_PATH=/path/to/your/project
-# Or use stdio copied from the IDE:
-# IDE_MCP_TRANSPORT=stdio
-# IDE_MCP_COMMAND=npx
-# IDE_MCP_ARGS=["-y","@jetbrains/mcp-proxy"]
-```
+### Cross-Session Memory
 
-When `IDE_MCP_ENABLED=true`, the Agent exposes two extra tools:
+sagent stores project experience under the configured data directory. Memory includes recent task summaries, compacted historical context, and project knowledge. The memory panel in the sidebar lets you inspect, compact, or clear that state.
 
-- `ide_list_tools`: discover the MCP tools currently exposed by JetBrains IDE
-- `ide_call_tool`: call a specific IDE MCP tool with its argument object
+### IDE And Browser Integrations
 
-Tip: in JetBrains IDE, open `Settings | Tools | MCP Server`, enable it, then use `Copy SSE Config` or `Copy Stdio Config` and mirror the connection details into `.env`. If your IDE shows a different URL or port than `127.0.0.1:6365/sse`, prefer the IDE-provided value.
-
-## Recovery After Backend Restart
-
-Each completed step is written to `data/checkpoints/` (atomic writes, crash-safe).
-
-When the backend restarts:
-
-- **`AGENT_RESUME=true` (default)**: Automatically detects unfinished checkpoints, restores the last runId and step history, and resumes from the breakpoint. The frontend can also reconnect via SSE after refresh.
-- **`AGENT_RESUME=false`**: Clears all checkpoints on startup; does not resume any interrupted tasks.
-
-Successfully completed tasks automatically clean up their checkpoints.
+JetBrains IDE MCP adds `ide_list_tools` and `ide_call_tool` to the Agent. Chrome DevTools MCP adds browser inspection and control through `chrome_list_tools` and `chrome_call_tool`. Both integrations are optional and documented in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Common Commands
 
 ```bash
-npm run build    # Type-check backend and build frontend
-npm run sandbox  # Start with sandbox (recommended)
-npm run dev      # Start without sandbox
-npm run stop     # Stop frontend and backend
+npm run sandbox      # Start server and client with sandboxed Agent workers
+npm run dev          # Start server and client without sandboxed workers
+npm run build        # Type-check backend and build frontend
+npm run lint         # Run ESLint
+npm test             # Run Vitest tests
+npm run smoke        # Run Agent smoke scenarios against a running server
+npm run stop         # Stop frontend and backend processes
+npm run chrome:mcp   # Start the Chrome DevTools MCP SSE bridge
 ```
 
-## Multi-Model Agent
+For smoke tests, start sagent first, then run `npm run smoke` in another terminal. Reports are written to `data/smoke-reports/`, and failed cases point to their trace files under `data/traces/`.
 
-The Agent can invoke multiple models concurrently for each step, picking the fastest result.
+## Project Layout
 
-- **Race mode**: Models launch in priority order. First valid result wins; remaining are cancelled.
-- **Vote mode**: All models run concurrently, results are aggregated by majority vote.
-- **Batch race**: `AGENT_BATCH_SIZE` controls models per batch. If the entire batch fails, next batch starts immediately.
-
-Frontend: select multiple models in Agent mode, reorder with arrows to set priority, toggle between race/vote strategies.
-
-## Cross-Session Memory
-
-The Agent accumulates project experience across sessions, persisted in local storage.
-
-- **Conversation records**: Summaries of recent tasks (task, result, models, timestamp)
-- **Compacted summary**: LLM-distilled historical summary (deduplicated, up to 2000 chars)
-- **Project knowledge**: Directory structure, common paths, user preferences, learnings
-
-Auto-compaction triggers when records exceed `AGENT_MEMORY_MAX_ENTRIES` (default 20).
-
-### Memory Panel
-
-Click the brain icon in the left sidebar to open the memory panel — it's global, not tied to any specific task. You can view conversation history, project knowledge, manually trigger compaction, or clear memory.
-
-```bash
-AGENT_MEMORY_MAX_ENTRIES=20  # Compaction threshold
-MEMORY_DIR=data              # Memory file storage directory
+```text
+agent/      Agent runtime, providers, tools, policy, workers
+routes/     Express API routes
+helpers/    Shared server helpers and stores
+client/     React/Vite frontend
+scripts/    Smoke tests, stop script, Chrome MCP bridge
+test/       Vitest and integration tests
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,158 +1,126 @@
 <div align="center">
   <img src="client/public/favicon.svg" width="64" height="64" alt="sagent logo">
   <h1>sagent</h1>
-  <p>多模型 AI 聊天 + 桌面 Agent，支持浏览器自动化、文件操作、终端命令、macOS 控制，以及 JetBrains IDE MCP 接入。</p>
+  <p>本地多模型 AI 聊天与桌面 Agent 工作台。</p>
 </div>
 
-> **仅支持 macOS**。Agent 需要操控本地浏览器和系统，目前只在 Mac 上测试通过。
+> sagent 以 macOS 桌面自动化为核心。Web UI 和 API 可以用 Docker 打包运行，但完整 Agent 能力依赖 macOS、Bun 1.3+ `Bun.WebView` 和本机系统权限。
 >
-> 浏览器自动化基于 Bun 1.3+ 内置 `Bun.WebView`，macOS 会直接使用系统 WebKit。
+> 英文版：[README.md](README.md)
 >
-> 前端适配移动端 — 手机、平板、电脑浏览器都能用，随时随地查看 Agent 进度、继续对话。
+> 环境变量和运行时配置：[CONFIGURATION.md](CONFIGURATION.md)
+
+## 项目简介
+
+sagent 把 React Web UI、Bun/Express 后端和可调用工具的 Agent runtime 组合在一起。它可以接入多个模型供应商，执行桌面自动化，读写文件，运行终端命令，查看浏览器页面，调用 JetBrains IDE MCP 工具，并在不同会话之间保留项目记忆。
+
+它更像一个本地 AI 工作台：选择项目目录，输入任务，审批敏感操作，然后在界面里实时查看每一步执行过程和最终结果。
+
+## 核心特性
+
+- 多模型聊天和 Agent 模式，支持竞速与汇总策略。
+- macOS 桌面控制、截图、浏览器自动化，以及可选的 Chrome DevTools MCP 集成。
+- 文件、终端、搜索、视觉、IDE MCP、浏览器等工具统一接入 Agent runtime。
+- 使用 `npm run sandbox` 时，每次 Agent 任务都会进入短生命周期沙盒 worker。
+- 项目级记忆、trace、上传文件、checkpoint 和中断恢复。
+- 局域网内手机、平板、电脑都能实时查看 Agent 进度。
+- 内置 smoke 测试和 trace 文件，方便功能开发后回归验证。
+
+## 运行要求
+
+- macOS，用于完整桌面 Agent 能力。
+- Bun 1.3+。
+- Node.js 和 npm，用于安装依赖、构建前端。
+- 至少配置一个模型供应商 API Key，见 [CONFIGURATION.md](CONFIGURATION.md)。
+- 推荐使用 Chromium 内核浏览器，以获得带「允许 / 拒绝」按钮的桌面通知。
 
 ## 快速开始
 
 ```bash
-git clone https://github.com/longxiazy/sagent && cd sagent
-cp .env.example .env                    # 编辑填入 API Key
-npm install && cd client && npm install && cd ..
-npm run sandbox                         # 需要 Bun 1.3+
+git clone https://github.com/longxiazy/sagent
+cd sagent
+cp .env.example .env
+npm install
+cd client && npm install && cd ..
+npm run sandbox
 ```
 
-打开 http://localhost:5173
+如果还没填 API Key，请先编辑 `.env`。开发服务启动后打开 http://localhost:5173。
 
-Agent 等待审批时，sagent 会通过浏览器桌面通知提醒你，并提供「允许 / 拒绝」按钮（Chromium 内核浏览器支持）。首次出现审批请求时，页面上方会弹出小横条，点击「开启桌面通知」即可触发浏览器的权限请求。Safari / Firefox 桌面端不支持通知里的按钮，通知仍会弹出，点击通知会聚焦回 sagent 页面，在右侧审批面板上做决定即可。
+`npm run sandbox` 会正常启动 UI/API server，并让每次 Agent 任务在 macOS 沙盒 worker 中执行。只有明确需要无沙盒调试时，才使用 `npm run dev`。
 
 ## Docker 运行
 
-Docker 镜像会构建前端并用 Bun 运行后端，适合打包 server/UI 给别人试用。依赖 macOS 桌面、系统 WebView 或本机浏览器控制的 Agent 能力，建议仍用原生 `npm run sandbox` 运行。
+Docker 会构建前端，并用一个 Bun 进程提供 UI/API 服务。它适合分发 server/UI 包；依赖桌面、系统 WebView 或宿主浏览器控制的 Agent 能力，仍建议在 macOS 上原生运行。
 
 ```bash
 cp .env.example .env
-# 编辑 .env 填入 NVIDIA_API_KEY 或 GEMINI_API_KEY
 docker compose up --build
 ```
 
-打开 http://localhost:5173
+打开 http://localhost:5173。
 
-也可以手动构建和运行：
+手动构建和运行：
 
 ```bash
 docker build -t sagent:local .
 docker run --env-file .env -p 5173:5173 -v "$(pwd)/data-docker:/app/data" sagent:local
 ```
 
-## 安全：沙盒策略
+## Agent 安全机制
 
-通过 `npm run sandbox` 启动时，UI/API server 常驻在沙盒外，每次 Agent run 会启动一个短生命周期 worker，并用 `sandbox-exec` 将该 worker 限制在当前 run 的项目根目录内；权限由 `sandbox.sb` 文件控制。
+Agent 等待审批时，sagent 会显示页面内审批面板，并发送浏览器桌面通知。Chromium 内核浏览器支持通知里的「允许 / 拒绝」按钮；Safari 和 Firefox 仍会弹出通知，点击后回到 sagent 页面处理审批。
 
-你可以自定义 `sandbox.sb` 来调整 Agent 的权限边界。修改该文件可能导致 Agent 部分功能无权限执行（如无法访问网络、无法打开浏览器等）。
-
-危险操作（删文件、装包、执行终端命令）会弹窗确认，你不点同意 Agent 就没法继续。
+删除文件、安装依赖、执行终端命令等危险操作都需要显式确认。通过 `npm run sandbox` 启动时，沙盒权限边界由 [sandbox.sb](sandbox.sb) 控制。
 
 ## 多设备查看
 
-局域网内其他设备（手机、iPad）打开 `http://<Mac的IP>:5173` 可以实时查看 Agent 的执行进度。
+局域网内其他设备可以打开 `http://<Mac-IP>:5173` 实时查看当前 Agent 运行。
 
-- **Agent 运行中**：其他设备进入后只能看 agent 执行流程，聊天区为空，等待 agent 完成后显示最终结果
-- **聊天记录**：各设备独立，不共享历史会话
-- **同时只能跑一个 Agent**：新请求会收到 409 提示
+- Agent 运行中，其他设备展示执行流程，并在完成后收到最终结果。
+- 聊天历史保存在各自浏览器里，不跨设备共享。
+- 同一时间只能运行一个 Agent，新的任务请求会收到 409。
 
-## 配置
+## 核心工作流
 
-编辑 `.env`：
+### 多模型 Agent
 
-```bash
-# API Key（至少填一个）
-NVIDIA_API_KEY=nvapi-...              # MiniMax、Kimi、Qwen、GLM、DeepSeek 等
-GEMINI_API_KEY=...
+Agent 模式下，每一步都可以同时调用多个模型。竞速模式采用第一个有效结果并取消其余请求；汇总模式会等待所有选中模型并聚合结果。前端支持选择模型、调整优先级、切换策略。
 
-# Agent 行为（可选）
-AGENT_MAX_STEPS=128              # 单次任务最大步数，默认 8
-AGENT_MODEL_TIMEOUT=30           # 单模型超时秒数
-AGENT_MAX_HISTORY_STEPS=20       # 发送给 LLM 的最大历史步数（防止上下文溢出）
-AGENT_MAX_RESULT_CHARS=1000      # 每步结果保留的最大字符数
-AGENT_MEMORY_MAX_ENTRIES=20      # 记忆压缩阈值
-AGENT_RESUME=true                # 后端重启后自动恢复未完成的 Agent 任务
+### Checkpoint 恢复
 
-# 多模型竞速（可选）
-AGENT_STAGGER_DELAY=3            # 批次间隔秒数
-AGENT_BATCH_SIZE=2               # 每批启动模型数
-# AGENT_MULTI_MODELS=moonshotai/kimi-k2.5,qwen/qwen3.5-397b-a17b
+Agent 每完成一步都会写入 `data/checkpoints/`。如果后端重启且恢复已启用，sagent 会还原上次运行状态，并从下一步继续执行。正常完成的任务会自动清理 checkpoint。
 
-# JetBrains IDE MCP（可选）
-IDE_MCP_ENABLED=true
-IDE_MCP_TRANSPORT=sse
-IDE_MCP_URL=http://127.0.0.1:6365/sse
-IDE_PROJECT_PATH=/path/to/your/project
-# 或者使用 IDE 里复制出来的 stdio 配置：
-# IDE_MCP_TRANSPORT=stdio
-# IDE_MCP_COMMAND=npx
-# IDE_MCP_ARGS=["-y","@jetbrains/mcp-proxy"]
-```
+### 跨会话记忆
 
-当 `IDE_MCP_ENABLED=true` 时，Agent 会额外暴露两个工具：
+sagent 会在配置的数据目录下保存项目经验，包括近期任务摘要、压缩后的历史上下文和项目知识。侧边栏记忆面板可以查看、手动压缩或清空这些状态。
 
-- `ide_list_tools`：查看当前 JetBrains IDE 暴露出来的 MCP 工具列表
-- `ide_call_tool`：按工具名调用具体 IDE MCP 工具，并传入对应参数对象
+### IDE 与浏览器集成
 
-建议先在 JetBrains IDE 的 `Settings | Tools | MCP Server` 中启用 MCP Server，再用 `Copy SSE Config` 或 `Copy Stdio Config` 把连接信息同步到 `.env`。如果 IDE 里显示的地址或端口不是 `127.0.0.1:6365/sse`，以 IDE 提供的配置为准。
-
-## 后端重启恢复
-
-Agent 每完成一步都会将状态写入 `data/checkpoints/` 目录（原子写入，防崩溃损坏）。
-
-当后端进程重启时：
-
-- **`AGENT_RESUME=true`（默认）**：自动检测未完成的 checkpoint，从断点继续执行。前端刷新后也能通过 SSE 重连接上。
-- **`AGENT_RESUME=false`**：启动时清除所有 checkpoint，不恢复任何中断的任务。
-
-正常运行完成的任务会自动清理 checkpoint，无需手动维护。
+JetBrains IDE MCP 会给 Agent 增加 `ide_list_tools` 和 `ide_call_tool`。Chrome DevTools MCP 会增加 `chrome_list_tools` 和 `chrome_call_tool`。两者都是可选能力，配置方式见 [CONFIGURATION.md](CONFIGURATION.md)。
 
 ## 常用命令
 
 ```bash
-npm run build        # 后端类型检查 + 构建前端
-npm run sandbox      # 沙盒模式启动（推荐）
-npm run dev          # 无沙盒启动
-npm run stop         # 停止前后端
-npm run smoke        # 冒烟测试：跑一组预设问题验证 /api/agent 主流程
+npm run sandbox      # 沙盒 worker 模式启动 server 和 client
+npm run dev          # 无沙盒 worker 模式启动 server 和 client
+npm run build        # 后端类型检查 + 前端构建
+npm run lint         # 运行 ESLint
+npm test             # 运行 Vitest 测试
+npm run smoke        # 对运行中的服务执行 Agent 冒烟场景
+npm run stop         # 停止前后端进程
+npm run chrome:mcp   # 启动 Chrome DevTools MCP SSE bridge
 ```
 
-### 冒烟测试 (`npm run smoke`)
+运行 smoke 测试时，先启动 sagent，再在另一个终端执行 `npm run smoke`。报告会写入 `data/smoke-reports/`，失败用例会打印对应的 `data/traces/` 文件路径。
 
-每次功能开发完，先 `npm run dev` 起服务，然后另开终端 `npm run smoke`，会顺序跑 `scripts/smoke-queries.json` 里的预设问题，用 `quality.status` / `quality.reasons` / 工具使用情况做断言，输出控制台表格并把详情写到 `data/smoke-reports/smoke-<时间戳>.json`。
+## 目录结构
 
-- 退出码：`0` 全过 / `1` 有降级警告 / `2` 有失败，便于接 CI
-- 失败时打印对应 `data/traces/<runId>.jsonl` 路径，方便复盘
-- 常用选项：`--only <id1,id2>`、`--category <typical-search|quality-classification|tool-coverage>`、`--model <id>`、`--timeout <ms>`
-
-
-## 多模型 Agent
-
-Agent 每步可并发调用多个模型，取最快结果。
-
-- **竞速模式**：模型按优先级顺序启动。第一个有效结果直接采用，其余取消。
-- **汇总模式**：所有模型同时并发，结果按多数投票聚合。
-- **分批竞速**：`AGENT_BATCH_SIZE` 控制每批启动几个模型。整批全部失败后，下一批跳过延迟立即启动。
-
-前端：Agent 模式下选择多个模型，用箭头调整优先级顺序，切换竞速/汇总策略。
-
-## 跨会话记忆
-
-Agent 自动积累项目经验和对话历史，跨会话持久化。
-
-- **对话记录**：最近 N 次任务的摘要（任务、结果、模型、时间戳）
-- **压缩摘要**：LLM 提炼的历史摘要（去重合并，上限 2000 字）
-- **项目知识**：目录结构、常用路径、用户偏好、经验积累
-
-当对话记录超过 `AGENT_MEMORY_MAX_ENTRIES`（默认 20）时自动触发压缩。
-
-### 记忆面板
-
-点击左侧会话列表顶部的 brain 图标可打开记忆面板 — 它是全局的，不属于任何任务。可以查看对话历史、项目知识、手动触发压缩或清空记忆。
-
-```bash
-AGENT_MEMORY_MAX_ENTRIES=20    # 对话记录压缩阈值
-MEMORY_DIR=data                # 记忆文件存储目录
+```text
+agent/      Agent runtime、供应商、工具、策略、worker
+routes/     Express API 路由
+helpers/    后端共享 helper 和 store
+client/     React/Vite 前端
+scripts/    冒烟测试、停止脚本、Chrome MCP bridge
+test/       Vitest 和集成测试
 ```


### PR DESCRIPTION
## Summary
- rewrite the English and Chinese READMEs as concise project overviews
- move environment variables and runtime settings into CONFIGURATION.md
- document provider, storage, sandbox, IDE MCP, Chrome MCP, and Docker configuration in one place

## Testing
- git diff --check