### PR TITLE
Show first-request context estimate

### DIFF
--- a/agent/core/context-estimate.ts
+++ b/agent/core/context-estimate.ts
@@ -1,0 +1,286 @@
+import {
+  buildClaudeTaskMessages,
+  buildDesktopAgentSystemPrompt,
+  buildGeminiTaskMessages,
+  buildNvidiaTaskMessages,
+} from './prompts.ts';
+import { createModelTools } from './tool-definitions.ts';
+
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const PROMPT_PREVIEW_CHAR_LIMIT = 60_000;
+
+function explicitContextWindow(model: any) {
+  const candidates = [
+    model?.contextWindow,
+    model?.context_window,
+    model?.contextLength,
+    model?.context_length,
+    model?.maxContextTokens,
+    model?.max_context_tokens,
+    model?.inputTokenLimit,
+    model?.input_token_limit,
+  ];
+  for (const value of candidates) {
+    const n = Number(value);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return null;
+}
+
+export function inferContextWindow(modelId = '', modelInfo: any = null) {
+  const explicit = explicitContextWindow(modelInfo);
+  if (explicit) return explicit;
+
+  const id = String(modelId || '').toLowerCase();
+  if (/gemini.*(1\.5|2\.0|2\.5|pro|flash)/.test(id)) return 1_000_000;
+  if (/claude|anthropic/.test(id)) return 200_000;
+  if (/kimi/.test(id)) return 200_000;
+  if (/qwen.*(235|256|480|coder|long)/.test(id)) return 256_000;
+  if (/deepseek/.test(id)) return 128_000;
+  if (/nemotron|llama|mistral|mixtral/.test(id)) return 128_000;
+  return DEFAULT_CONTEXT_WINDOW;
+}
+
+export function estimateTextTokens(text = '') {
+  const value = String(text || '');
+  if (!value) return 0;
+  const cjk = (value.match(/[\u3400-\u9fff\u3040-\u30ff\uac00-\ud7af]/g) || []).length;
+  const asciiLike = value.length - cjk;
+  return Math.max(1, Math.ceil(cjk * 0.75 + asciiLike / 4));
+}
+
+export function estimatePayloadTokens(value: any): number {
+  if (value == null) return 0;
+  if (typeof value === 'string') return estimateTextTokens(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return estimateTextTokens(String(value));
+  if (Array.isArray(value)) {
+    return value.reduce((sum, item) => sum + estimatePayloadTokens(item), 2);
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value).reduce(
+      (sum, [key, item]) => sum + estimateTextTokens(key) + estimatePayloadTokens(item) + 1,
+      2
+    );
+  }
+  return estimateTextTokens(String(value));
+}
+
+export function formatTokenCount(tokens: number) {
+  return String(Math.round(tokens));
+}
+
+export function riskForRatio(ratio: number) {
+  if (ratio >= 0.8) return 'danger';
+  if (ratio >= 0.5) return 'warning';
+  return 'ok';
+}
+
+function formatPromptValue(value: any) {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function appendPromptSection(parts: string[], title: string, value: any) {
+  if (value == null) return;
+  parts.push(`## ${title}\n${formatPromptValue(value)}`);
+}
+
+function formatPromptMessages(messages: any[]) {
+  return messages.map((message, index) => {
+    const role = String(message?.role || `message ${index + 1}`).toUpperCase();
+    const content = message && Object.prototype.hasOwnProperty.call(message, 'content')
+      ? message.content
+      : message;
+    return `## ${role}\n${formatPromptValue(content)}`;
+  }).join('\n\n');
+}
+
+function formatGeminiContents(contents: any[]) {
+  return contents.map((content, index) => {
+    const role = String(content?.role || `content ${index + 1}`).toUpperCase();
+    return `## ${role}\n${formatPromptValue(content?.parts ?? content)}`;
+  }).join('\n\n');
+}
+
+export function buildPromptPreview({
+  payload,
+  modelId,
+  providerName,
+  usedTokens,
+}: {
+  payload: any;
+  modelId: string;
+  providerName: string;
+  usedTokens: number;
+}) {
+  const sections: string[] = [];
+  appendPromptSection(sections, 'MODEL', `${modelId} (${providerName})`);
+  appendPromptSection(sections, 'SYSTEM', payload?.system);
+  appendPromptSection(sections, 'SYSTEM INSTRUCTION', payload?.systemInstruction);
+  if (Array.isArray(payload?.messages)) sections.push(formatPromptMessages(payload.messages));
+  if (Array.isArray(payload?.contents)) sections.push(formatGeminiContents(payload.contents));
+  appendPromptSection(sections, 'TOOLS', payload?.tools);
+  appendPromptSection(sections, 'TOOL CONFIG', payload?.toolConfig);
+
+  const handled = new Set(['system', 'systemInstruction', 'messages', 'contents', 'tools', 'toolConfig']);
+  for (const [key, value] of Object.entries(payload || {})) {
+    if (!handled.has(key)) appendPromptSection(sections, key.toUpperCase(), value);
+  }
+
+  const text = sections.filter(Boolean).join('\n\n');
+  const truncated = text.length > PROMPT_PREVIEW_CHAR_LIMIT;
+  return {
+    modelId,
+    provider: providerName,
+    usedTokens,
+    chars: text.length,
+    truncated,
+    text: truncated ? text.slice(0, PROMPT_PREVIEW_CHAR_LIMIT) : text,
+  };
+}
+
+export function buildInitialPlanningObservation(projectRoot?: string | null) {
+  const cwd = projectRoot || process.cwd();
+  return {
+    desktop: { frontmostApp: '', frontmostWindowTitle: '', windows: [] },
+    browser: null,
+    filesystem: {
+      cwd,
+      note: '当前工作目录;仅当任务确需读写文件时才使用 fs 工具',
+    },
+    terminal: {
+      cwd,
+      note: 'run_safe 仅允许运行只读命令',
+    },
+    title: 'Desktop',
+    url: '',
+    text: '',
+    elements: [],
+  };
+}
+
+function buildPlanningPayload({
+  providerName,
+  task,
+  systemPrompt,
+  conversationHistory,
+  projectRoot,
+}: {
+  providerName: string;
+  task: string;
+  systemPrompt?: string | null;
+  conversationHistory?: Array<{ role: string; content: string }>;
+  projectRoot?: string | null;
+}) {
+  const baseContext = {
+    task,
+    systemPrompt,
+    step: 1,
+    history: [],
+    observation: buildInitialPlanningObservation(projectRoot),
+    conversationHistory,
+  };
+
+  if (providerName === 'anthropic') {
+    return {
+      system: buildDesktopAgentSystemPrompt(systemPrompt || ''),
+      messages: buildClaudeTaskMessages(baseContext),
+      tools: createModelTools(),
+    };
+  }
+
+  if (providerName === 'gemini') {
+    const { contents } = buildGeminiTaskMessages(baseContext);
+    return {
+      systemInstruction: buildDesktopAgentSystemPrompt(systemPrompt || ''),
+      contents,
+      tools: createModelTools(),
+      toolConfig: { functionCallingConfig: { mode: 'ANY' } },
+    };
+  }
+
+  return {
+    messages: buildNvidiaTaskMessages(baseContext),
+  };
+}
+
+export function buildModelContextEstimate({
+  modelId,
+  modelInfo,
+  providerName,
+  task,
+  systemPrompt,
+  conversationHistory,
+  projectRoot,
+}: {
+  modelId: string;
+  modelInfo?: any;
+  providerName: string;
+  task: string;
+  systemPrompt?: string | null;
+  conversationHistory?: Array<{ role: string; content: string }>;
+  projectRoot?: string | null;
+}) {
+  const payload = buildPlanningPayload({
+    providerName,
+    task,
+    systemPrompt,
+    conversationHistory,
+    projectRoot,
+  });
+  const usedTokens = estimatePayloadTokens(payload);
+  const windowTokens = inferContextWindow(modelId, modelInfo);
+  const ratio = windowTokens > 0 ? Math.min(1, usedTokens / windowTokens) : 0;
+  const promptPreview = buildPromptPreview({ payload, modelId, providerName, usedTokens });
+
+  return {
+    modelId,
+    provider: providerName,
+    usedTokens,
+    windowTokens,
+    ratio,
+    percent: Math.round(ratio * 100),
+    risk: riskForRatio(ratio),
+    promptPreview,
+  };
+}
+
+export function summarizeContextEstimates(modelEstimates: any[]) {
+  const estimates = modelEstimates.length > 0 ? modelEstimates : [{
+    modelId: null,
+    provider: 'unknown',
+    usedTokens: 0,
+    windowTokens: DEFAULT_CONTEXT_WINDOW,
+    ratio: 0,
+    percent: 0,
+    risk: 'ok',
+  }];
+  const max = estimates.reduce((acc, item) => item.ratio > acc.ratio ? item : acc, estimates[0]);
+  const averageRatio = estimates.reduce((sum, item) => sum + item.ratio, 0) / estimates.length;
+  const averageWindowTokens = Math.round(estimates.reduce((sum, item) => sum + item.windowTokens, 0) / estimates.length);
+
+  return {
+    source: 'server_actual_prompt',
+    usedTokens: max.usedTokens,
+    max,
+    average: {
+      windowTokens: averageWindowTokens,
+      ratio: averageRatio,
+      percent: Math.round(averageRatio * 100),
+      risk: riskForRatio(averageRatio),
+    },
+    modelCount: estimates.length,
+    modelEstimates: estimates,
+    promptPreview: max.promptPreview || null,
+    risk: max.risk,
+    percent: max.percent,
+    ratio: max.ratio,
+    usedLabel: formatTokenCount(max.usedTokens),
+    maxWindowLabel: formatTokenCount(max.windowTokens),
+    averageWindowLabel: formatTokenCount(averageWindowTokens),
+  };
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -437,52 +437,73 @@ select,
   gap: 8px;
 }
 
-.hero-input-card {
+.agent-composer {
   width: 100%;
-  background: var(--c-surface);
-  border-radius: var(--r-xl);
-  box-shadow: var(--shadow-card);
-  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  border: 1px solid var(--c-border);
 }
 
-.hero-input-card textarea {
+.agent-composer textarea {
+  width: 100%;
+  resize: none;
   border: none;
   outline: none;
-  resize: none;
-  font-size: 16px;
-  padding: 8px 4px;
   line-height: 1.5;
-  min-height: 56px;
+  overflow-y: auto;
   background: transparent;
   color: var(--c-text);
 }
 
-.hero-input-card textarea:focus {
+.agent-composer textarea:focus,
+.agent-composer textarea:focus-visible {
   border: none;
-}
-
-.hero-input-card textarea:focus-visible {
   outline: none;
+  box-shadow: none;
 }
 
-.hero-input-card textarea:disabled {
+.agent-composer textarea:disabled {
+  background: transparent;
   color: var(--c-text-hint);
+  cursor: not-allowed;
 }
 
-.hero-toolbar {
+.agent-composer-toolbar {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
+}
+
+.agent-composer-context {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.agent-composer--hero {
+  background: var(--c-surface);
+  border-radius: var(--r-xl);
+  box-shadow: var(--shadow-card);
+  padding: 16px;
+  gap: 12px;
+  border: 1px solid var(--c-border);
+}
+
+.agent-composer--hero textarea {
+  font-size: 16px;
+  padding: 8px 4px;
+  min-height: 56px;
+  max-height: 220px;
+}
+
+.agent-composer--hero .agent-composer-toolbar {
   gap: 8px;
   padding-top: 12px;
   border-top: 1px solid var(--c-border);
 }
-.hero-toolbar .model-dropdown-trigger,
-.hero-toolbar .attach-btn,
-.hero-toolbar .send-btn {
+.agent-composer--hero .model-dropdown-trigger,
+.agent-composer--hero .attach-btn,
+.agent-composer--hero .send-btn {
   height: 34px;
   border-radius: var(--r-sm);
   border: 1px solid var(--c-border);
@@ -491,47 +512,47 @@ select,
   box-shadow: none;
   transition: background var(--ease), border-color var(--ease), color var(--ease), transform var(--ease);
 }
-.hero-toolbar .model-dropdown-trigger,
-.hero-toolbar .attach-btn,
-.hero-toolbar .send-btn {
+.agent-composer--hero .model-dropdown-trigger,
+.agent-composer--hero .attach-btn,
+.agent-composer--hero .send-btn {
   padding: 0 12px;
 }
-.hero-toolbar .model-dropdown-trigger {
+.agent-composer--hero .model-dropdown-trigger {
   max-width: 230px;
   gap: 6px;
 }
-.hero-toolbar .attach-btn {
+.agent-composer--hero .attach-btn {
   font-size: var(--f-sm);
 }
-.hero-toolbar .send-btn.idle {
+.agent-composer--hero .send-btn.idle {
   border-color: var(--c-primary);
   background: var(--c-primary);
   color: var(--c-on-accent);
 }
-.hero-toolbar .send-btn.stop {
+.agent-composer--hero .send-btn.stop {
   border-color: var(--c-danger);
   background: var(--c-surface);
   color: var(--c-danger);
 }
-.hero-toolbar .model-dropdown-trigger:hover:not(:disabled),
-.hero-toolbar .attach-btn:hover:not(:disabled) {
+.agent-composer--hero .model-dropdown-trigger:hover:not(:disabled),
+.agent-composer--hero .attach-btn:hover:not(:disabled) {
   border-color: var(--c-primary-light);
   background: var(--c-primary-bg);
   color: var(--c-primary);
 }
-.hero-toolbar .send-btn.idle:hover:not(:disabled) {
+.agent-composer--hero .send-btn.idle:hover:not(:disabled) {
   filter: brightness(0.96);
 }
-.hero-toolbar .send-btn.stop:hover:not(:disabled) {
+.agent-composer--hero .send-btn.stop:hover:not(:disabled) {
   background: var(--c-danger-bg);
 }
-.hero-toolbar .model-dropdown-trigger:disabled,
-.hero-toolbar .attach-btn:disabled,
-.hero-toolbar .send-btn:disabled {
+.agent-composer--hero .model-dropdown-trigger:disabled,
+.agent-composer--hero .attach-btn:disabled,
+.agent-composer--hero .send-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
-.hero-toolbar .send-btn.idle:disabled {
+.agent-composer--hero .send-btn.idle:disabled {
   border-color: var(--c-border);
   background: var(--c-surface-dim);
   color: var(--c-text-hint);
@@ -3517,30 +3538,149 @@ select,
   margin-top: auto;
 }
 
-.input-card {
-  display: flex;
-  flex-direction: column;
+.agent-composer--dock {
   background: var(--c-input-bg);
   backdrop-filter: blur(16px) saturate(1.4);
   -webkit-backdrop-filter: blur(16px) saturate(1.4);
   border: 1px solid var(--c-input-border);
   border-radius: 18px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
-  overflow: hidden;
+  overflow: visible;
   transition: border-color var(--ease), box-shadow var(--ease);
 }
 
-.input-card:focus-within {
+.agent-composer--dock:focus-within {
   border-color: rgba(83, 74, 183, 0.25);
   box-shadow: 0 0 0 3px rgba(124, 110, 240, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04);
 }
 
-.input-toolbar {
-  display: flex;
-  align-items: center;
+.agent-composer--dock .agent-composer-toolbar {
   gap: 6px;
   padding: 4px 8px 6px;
-  flex-shrink: 0;
+}
+
+.context-meter {
+  --context-color: #16a34a;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+  color: var(--c-text-muted);
+  font-size: 10px;
+}
+
+.agent-composer--hero .context-meter {
+  padding: 0;
+}
+
+.agent-composer--dock .context-meter {
+  padding: 0;
+}
+
+.context-meter.warning { --context-color: #d97706; }
+.context-meter.danger { --context-color: var(--c-danger); }
+
+.context-meter-head,
+.context-meter-sub {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+  min-width: 0;
+}
+
+.context-meter-title {
+  color: var(--c-text-hint);
+  font-weight: 500;
+}
+
+.context-meter-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--c-text-hint);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.context-meter-track {
+  display: none;
+}
+
+.context-meter-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--context-color);
+  transition: width var(--ease), background var(--ease);
+}
+
+.context-meter-sub {
+  display: none;
+  margin-top: 3px;
+  color: var(--c-text-hint);
+  font-size: 9px;
+}
+
+.context-prompt-details {
+  position: relative;
+  flex: 0 0 auto;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
+}
+
+.context-prompt-summary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 24px;
+  padding: 0 6px;
+  color: var(--c-text-hint);
+  cursor: pointer;
+  list-style: none;
+}
+
+.context-prompt-summary::-webkit-details-marker {
+  display: none;
+}
+
+.context-prompt-summary span:first-child {
+  font-weight: 500;
+}
+
+.context-prompt-summary span:last-child {
+  display: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.context-prompt-details:hover,
+.context-prompt-details[open] {
+  border-color: var(--c-border);
+  background: var(--c-surface);
+}
+
+.context-prompt-text {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  z-index: 20;
+  width: min(720px, calc(100vw - 32px));
+  max-height: 260px;
+  margin: 0;
+  padding: 8px;
+  overflow: auto;
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-sm);
+  box-shadow: var(--shadow-lg);
+  background: var(--c-surface-dim);
+  color: var(--c-text);
+  font-size: 10px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .toolbar-chip {
@@ -3593,6 +3733,7 @@ textarea:disabled {
 }
 
 .send-btn {
+  --send-risk-color: #16a34a;
   flex-shrink: 0;
   height: 32px;
   padding: 0 16px;
@@ -3607,6 +3748,28 @@ textarea:disabled {
   gap: 4px;
 }
 
+.send-btn.context-warning { --send-risk-color: #d97706; }
+.send-btn.context-danger { --send-risk-color: var(--c-danger); }
+
+.send-progress-ring {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  margin-left: -6px;
+  border-radius: 50%;
+  color: inherit;
+  background:
+    radial-gradient(circle at center, currentColor 0 58%, transparent 59%),
+    conic-gradient(var(--send-risk-color) var(--send-context-progress, 0%), rgba(255, 255, 255, 0.35) 0);
+}
+
+.send-btn.idle .send-progress-ring svg {
+  color: var(--c-primary);
+  stroke-width: 2.4;
+}
+
 .send-btn.idle {
   background: var(--c-primary);
   color: var(--c-on-accent);
@@ -3615,6 +3778,10 @@ textarea:disabled {
 .send-btn.idle:disabled {
   background: var(--c-border-input);
   cursor: not-allowed;
+}
+
+.send-btn.idle:disabled .send-progress-ring svg {
+  color: var(--c-text-hint);
 }
 
 .send-btn.stop {
@@ -4720,7 +4887,7 @@ textarea:disabled {
     padding: 8px 12px;
   }
 
-  .input-card {
+  .agent-composer--dock {
     border-radius: 14px;
   }
 
@@ -4741,12 +4908,12 @@ textarea:disabled {
 }
 
 @media (max-width: 480px) {
-  .hero-input-card {
+  .agent-composer--hero {
     padding: 10px;
     gap: 8px;
   }
 
-  .hero-toolbar {
+  .agent-composer--hero .agent-composer-toolbar {
     flex-wrap: wrap;
   }
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,6 +20,7 @@ import { ModelSelector } from './components/ModelSelector.jsx';
 import { SendButton } from './components/SendButton.jsx';
 import { AttachButton } from './components/AttachButton.jsx';
 import { AttachmentBar } from './components/AttachmentBar.jsx';
+import { ContextMeter } from './components/ContextMeter.jsx';
 import { NotificationBanner } from './components/NotificationBanner.jsx';
 import { AppHeader } from './components/AppHeader.jsx';
 import { HeroScreen } from './components/HeroScreen.jsx';
@@ -50,6 +51,7 @@ import { formatMsgTime } from './utils/format.js';
 import { shuffled } from './utils/random.js';
 import { hasThinkContent } from './utils/markdown.js';
 import { appendUniqueTraceEvent } from './utils/agent-trace.js';
+import { buildActualContextEstimate } from './utils/context-usage.js';
 
 // 稳定的空数组:作为 useProjectScopedState 的 initialValue,scope 缺省时返回同一引用,避免无谓重渲染。
 const EMPTY_AGENT_MODELS = [];
@@ -121,6 +123,7 @@ export default function App() {
   // 避免启动阶段误清理用户已选的多模型。
   const [modelsLoaded, setModelsLoaded] = useState(false);
   const [input, setInput] = useState('');
+  const [contextEstimate, setContextEstimate] = useState(null);
   const mode = 'agent';
   const [suggestionSeed, setSuggestionSeed] = useState(0);
   const [suggestionData, setSuggestionData] = useState(EMPTY_SUGGESTIONS);
@@ -806,6 +809,56 @@ export default function App() {
       sessionLocked={sessionLocked}
     />
   );
+  const contextInputText = useMemo(
+    () => buildTaskWithAttachments(input, attachments.filter(item => item.status === 'ready'), t),
+    [attachments, input, t]
+  );
+
+  useEffect(() => {
+    if (selectedAgentModels.length === 0) {
+      setContextEstimate(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      apiFetch('/api/agent/context', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: controller.signal,
+        body: JSON.stringify({
+          task: contextInputText,
+          model: selectedAgentModels[0],
+          models: selectedAgentModels,
+          strategy: selectedAgentModels.length > 1 ? agentStrategy : 'race',
+          memory: agentMemory,
+          projectId: activeProjectId ?? null,
+          messages: messages.slice(-10).map(message => ({ role: message.role, content: message.content })),
+        }),
+      })
+        .then(res => res.ok ? res.json() : null)
+        .then(data => {
+          if (!controller.signal.aborted) setContextEstimate(data);
+        })
+        .catch(err => {
+          if (err?.name !== 'AbortError') setContextEstimate(null);
+        });
+    }, 250);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [activeProjectId, agentMemory, agentStrategy, contextInputText, messages, selectedAgentModels]);
+
+  const actualContextEstimate = useMemo(
+    () => buildActualContextEstimate(agentTrace, contextEstimate),
+    [agentTrace, contextEstimate]
+  );
+  const visibleContextEstimate = agentRunning && actualContextEstimate
+    ? actualContextEstimate
+    : contextEstimate;
+  const contextMeter = <ContextMeter estimate={visibleContextEstimate} />;
   const sendButton = (
     <SendButton
       agentRunning={agentRunning}
@@ -815,6 +868,7 @@ export default function App() {
       inputValue={attachmentsUploading ? '' : (input || (hasReadyAttachments ? ' ' : ''))}
       // 一个模型都没选时禁止发送,并给出原因提示。
       blockReason={selectedAgentModels.length === 0 ? t('send.needModel') : ''}
+      contextEstimate={visibleContextEstimate}
       onSend={handleSubmit}
       onStopAgent={stopAgent}
     />
@@ -896,6 +950,7 @@ export default function App() {
           sessionLocked={sessionLocked}
           toolbarSlots={{ modelSelect, sendButton, attachButton }}
           attachmentBar={attachmentBar}
+          contextMeter={contextMeter}
           suggestions={suggestions}
           categories={agentCategories}
           activeCategoryId={activeCategoryId}
@@ -970,6 +1025,7 @@ export default function App() {
               sendButton={sendButton}
               attachButton={attachButton}
               attachmentBar={attachmentBar}
+              contextMeter={contextMeter}
               touchStartRef={touchStartRef}
               agentMobileTab={agentMobileTab}
               setAgentMobileTab={setAgentMobileTab}

--- a/client/src/components/AgentComposer.jsx
+++ b/client/src/components/AgentComposer.jsx
@@ -1,0 +1,40 @@
+export function AgentComposer({
+  variant = 'dock',
+  value,
+  setValue,
+  textareaRef,
+  onKeyDown,
+  placeholder,
+  rows = 1,
+  disabled = false,
+  modelSelect = null,
+  attachButton = null,
+  sendButton = null,
+  attachmentBar = null,
+  contextMeter = null,
+}) {
+  const hasToolbar = Boolean(modelSelect || attachButton || contextMeter || sendButton);
+
+  return (
+    <div className={`agent-composer agent-composer--${variant}`}>
+      {attachmentBar}
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={event => setValue(event.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        rows={rows}
+        disabled={disabled}
+      />
+      {hasToolbar && (
+        <div className="agent-composer-toolbar">
+          {modelSelect}
+          {attachButton}
+          {contextMeter && <div className="agent-composer-context">{contextMeter}</div>}
+          {sendButton}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ChatPane.jsx
+++ b/client/src/components/ChatPane.jsx
@@ -1,3 +1,5 @@
+import { AgentComposer } from './AgentComposer.jsx';
+
 function formatMessageModels(message, getModelLabel) {
   const ids = Array.isArray(message.modelsUsed) && message.modelsUsed.length > 0
     ? message.modelsUsed
@@ -25,6 +27,7 @@ export function ChatPane({
   sendButton,
   attachButton,
   attachmentBar,
+  contextMeter,
   touchStartRef,
   agentMobileTab,
   setAgentMobileTab,
@@ -78,22 +81,20 @@ export function ChatPane({
         })}
         <div ref={bottomRef} />
         <div className="input-area">
-          <div className="input-card">
-            {attachmentBar}
-            <textarea
-              ref={textareaRef}
-              value={inputValue}
-              onChange={event => setInput(event.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={placeholder}
-              rows={1}
-              disabled={disabled}
-            />
-            <div className="input-toolbar">
-              {attachButton}
-              {sendButton}
-            </div>
-          </div>
+          <AgentComposer
+            variant="dock"
+            value={inputValue}
+            setValue={setInput}
+            textareaRef={textareaRef}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            rows={1}
+            disabled={disabled}
+            attachButton={attachButton}
+            sendButton={sendButton}
+            attachmentBar={attachmentBar}
+            contextMeter={contextMeter}
+          />
         </div>
       </div>
     </div>

--- a/client/src/components/ContextMeter.jsx
+++ b/client/src/components/ContextMeter.jsx
@@ -1,0 +1,49 @@
+import { useT } from '../i18n/I18nProvider.jsx';
+
+export function ContextMeter({ estimate }) {
+  const t = useT();
+  if (!estimate) return null;
+
+  const percent = Math.max(0, Math.min(100, estimate.percent || 0));
+  const averagePercent = Math.max(0, Math.min(100, estimate.average?.percent || 0));
+  const showAverage = estimate.modelCount > 1;
+  const actual = estimate.source === 'actual_prompt_usage';
+  const promptPreview = estimate.promptPreview;
+  const promptText = promptPreview?.text
+    ? `${promptPreview.text}${promptPreview.truncated ? `\n\n${t('context.promptTruncated', { chars: promptPreview.chars })}` : ''}`
+    : '';
+
+  return (
+    <div className={`context-meter ${estimate.risk}${actual ? ' actual' : ''}`} aria-label={t(actual ? 'context.actualLabel' : 'context.label')}>
+      <div className="context-meter-head">
+        <span className="context-meter-title">{t(actual ? 'context.actualLabel' : 'context.label')}</span>
+        <span className="context-meter-value">{t(actual ? 'context.actualSummary' : 'context.summary', {
+          percent,
+          used: estimate.usedLabel,
+          limit: estimate.maxWindowLabel,
+        })}</span>
+      </div>
+      <div className="context-meter-track" aria-hidden="true">
+        <span className="context-meter-fill" style={{ width: `${percent}%` }} />
+      </div>
+      {showAverage && (
+        <div className="context-meter-sub">
+          <span>{t(actual ? 'context.actualMax' : 'context.max', { percent })}</span>
+          <span>{t(actual ? 'context.actualAvg' : 'context.avg', { percent: averagePercent })}</span>
+        </div>
+      )}
+      {promptPreview?.text && (
+        <details className="context-prompt-details">
+          <summary className="context-prompt-summary">
+            <span>{t('context.promptToggle')}</span>
+            <span title={promptPreview.modelId || ''}>{t('context.promptMeta', {
+              model: promptPreview.modelId || '-',
+              used: estimate.usedLabel || promptPreview.usedTokens || '-',
+            })}</span>
+          </summary>
+          <pre className="context-prompt-text">{promptText}</pre>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/HeroScreen.jsx
+++ b/client/src/components/HeroScreen.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Lightbulb } from 'lucide-react';
+import { AgentComposer } from './AgentComposer.jsx';
 import { SuggestionsList } from './SuggestionsList.jsx';
 import { useT } from '../i18n/I18nProvider.jsx';
 
@@ -25,6 +26,7 @@ export function HeroScreen({
   sessionLocked,
   toolbarSlots,
   attachmentBar,
+  contextMeter,
   suggestions,
   categories,
   activeCategoryId,
@@ -54,23 +56,21 @@ export function HeroScreen({
           <span className="hero-brand-name">sagent</span>
         </div>
 
-        <div className="hero-input-card">
-          {attachmentBar}
-          <textarea
-            ref={textareaRef}
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            onKeyDown={onKeyDown}
-            placeholder={t('input.agentPlaceholder')}
-            rows={2}
-            disabled={sessionLocked}
-          />
-          <div className="hero-toolbar">
-            {modelSelect}
-            {attachButton}
-            {sendButton}
-          </div>
-        </div>
+        <AgentComposer
+          variant="hero"
+          value={input}
+          setValue={setInput}
+          textareaRef={textareaRef}
+          onKeyDown={onKeyDown}
+          placeholder={t('input.agentPlaceholder')}
+          rows={2}
+          disabled={sessionLocked}
+          modelSelect={modelSelect}
+          attachButton={attachButton}
+          sendButton={sendButton}
+          attachmentBar={attachmentBar}
+          contextMeter={contextMeter}
+        />
 
         {suggestionsHidden ? (
           <button className="suggestions-show" onClick={showSuggestions} title={t('suggestions.show')}>

--- a/client/src/components/SendButton.jsx
+++ b/client/src/components/SendButton.jsx
@@ -8,10 +8,13 @@ export function SendButton({
   pendingApproval,
   inputValue,
   blockReason,
+  contextEstimate,
   onSend,
   onStopAgent,
 }) {
   const t = useT();
+  const contextPercent = Math.max(0, Math.min(100, contextEstimate?.percent || 0));
+  const contextRisk = contextEstimate?.risk || 'ok';
   if (agentRunning) {
     return (
       <button className="send-btn stop" onClick={onStopAgent} disabled={agentStopping}>
@@ -22,12 +25,16 @@ export function SendButton({
   // blockReason 非空时(例如 agent 模式一个模型都没选)禁用并把原因作为 tooltip。
   return (
     <button
-      className="send-btn idle"
+      className={`send-btn idle context-${contextRisk}`}
       onClick={onSend}
       disabled={!inputValue.trim() || !!blockReason}
       title={blockReason || undefined}
+      style={{ '--send-context-progress': `${contextPercent}%` }}
     >
-      <Send size={14} /> {t('send.send')}
+      <span className="send-progress-ring" aria-hidden="true">
+        <Send size={13} />
+      </span>
+      {t('send.send')}
     </button>
   );
 }

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -53,6 +53,17 @@ export const en = {
 
   // Input box
   'input.agentPlaceholder': 'Describe the task for the Agent…',
+  'context.label': 'Context estimate',
+  'context.actualLabel': 'Actual context',
+  'context.summary': 'First {used}/{limit} tok · {percent}%',
+  'context.actualSummary': 'Actual {used}/{limit} tok · {percent}%',
+  'context.max': 'Max first-request estimate {percent}%',
+  'context.avg': 'Average first-request estimate {percent}%',
+  'context.actualMax': 'Max actual {percent}%',
+  'context.actualAvg': 'Average actual {percent}%',
+  'context.promptToggle': 'First prompt',
+  'context.promptMeta': '{model} · {used} tok',
+  'context.promptTruncated': 'Prompt is long and was truncated; full length {chars} chars.',
 
   // Attachments (task text block + display)
   'attach.taskBlockHeader': '[Attachments]',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -54,6 +54,17 @@ export const zh = {
 
   // 输入框
   'input.agentPlaceholder': '描述要让 Agent 完成的任务…',
+  'context.label': 'Context 预估',
+  'context.actualLabel': 'Context 实际',
+  'context.summary': '首轮 {used}/{limit} tok · {percent}%',
+  'context.actualSummary': '实际 {used}/{limit} tok · {percent}%',
+  'context.max': '最大首轮预估 {percent}%',
+  'context.avg': '平均首轮预估 {percent}%',
+  'context.actualMax': '最大实际 {percent}%',
+  'context.actualAvg': '平均实际 {percent}%',
+  'context.promptToggle': '首轮提示词',
+  'context.promptMeta': '{model} · {used} tok',
+  'context.promptTruncated': '提示词过长，已截断；完整长度 {chars} 字符。',
 
   // 附件（任务文本块 + 展示）
   'attach.taskBlockHeader': '[附件]',

--- a/client/src/utils/context-usage.js
+++ b/client/src/utils/context-usage.js
@@ -1,0 +1,72 @@
+function formatTokenCount(tokens) {
+  return String(Math.round(tokens));
+}
+
+function riskForRatio(ratio) {
+  if (ratio >= 0.8) return 'danger';
+  if (ratio >= 0.5) return 'warning';
+  return 'ok';
+}
+
+export function buildActualContextEstimate(trace = [], estimate = null) {
+  if (!estimate || !Array.isArray(trace)) return null;
+
+  const usageEvents = trace.filter(event =>
+    event?.type === 'model_plan'
+    && ['success', 'winner', 'cancelled'].includes(event.stage)
+    && Number(event.usage?.prompt_tokens) > 0
+  );
+  if (usageEvents.length === 0) return null;
+
+  const firstStep = Math.min(...usageEvents.map(event => Number(event.step)).filter(Number.isFinite));
+  if (!Number.isFinite(firstStep)) return null;
+
+  const baseByModel = new Map((estimate.modelEstimates || []).map(item => [item.modelId, item]));
+  const actualByModel = new Map();
+  for (const event of usageEvents.filter(item => Number(item.step) === firstStep)) {
+    const modelId = event.model || estimate.max?.modelId || null;
+    const promptTokens = Number(event.usage?.prompt_tokens) || 0;
+    const base = baseByModel.get(modelId) || estimate.max || {};
+    const windowTokens = base.windowTokens || estimate.max?.windowTokens || 128_000;
+    const ratio = windowTokens > 0 ? Math.min(1, promptTokens / windowTokens) : 0;
+    actualByModel.set(modelId || 'unknown', {
+      ...base,
+      modelId,
+      usedTokens: promptTokens,
+      windowTokens,
+      ratio,
+      percent: Math.round(ratio * 100),
+      risk: riskForRatio(ratio),
+    });
+  }
+
+  const modelEstimates = [...actualByModel.values()];
+  if (modelEstimates.length === 0) return null;
+
+  const max = modelEstimates.reduce((acc, item) => item.ratio > acc.ratio ? item : acc, modelEstimates[0]);
+  const averageRatio = modelEstimates.reduce((sum, item) => sum + item.ratio, 0) / modelEstimates.length;
+  const averageWindowTokens = Math.round(modelEstimates.reduce((sum, item) => sum + item.windowTokens, 0) / modelEstimates.length);
+
+  return {
+    ...estimate,
+    source: 'actual_prompt_usage',
+    usedTokens: max.usedTokens,
+    max,
+    average: {
+      windowTokens: averageWindowTokens,
+      ratio: averageRatio,
+      percent: Math.round(averageRatio * 100),
+      risk: riskForRatio(averageRatio),
+    },
+    modelCount: modelEstimates.length,
+    modelEstimates,
+    promptPreview: max.promptPreview || estimate.promptPreview || null,
+    risk: max.risk,
+    percent: max.percent,
+    ratio: max.ratio,
+    usedLabel: formatTokenCount(max.usedTokens),
+    maxWindowLabel: formatTokenCount(max.windowTokens),
+    averageWindowLabel: formatTokenCount(averageWindowTokens),
+    actualStep: firstStep,
+  };
+}

--- a/routes/agent-context.ts
+++ b/routes/agent-context.ts
@@ -1,0 +1,83 @@
+import { Router } from 'express';
+import { loadMemoryForPrompt } from '../helpers/run-agent.ts';
+import { resolveRunPaths } from '../agent/core/project-store.ts';
+import {
+  buildModelContextEstimate,
+  summarizeContextEstimates,
+} from '../agent/core/context-estimate.ts';
+import type { AgentRouterContext } from './agent-types.ts';
+
+function uniqueModelIds(value: any) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value
+    .filter(item => typeof item === 'string')
+    .map(item => item.trim())
+    .filter(Boolean))];
+}
+
+function normalizeConversationHistory(value: any) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .slice(-10)
+    .filter(item => item && (item.role === 'user' || item.role === 'assistant') && typeof item.content === 'string')
+    .map(item => ({ role: item.role, content: item.content }));
+}
+
+export function createAgentContextRouter({
+  memoryDir,
+  modelConfig,
+  registry,
+  projectStore,
+}: AgentRouterContext) {
+  const router = Router();
+
+  router.post('/api/agent/context', async (req, res) => {
+    const {
+      task = '',
+      model,
+      models: reqModels,
+      memory: useMemory = true,
+      messages,
+      projectId,
+    } = req.body ?? {};
+
+    const requestedModel = typeof model === 'string' && model.trim() ? model.trim() : null;
+    const agentModels = uniqueModelIds(reqModels);
+    const models = agentModels.length > 0
+      ? agentModels
+      : requestedModel
+        ? [requestedModel]
+        : [];
+
+    if (models.length === 0) {
+      return res.status(400).json({ error: 'model is required' });
+    }
+
+    const { projectRoot, dataDir } = resolveRunPaths(
+      projectStore,
+      typeof projectId === 'string' && projectId.trim() ? projectId : null,
+      memoryDir
+    );
+    const loaded = useMemory ? await loadMemoryForPrompt(dataDir) : { systemPrompt: '' };
+    const conversationHistory = normalizeConversationHistory(messages);
+    const normalizedTask = typeof task === 'string' ? task : String(task || '');
+
+    const estimates = models.map(modelId => {
+      const provider = registry.resolve(modelId, modelConfig);
+      const modelInfo = modelConfig.find(item => item.id === modelId) || null;
+      return buildModelContextEstimate({
+        modelId,
+        modelInfo,
+        providerName: provider.name,
+        task: normalizedTask,
+        systemPrompt: loaded.systemPrompt,
+        conversationHistory,
+        projectRoot,
+      });
+    });
+
+    return res.json(summarizeContextEstimates(estimates));
+  });
+
+  return router;
+}

--- a/routes/agent.ts
+++ b/routes/agent.ts
@@ -20,6 +20,7 @@ import { createAgentTraceRouter } from './agent-traces.ts';
 import { createAgentUploadsRouter } from './agent-uploads.ts';
 import { createAgentProjectsRouter } from './agent-projects.ts';
 import { createAgentCodegraphRouter } from './agent-codegraph.ts';
+import { createAgentContextRouter } from './agent-context.ts';
 import type { AgentRouterContext } from './agent-types.ts';
 
 export function createAgentRouter(context: AgentRouterContext) {
@@ -35,6 +36,7 @@ export function createAgentRouter(context: AgentRouterContext) {
   router.use(createAgentUploadsRouter(context));
   router.use(createAgentProjectsRouter(context));
   router.use(createAgentCodegraphRouter(context));
+  router.use(createAgentContextRouter(context));
 
   return router;
 }

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -164,6 +164,29 @@ describe('POST /api/agent', () => {
   });
 });
 
+describe('POST /api/agent/context', () => {
+  it('returns context usage based on the server-built agent prompt', async () => {
+    const res = await request(app)
+      .post('/api/agent/context')
+      .send({
+        task: 'inspect the repo',
+        model: 'test-model',
+        models: ['test-model'],
+        memory: false,
+        messages: [{ role: 'user', content: 'previous message' }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.source).toBe('server_actual_prompt');
+    expect(res.body.usedTokens).toBeGreaterThan(0);
+    expect(res.body.max.modelId).toBe('test-model');
+    expect(res.body.usedLabel).toBeTruthy();
+    expect(res.body.promptPreview.modelId).toBe('test-model');
+    expect(res.body.promptPreview.text).toContain('inspect the repo');
+    expect(res.body.promptPreview.text).toContain('previous message');
+  });
+});
+
 describe('GET /api/agent/stream/:runId', () => {
   it('replays pending approval details for reconnect streams', async () => {
     const run = agentRunStore.createRun({

--- a/test/context-estimate.test.js
+++ b/test/context-estimate.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildModelContextEstimate,
+  estimateTextTokens,
+  formatTokenCount,
+  inferContextWindow,
+  summarizeContextEstimates,
+} from '../agent/core/context-estimate.ts';
+
+describe('context estimate', () => {
+  it('infers common context windows from model ids', () => {
+    expect(inferContextWindow('deepseek-ai/deepseek-v4-flash')).toBe(128_000);
+    expect(inferContextWindow('anthropic/claude-sonnet-4')).toBe(200_000);
+    expect(inferContextWindow('google/gemini-2.5-pro')).toBe(1_000_000);
+  });
+
+  it('uses explicit model metadata before id heuristics', () => {
+    expect(inferContextWindow('unknown/model', { context_length: 64_000 })).toBe(64_000);
+  });
+
+  it('estimates mixed language text tokens', () => {
+    expect(estimateTextTokens('hello world')).toBeGreaterThan(0);
+    expect(estimateTextTokens('你好，世界')).toBeGreaterThan(0);
+  });
+
+  it('formats token counts as exact integers', () => {
+    expect(formatTokenCount(2634)).toBe('2634');
+    expect(formatTokenCount(128_000)).toBe('128000');
+  });
+
+  it('counts the actual provider planning payload instead of a fixed frontend overhead', () => {
+    const base = buildModelContextEstimate({
+      modelId: 'deepseek-ai/deepseek-v4-flash',
+      modelInfo: { id: 'deepseek-ai/deepseek-v4-flash' },
+      providerName: 'openai-compat',
+      task: 'read the repo',
+      systemPrompt: '',
+      conversationHistory: [],
+    });
+
+    const withMemory = buildModelContextEstimate({
+      modelId: 'deepseek-ai/deepseek-v4-flash',
+      modelInfo: { id: 'deepseek-ai/deepseek-v4-flash' },
+      providerName: 'openai-compat',
+      task: 'read the repo',
+      systemPrompt: 'project memory '.repeat(200),
+      conversationHistory: [{ role: 'user', content: 'previous context' }],
+    });
+
+    expect(withMemory.usedTokens).toBeGreaterThan(base.usedTokens);
+  });
+
+  it('includes the first planning prompt preview used for the estimate', () => {
+    const estimate = buildModelContextEstimate({
+      modelId: 'deepseek-ai/deepseek-v4-flash',
+      modelInfo: { id: 'deepseek-ai/deepseek-v4-flash' },
+      providerName: 'openai-compat',
+      task: 'inspect the prompt',
+      systemPrompt: 'remember this project',
+      conversationHistory: [{ role: 'user', content: 'previous context' }],
+    });
+
+    expect(estimate.promptPreview.modelId).toBe('deepseek-ai/deepseek-v4-flash');
+    expect(estimate.promptPreview.usedTokens).toBe(estimate.usedTokens);
+    expect(estimate.promptPreview.text).toContain('inspect the prompt');
+    expect(estimate.promptPreview.text).toContain('previous context');
+    expect(estimate.promptPreview.text).toContain('remember this project');
+  });
+
+  it('reports max and average usage for multi-model selections', () => {
+    const small = buildModelContextEstimate({
+      modelId: 'small-model',
+      modelInfo: { context_length: 8_000 },
+      providerName: 'openai-compat',
+      task: 'x'.repeat(20_000),
+      systemPrompt: '',
+      conversationHistory: [],
+    });
+    const large = buildModelContextEstimate({
+      modelId: 'google/gemini-2.5-pro',
+      modelInfo: null,
+      providerName: 'gemini',
+      task: 'x'.repeat(20_000),
+      systemPrompt: '',
+      conversationHistory: [],
+    });
+    const estimate = summarizeContextEstimates([small, large]);
+
+    expect(estimate.modelCount).toBe(2);
+    expect(estimate.max.modelId).toBe('small-model');
+    expect(estimate.promptPreview.modelId).toBe('small-model');
+    expect(estimate.percent).toBeGreaterThan(estimate.average.percent);
+    expect(['warning', 'danger']).toContain(estimate.risk);
+  });
+});

--- a/test/context-usage.test.js
+++ b/test/context-usage.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildActualContextEstimate } from '../client/src/utils/context-usage.js';
+
+describe('context usage', () => {
+  it('builds an actual first-step context estimate from model_plan usage', () => {
+    const estimate = {
+      source: 'server_actual_prompt',
+      max: { modelId: 'model-a', windowTokens: 10_000 },
+      modelEstimates: [
+        { modelId: 'model-a', windowTokens: 10_000, promptPreview: { modelId: 'model-a', text: 'prompt a' } },
+        { modelId: 'model-b', windowTokens: 20_000, promptPreview: { modelId: 'model-b', text: 'prompt b' } },
+      ],
+    };
+    const actual = buildActualContextEstimate([
+      { type: 'model_plan', stage: 'thinking', step: 1, model: 'model-a' },
+      { type: 'model_plan', stage: 'success', step: 1, model: 'model-a', usage: { prompt_tokens: 5_000, completion_tokens: 50 } },
+      { type: 'model_plan', stage: 'success', step: 1, model: 'model-b', usage: { prompt_tokens: 6_000, completion_tokens: 50 } },
+      { type: 'model_plan', stage: 'success', step: 2, model: 'model-a', usage: { prompt_tokens: 9_000, completion_tokens: 50 } },
+    ], estimate);
+
+    expect(actual.source).toBe('actual_prompt_usage');
+    expect(actual.usedTokens).toBe(5_000);
+    expect(actual.percent).toBe(50);
+    expect(actual.modelCount).toBe(2);
+    expect(actual.average.percent).toBe(40);
+    expect(actual.promptPreview.text).toBe('prompt a');
+  });
+
+  it('returns null until prompt usage is available', () => {
+    expect(buildActualContextEstimate([
+      { type: 'model_plan', stage: 'thinking', step: 1, model: 'model-a' },
+    ], { max: { windowTokens: 10_000 } })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a server-side first-request context estimator based on the actual agent planning payload
- show a subtle context/token indicator and expandable first prompt preview in the shared composer
- unify hero and in-chat agent input through AgentComposer

## Tests
- npm run build:client
- npm run typecheck
- npm run lint
- npm test