### PR TITLE
Slim context prompt preview response

### DIFF
--- a/agent/core/context-estimate.ts
+++ b/agent/core/context-estimate.ts
@@ -262,11 +262,16 @@ export function summarizeContextEstimates(modelEstimates: any[]) {
   const max = estimates.reduce((acc, item) => item.ratio > acc.ratio ? item : acc, estimates[0]);
   const averageRatio = estimates.reduce((sum, item) => sum + item.ratio, 0) / estimates.length;
   const averageWindowTokens = Math.round(estimates.reduce((sum, item) => sum + item.windowTokens, 0) / estimates.length);
+  const stripPromptPreview = (estimate: any) => {
+    if (!estimate || typeof estimate !== 'object') return estimate;
+    const { promptPreview, ...rest } = estimate;
+    return rest;
+  };
 
   return {
     source: 'server_actual_prompt',
     usedTokens: max.usedTokens,
-    max,
+    max: stripPromptPreview(max),
     average: {
       windowTokens: averageWindowTokens,
       ratio: averageRatio,
@@ -274,7 +279,7 @@ export function summarizeContextEstimates(modelEstimates: any[]) {
       risk: riskForRatio(averageRatio),
     },
     modelCount: estimates.length,
-    modelEstimates: estimates,
+    modelEstimates: estimates.map(stripPromptPreview),
     promptPreview: max.promptPreview || null,
     risk: max.risk,
     percent: max.percent,

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -184,6 +184,8 @@ describe('POST /api/agent/context', () => {
     expect(res.body.promptPreview.modelId).toBe('test-model');
     expect(res.body.promptPreview.text).toContain('inspect the repo');
     expect(res.body.promptPreview.text).toContain('previous message');
+    expect(res.body.max.promptPreview).toBeUndefined();
+    expect(res.body.modelEstimates.every((item: any) => item.promptPreview == null)).toBe(true);
   });
 });
 

--- a/test/context-estimate.test.js
+++ b/test/context-estimate.test.js
@@ -88,7 +88,9 @@ describe('context estimate', () => {
 
     expect(estimate.modelCount).toBe(2);
     expect(estimate.max.modelId).toBe('small-model');
+    expect(estimate.max.promptPreview).toBeUndefined();
     expect(estimate.promptPreview.modelId).toBe('small-model');
+    expect(estimate.modelEstimates.every(item => item.promptPreview == null)).toBe(true);
     expect(estimate.percent).toBeGreaterThan(estimate.average.percent);
     expect(['warning', 'danger']).toContain(estimate.risk);
   });

--- a/test/context-usage.test.js
+++ b/test/context-usage.test.js
@@ -6,9 +6,10 @@ describe('context usage', () => {
     const estimate = {
       source: 'server_actual_prompt',
       max: { modelId: 'model-a', windowTokens: 10_000 },
+      promptPreview: { modelId: 'model-a', text: 'prompt a' },
       modelEstimates: [
-        { modelId: 'model-a', windowTokens: 10_000, promptPreview: { modelId: 'model-a', text: 'prompt a' } },
-        { modelId: 'model-b', windowTokens: 20_000, promptPreview: { modelId: 'model-b', text: 'prompt b' } },
+        { modelId: 'model-a', windowTokens: 10_000 },
+        { modelId: 'model-b', windowTokens: 20_000 },
       ],
     };
     const actual = buildActualContextEstimate([


### PR DESCRIPTION
## Summary
- keep only the selected top-level prompt preview in context estimate responses
- strip large promptPreview payloads from max and modelEstimates
- update tests to lock the lighter response shape

## Tests
- npm test -- test/context-estimate.test.js test/context-usage.test.js test/agent-api.test.ts
- npm run typecheck
- npm run lint
- npm test