### PR TITLE
Add agent trace debug panel

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2448,6 +2448,159 @@ select,
 
 .agent-token-detail { font-weight: 400; color: var(--c-agent-tokens); }
 
+/* ── Trace Debug Panel ── */
+
+.trace-debug-panel {
+  margin: 8px 0 4px;
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-md);
+  background: var(--c-surface-inline);
+  overflow: hidden;
+}
+
+.trace-debug-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 10px;
+  cursor: pointer;
+  list-style: none;
+  min-height: 34px;
+}
+
+.trace-debug-summary::-webkit-details-marker { display: none; }
+
+.trace-debug-title,
+.trace-debug-summary-meta,
+.trace-debug-bars-head span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.trace-debug-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--c-text);
+}
+
+.trace-debug-summary-meta {
+  font-size: 11px;
+  color: var(--c-text-secondary);
+  white-space: nowrap;
+}
+
+.trace-debug-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1px;
+  border-top: 1px solid var(--c-border);
+  background: var(--c-border);
+}
+
+.trace-debug-metric {
+  min-width: 0;
+  padding: 8px 10px;
+  background: var(--c-surface);
+}
+
+.trace-debug-label {
+  display: block;
+  margin-bottom: 2px;
+  font-size: 10px;
+  color: var(--c-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trace-debug-metric strong {
+  display: block;
+  font-size: 13px;
+  color: var(--c-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trace-debug-metric.ok strong { color: var(--c-badge-done); }
+.trace-debug-metric.warn strong { color: var(--c-badge-error); }
+.trace-debug-metric.tokens strong { color: var(--c-agent-tokens); }
+
+.trace-debug-bars {
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--c-border);
+  background: var(--c-surface);
+}
+
+.trace-debug-bars-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 7px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-text-secondary);
+}
+
+.trace-debug-bar-row {
+  display: grid;
+  grid-template-columns: 28px minmax(80px, 1fr) 44px minmax(42px, auto);
+  align-items: center;
+  gap: 7px;
+  min-height: 20px;
+}
+
+.trace-debug-step,
+.trace-debug-duration,
+.trace-debug-tokens {
+  font-size: 10px;
+  color: var(--c-text-secondary);
+  white-space: nowrap;
+}
+
+.trace-debug-step { font-weight: 700; color: var(--c-text); }
+.trace-debug-duration { text-align: right; }
+.trace-debug-tokens { color: var(--c-agent-tokens); }
+
+.trace-debug-bar-track {
+  height: 7px;
+  border-radius: var(--r-pill);
+  background: var(--c-surface-inline);
+  overflow: hidden;
+}
+
+.trace-debug-bar {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--c-badge-done);
+}
+
+.trace-debug-bar.normal { background: var(--c-badge-approval); }
+.trace-debug-bar.slow,
+.trace-debug-bar.failed { background: var(--c-badge-error); }
+.trace-debug-bar.running { background: var(--c-agent-timer); }
+
+@media (max-width: 720px) {
+  .trace-debug-summary {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .trace-debug-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .trace-debug-bar-row {
+    grid-template-columns: 26px minmax(60px, 1fr) 42px;
+  }
+
+  .trace-debug-tokens { display: none; }
+}
+
 /* ── Agent Trace ── */
 
 .agent-trace {

--- a/client/src/components/agent/AgentPanel.jsx
+++ b/client/src/components/agent/AgentPanel.jsx
@@ -9,6 +9,7 @@ import { ElapsedTimer } from './ElapsedTimer.jsx';
 import { TraceItem } from './TraceItem.jsx';
 import { StepCard } from './StepCard.jsx';
 import { computeTraceMetrics } from './trace-metrics.js';
+import { TraceDebugPanel } from './TraceDebugPanel.jsx';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { useT } from '../../i18n/I18nProvider.jsx';
 
@@ -166,6 +167,8 @@ export function AgentPanel({ running, trace, startedAt, modelList, collapsed, on
           <p className="agent-panel-note">
             {t('agentPanel.note')}
           </p>
+
+          {trace.length > 0 && <TraceDebugPanel metrics={metrics} t={t} />}
 
               {trace.length === 0 && running ? (
                 <div className="agent-skeleton">

--- a/client/src/components/agent/TraceDebugPanel.jsx
+++ b/client/src/components/agent/TraceDebugPanel.jsx
@@ -1,0 +1,73 @@
+import { Activity, BarChart3 } from 'lucide-react';
+import { formatDurationMs, formatTokenCount } from './trace-metrics.js';
+
+function formatRate(value) {
+  if (value == null) return '--';
+  return `${Math.round(value * 100)}%`;
+}
+
+function MetricCell({ label, value, tone }) {
+  return (
+    <div className={`trace-debug-metric${tone ? ` ${tone}` : ''}`}>
+      <span className="trace-debug-label">{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+export function TraceDebugPanel({ metrics, t }) {
+  const steps = metrics.stepDurations || [];
+  const visibleSteps = steps.slice(-12);
+  const maxDuration = Math.max(1, ...visibleSteps.map(step => step.durationMs || 0));
+  const slowest = metrics.slowestStep;
+
+  return (
+    <details className="trace-debug-panel">
+      <summary className="trace-debug-summary">
+        <span className="trace-debug-title">
+          <Activity size={13} />
+          {t('agentPanel.traceDebug')}
+        </span>
+        <span className="trace-debug-summary-meta">
+          {t('agentPanel.traceDebugMeta', {
+            llm: metrics.llmCalls,
+            tools: metrics.completedToolCalls,
+          })}
+        </span>
+      </summary>
+
+      <div className="trace-debug-grid">
+        <MetricCell label={t('agentPanel.metricLlmCalls')} value={metrics.llmCalls} />
+        <MetricCell label={t('agentPanel.metricTokens')} value={formatTokenCount(metrics.totalTokens)} tone="tokens" />
+        <MetricCell label={t('agentPanel.metricToolSuccess')} value={formatRate(metrics.toolSuccessRate)} tone={metrics.toolFailures > 0 ? 'warn' : 'ok'} />
+        <MetricCell label={t('agentPanel.metricAvgStep')} value={formatDurationMs(metrics.avgStepMs)} />
+        <MetricCell label={t('agentPanel.metricSlowestStep')} value={slowest ? `Step ${slowest.step} · ${formatDurationMs(slowest.durationMs)}` : '--'} tone={slowest?.status === 'failed' || slowest?.status === 'slow' ? 'warn' : ''} />
+      </div>
+
+      {visibleSteps.length > 0 && (
+        <div className="trace-debug-bars" aria-label={t('agentPanel.stepLatency')}>
+          <div className="trace-debug-bars-head">
+            <span>
+              <BarChart3 size={12} />
+              {t('agentPanel.stepLatency')}
+            </span>
+            <span>{formatDurationMs(metrics.totalDurationMs)}</span>
+          </div>
+          {visibleSteps.map(step => (
+            <div className="trace-debug-bar-row" key={step.step}>
+              <span className="trace-debug-step">S{step.step}</span>
+              <div className="trace-debug-bar-track">
+                <span
+                  className={`trace-debug-bar ${step.status}`}
+                  style={{ width: `${Math.max(4, Math.round((step.durationMs / maxDuration) * 100))}%` }}
+                />
+              </div>
+              <span className="trace-debug-duration">{formatDurationMs(step.durationMs)}</span>
+              {step.tokens > 0 && <span className="trace-debug-tokens">{formatTokenCount(step.tokens)} tok</span>}
+            </div>
+          ))}
+        </div>
+      )}
+    </details>
+  );
+}

--- a/client/src/components/agent/trace-metrics.js
+++ b/client/src/components/agent/trace-metrics.js
@@ -1,3 +1,5 @@
+import { isFailureResult } from './result-status.js';
+
 // 统一的 trace 指标计算：桌面执行面板(AgentPanel)与移动端 tab(AgentPane)共用，
 // 避免两端各算一套导致 token 数对不上。
 //
@@ -15,14 +17,78 @@ function eventTokens(usage) {
   return (usage.prompt_tokens || 0) + (usage.completion_tokens || 0);
 }
 
+function eventTime(event) {
+  const candidates = [event?.end_time, event?.timestamp, event?.time, event?.ts];
+  for (const value of candidates) {
+    if (Number.isFinite(value)) return value;
+    if (typeof value === 'string') {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return null;
+}
+
+function emptyStep(step) {
+  return {
+    step,
+    firstTime: null,
+    lastTime: null,
+    observeTime: null,
+    actionTime: null,
+    resultTime: null,
+    explicitDurationMs: 0,
+    tokens: 0,
+    tool: null,
+    hasAction: false,
+    hasResult: false,
+    failed: false,
+  };
+}
+
+function actionIsToolCall(action) {
+  if (!action || typeof action !== 'object') return false;
+  return !['finish', 'ask_user', 'notify_user'].includes(action.type);
+}
+
 export function computeTraceMetrics(trace) {
   let lastStep = 0;
   let doneStepCount = null;
   const planByStep = new Map();
   const actionByStep = new Map();
+  const steps = new Map();
+  const llmCalls = new Set();
+
+  let firstTraceTime = null;
+  let lastTraceTime = null;
+  let doneElapsedMs = null;
+
+  const getStep = step => {
+    if (!steps.has(step)) steps.set(step, emptyStep(step));
+    return steps.get(step);
+  };
 
   for (const event of trace) {
     if (event.step != null && event.step > lastStep) lastStep = event.step;
+    const ts = eventTime(event);
+    if (ts != null) {
+      firstTraceTime = firstTraceTime == null ? ts : Math.min(firstTraceTime, ts);
+      lastTraceTime = lastTraceTime == null ? ts : Math.max(lastTraceTime, ts);
+      if (event.step != null) {
+        const step = getStep(event.step);
+        step.firstTime = step.firstTime == null ? ts : Math.min(step.firstTime, ts);
+        step.lastTime = step.lastTime == null ? ts : Math.max(step.lastTime, ts);
+        if (event.type === 'step' && event.stage === 'observe') step.observeTime = ts;
+        if (event.type === 'step' && event.stage === 'action') step.actionTime = ts;
+        if (event.type === 'step' && event.stage === 'result') step.resultTime = ts;
+      }
+    }
+
+    if (event.step != null && Number.isFinite(event.duration_ms)) {
+      const step = getStep(event.step);
+      step.explicitDurationMs += Math.max(0, event.duration_ms);
+    }
+
     const tok = eventTokens(event.usage);
     if (tok > 0) {
       if (event.type === 'model_plan') {
@@ -31,20 +97,104 @@ export function computeTraceMetrics(trace) {
         actionByStep.set(event.step, (actionByStep.get(event.step) || 0) + tok);
       }
     }
+    if (event.type === 'model_plan' && ['success', 'winner', 'cancelled', 'failed'].includes(event.stage)) {
+      llmCalls.add(`${event.step ?? ''}:${event.model ?? ''}:${event.stage}`);
+    }
+    if (event.type === 'step' && event.step != null && event.stage === 'action') {
+      const step = getStep(event.step);
+      step.tool = event.action?.tool || step.tool || 'core';
+      step.hasAction = actionIsToolCall(event.action);
+    }
+    if (event.type === 'step' && event.step != null && event.stage === 'result') {
+      const step = getStep(event.step);
+      step.hasResult = true;
+      step.failed = isFailureResult(event.result);
+    }
+    if (event.type === 'done' && Number.isFinite(event.meta?.elapsed_ms)) {
+      doneElapsedMs = event.meta.elapsed_ms;
+    }
     if (event.type === 'done' && event.meta?.step_count != null) {
       doneStepCount = event.meta.step_count;
     }
   }
 
   let totalTokens = 0;
-  const steps = new Set([...planByStep.keys(), ...actionByStep.keys()]);
-  for (const step of steps) {
-    totalTokens += planByStep.has(step) ? planByStep.get(step) : (actionByStep.get(step) || 0);
+  const tokenSteps = new Set([...planByStep.keys(), ...actionByStep.keys()]);
+  for (const step of tokenSteps) {
+    const tokens = planByStep.has(step) ? planByStep.get(step) : (actionByStep.get(step) || 0);
+    totalTokens += tokens;
+    if (step != null) getStep(step).tokens = tokens;
   }
 
-  return { lastStep, totalTokens, stepCount: doneStepCount ?? lastStep };
+  const stepDurations = [...steps.values()]
+    .filter(step => step.step != null)
+    .sort((a, b) => a.step - b.step)
+    .map(step => {
+      const durationMs = step.resultTime != null && step.firstTime != null
+        ? Math.max(0, step.resultTime - step.firstTime)
+        : step.explicitDurationMs || (step.lastTime != null && step.firstTime != null ? Math.max(0, step.lastTime - step.firstTime) : 0);
+      const status = step.failed
+        ? 'failed'
+        : !step.hasResult && step.hasAction
+          ? 'running'
+          : durationMs >= 10000
+            ? 'slow'
+            : durationMs >= 3000
+              ? 'normal'
+              : 'fast';
+      return {
+        step: step.step,
+        durationMs,
+        tokens: step.tokens,
+        tool: step.tool,
+        status,
+        hasResult: step.hasResult,
+      };
+    });
+
+  const completedToolCalls = stepDurations.filter(step => {
+    const source = steps.get(step.step);
+    return source?.hasAction && source?.hasResult;
+  });
+  const toolFailures = completedToolCalls.filter(step => step.status === 'failed').length;
+  const toolSuccesses = completedToolCalls.length - toolFailures;
+  const toolCalls = [...steps.values()].filter(step => step.hasAction).length;
+  const avgStepMs = stepDurations.length > 0
+    ? Math.round(stepDurations.reduce((sum, step) => sum + step.durationMs, 0) / stepDurations.length)
+    : 0;
+  const slowestStep = stepDurations.reduce((slowest, step) => (
+    !slowest || step.durationMs > slowest.durationMs ? step : slowest
+  ), null);
+  const totalDurationMs = doneElapsedMs ?? (
+    firstTraceTime != null && lastTraceTime != null ? Math.max(0, lastTraceTime - firstTraceTime) : 0
+  );
+
+  return {
+    lastStep,
+    totalTokens,
+    stepCount: doneStepCount ?? lastStep,
+    llmCalls: llmCalls.size,
+    toolCalls,
+    completedToolCalls: completedToolCalls.length,
+    toolSuccesses,
+    toolFailures,
+    toolSuccessRate: completedToolCalls.length > 0 ? toolSuccesses / completedToolCalls.length : null,
+    avgStepMs,
+    totalDurationMs,
+    slowestStep,
+    stepDurations,
+  };
 }
 
 export function formatTokenCount(value) {
   return value > 999 ? `${(value / 1000).toFixed(1)}k` : value;
+}
+
+export function formatDurationMs(value) {
+  if (!Number.isFinite(value) || value <= 0) return '0ms';
+  if (value < 1000) return `${Math.round(value)}ms`;
+  if (value < 60000) return `${(value / 1000).toFixed(value < 10000 ? 1 : 0)}s`;
+  const minutes = Math.floor(value / 60000);
+  const seconds = Math.round((value % 60000) / 1000);
+  return `${minutes}m ${seconds}s`;
 }

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -184,6 +184,14 @@ export const en = {
   'agentPanel.rolledBackTo': 'Rolled back to Step {step}',
   'agentPanel.badgeSnapshot': 'Snapshot',
   'agentPanel.snapshotSaved': 'Step {step} health snapshot saved',
+  'agentPanel.traceDebug': 'Trace debug',
+  'agentPanel.traceDebugMeta': '{llm} LLM calls · {tools} tools',
+  'agentPanel.metricLlmCalls': 'LLM calls',
+  'agentPanel.metricTokens': 'Tokens',
+  'agentPanel.metricToolSuccess': 'Tool success',
+  'agentPanel.metricAvgStep': 'Avg step',
+  'agentPanel.metricSlowestStep': 'Slowest',
+  'agentPanel.stepLatency': 'Step latency',
 
   // Model plan cards
   'modelCard.startIn': 'starts in {n}s',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -185,6 +185,14 @@ export const zh = {
   'agentPanel.rolledBackTo': '已回滚到 Step {step}',
   'agentPanel.badgeSnapshot': '快照',
   'agentPanel.snapshotSaved': 'Step {step} 健康快照已保存',
+  'agentPanel.traceDebug': 'Trace 调试',
+  'agentPanel.traceDebugMeta': '{llm} 次 LLM · {tools} 次工具',
+  'agentPanel.metricLlmCalls': 'LLM 调用',
+  'agentPanel.metricTokens': 'Tokens',
+  'agentPanel.metricToolSuccess': '工具成功率',
+  'agentPanel.metricAvgStep': '平均步骤',
+  'agentPanel.metricSlowestStep': '最慢步骤',
+  'agentPanel.stepLatency': '步骤耗时',
 
   // 模型计划卡片
   'modelCard.startIn': '{n}s 后启动',

--- a/helpers/run-agent.ts
+++ b/helpers/run-agent.ts
@@ -14,10 +14,107 @@ import { resetChromeSnapshotState } from '../agent/tools/chrome/execute.ts';
 import { appendTraceEvent } from './trace-store.ts';
 import { log } from './logger.ts';
 
+function spanPart(value: any) {
+  return String(value ?? '')
+    .replace(/[^a-z0-9_-]+/gi, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 80) || 'unknown';
+}
+
+function buildSpanId(payload: any) {
+  if (payload?.span_id) return payload.span_id;
+
+  if (payload?.type === 'step') {
+    return `step_${spanPart(payload.step)}_${spanPart(payload.stage)}`;
+  }
+  if (payload?.type === 'model_plan') {
+    return `step_${spanPart(payload.step)}_plan_${spanPart(payload.stage)}_${spanPart(payload.model || 'group')}`;
+  }
+  if (payload?.type === 'terminal_output') {
+    return `step_${spanPart(payload.step)}_terminal_${spanPart(payload.phase)}_${spanPart(payload.sequence ?? '')}`;
+  }
+  if (payload?.type === 'session_checkpoint') {
+    return `step_${spanPart(payload.step)}_checkpoint`;
+  }
+  return spanPart(payload?.type || 'event');
+}
+
+function buildParentId(payload: any) {
+  if (payload?.parent_id) return payload.parent_id;
+  if (payload?.step == null) return null;
+  if (payload?.type === 'terminal_output') return `step_${spanPart(payload.step)}_execute`;
+  if (payload?.type === 'model_plan') return `step_${spanPart(payload.step)}_observe`;
+  if (payload?.type === 'step' && payload.stage === 'action') return `step_${spanPart(payload.step)}_observe`;
+  if (payload?.type === 'step' && payload.stage === 'result') return `step_${spanPart(payload.step)}_action`;
+  if (payload?.type === 'step') return `step_${spanPart(payload.step)}`;
+  return null;
+}
+
+function buildOperation(payload: any) {
+  if (payload?.operation) return payload.operation;
+  if (payload?.type === 'step') {
+    if (payload.stage === 'result') return 'execute';
+    return payload.stage || 'step';
+  }
+  if (payload?.type === 'model_plan') return 'decide';
+  if (payload?.type === 'terminal_output') return 'terminal';
+  return payload?.type || 'event';
+}
+
 export function createBaseEventSender(runId: string, agentRunStore: any, memoryDir?: string) {
+  const stageTimes = new Map<string, number>();
+  const modelTimes = new Map<string, number>();
+
   return (payload: any) => {
-    agentRunStore.addEvent(runId, payload);
-    const traceWrite = appendTraceEvent(memoryDir, runId, payload).catch((err: any) => {
+    const timestamp = Number.isFinite(payload?.timestamp) ? payload.timestamp : Date.now();
+    const spanId = buildSpanId(payload);
+    const parentId = buildParentId(payload);
+    const event: any = {
+      ...payload,
+      runId: payload?.runId || runId,
+      timestamp,
+      trace_id: payload?.trace_id || runId,
+      span_id: spanId,
+      operation: buildOperation(payload),
+      ...(parentId ? { parent_id: parentId } : {}),
+    };
+
+    if (event.usage) {
+      event.input_tokens = event.input_tokens ?? event.usage.prompt_tokens ?? null;
+      event.output_tokens = event.output_tokens ?? event.usage.completion_tokens ?? event.usage.output_tokens ?? null;
+    }
+
+    if (event.type === 'step' && event.step != null) {
+      const prevStage = event.stage === 'action' ? 'observe' : event.stage === 'result' ? 'action' : null;
+      const prev = prevStage ? stageTimes.get(`${event.step}:${prevStage}`) : null;
+      if (prev != null && timestamp >= prev) {
+        event.start_time = event.start_time || prev;
+        event.end_time = event.end_time || timestamp;
+        event.duration_ms = event.duration_ms ?? (timestamp - prev);
+      }
+      stageTimes.set(`${event.step}:${event.stage}`, timestamp);
+    }
+
+    if (event.type === 'model_plan' && event.step != null) {
+      const modelKey = `${event.step}:${event.model || 'group'}`;
+      if (event.stage === 'start') {
+        stageTimes.set(`${event.step}:plan`, timestamp);
+      }
+      if (event.stage === 'thinking') {
+        modelTimes.set(modelKey, timestamp);
+      }
+      if (['success', 'winner', 'failed', 'cancelled'].includes(event.stage)) {
+        const started = modelTimes.get(modelKey) ?? stageTimes.get(`${event.step}:plan`);
+        if (started != null && timestamp >= started) {
+          event.start_time = event.start_time || started;
+          event.end_time = event.end_time || timestamp;
+          event.duration_ms = event.duration_ms ?? (timestamp - started);
+        }
+      }
+    }
+
+    agentRunStore.addEvent(runId, event);
+    const traceWrite = appendTraceEvent(memoryDir, runId, event).catch((err: any) => {
       log.warn(`[TraceStore] append failed runId=${runId}: ${err.message}`);
     });
     const run = agentRunStore.getRun(runId);
@@ -27,9 +124,10 @@ export function createBaseEventSender(runId: string, agentRunStore: any, memoryD
     }
     if (run?._reconnectWriters) {
       for (const writer of run._reconnectWriters) {
-        writer(payload);
+        writer(event);
       }
     }
+    return event;
   };
 }
 

--- a/routes/agent-run-session.ts
+++ b/routes/agent-run-session.ts
@@ -74,9 +74,9 @@ export function createAgentRunSession({
       modelsUsed.add(payload.model);
     }
     logAgentEvent(payload);
-    baseSendEvent(payload);
+    const event = baseSendEvent(payload);
     if (!sseClosed && !res.writableEnded) {
-      try { rawSendEvent(payload); } catch { sseClosed = true; }
+      try { rawSendEvent(event); } catch { sseClosed = true; }
     }
   };
 

--- a/test/trace-metrics.test.js
+++ b/test/trace-metrics.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { computeTraceMetrics, formatDurationMs } from '../client/src/components/agent/trace-metrics.js';
+
+describe('trace metrics', () => {
+  it('keeps the existing model-plan token de-duplication while adding observability metrics', () => {
+    const trace = [
+      { type: 'step', step: 1, stage: 'observe', timestamp: 1000 },
+      { type: 'model_plan', step: 1, stage: 'start', models: ['m1', 'm2'], timestamp: 1100 },
+      { type: 'model_plan', step: 1, stage: 'success', model: 'm1', usage: { prompt_tokens: 10, completion_tokens: 2 }, timestamp: 1800 },
+      { type: 'model_plan', step: 1, stage: 'success', model: 'm2', usage: { prompt_tokens: 12, completion_tokens: 3 }, timestamp: 1900 },
+      { type: 'step', step: 1, stage: 'action', action: { tool: 'fs', type: 'read_file' }, usage: { prompt_tokens: 10, completion_tokens: 2 }, timestamp: 2000 },
+      { type: 'step', step: 1, stage: 'result', result: 'ok', timestamp: 2600 },
+      { type: 'done', meta: { elapsed_ms: 1700, step_count: 1 }, timestamp: 2700 },
+    ];
+
+    const metrics = computeTraceMetrics(trace);
+
+    expect(metrics.totalTokens).toBe(27);
+    expect(metrics.llmCalls).toBe(2);
+    expect(metrics.completedToolCalls).toBe(1);
+    expect(metrics.toolSuccesses).toBe(1);
+    expect(metrics.toolSuccessRate).toBe(1);
+    expect(metrics.totalDurationMs).toBe(1700);
+    expect(metrics.stepDurations[0]).toMatchObject({
+      step: 1,
+      durationMs: 1600,
+      status: 'fast',
+      tokens: 27,
+      tool: 'fs',
+    });
+  });
+
+  it('marks failed tool results and slow steps for the debug panel', () => {
+    const trace = [
+      { type: 'step', step: 1, stage: 'observe', timestamp: 0 },
+      { type: 'model_plan', step: 1, stage: 'winner', model: 'm1', usage: { prompt_tokens: 1, completion_tokens: 1 }, timestamp: 1000 },
+      { type: 'step', step: 1, stage: 'action', action: { tool: 'browser', type: 'navigate' }, timestamp: 2000 },
+      { type: 'step', step: 1, stage: 'result', result: '导航超时', timestamp: 13000 },
+    ];
+
+    const metrics = computeTraceMetrics(trace);
+
+    expect(metrics.toolFailures).toBe(1);
+    expect(metrics.toolSuccessRate).toBe(0);
+    expect(metrics.slowestStep).toMatchObject({ step: 1, status: 'failed' });
+    expect(formatDurationMs(metrics.slowestStep.durationMs)).toBe('13s');
+  });
+});


### PR DESCRIPTION
## Summary
- add an agent trace debug panel for inspecting recorded runtime events
- include trace metrics and grouped event details in the agent panel
- persist run session metadata needed by the trace view

## Tests
- npm test -- test/trace-metrics.test.js
- npm run build:client
- npm run typecheck
- npm run lint