### PR TITLE
Make context prompt indicator subtler

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -3564,10 +3564,17 @@ select,
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 3px;
   min-width: 0;
   color: var(--c-text-muted);
-  font-size: 10px;
+  font-size: 9px;
+  opacity: 0.58;
+  transition: opacity var(--ease);
+}
+
+.context-meter:hover,
+.context-meter:focus-within {
+  opacity: 0.9;
 }
 
 .agent-composer--hero .context-meter {
@@ -3586,13 +3593,24 @@ select,
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 5px;
+  gap: 3px;
+  height: 20px;
+  padding: 0 4px;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
   min-width: 0;
+  cursor: default;
+}
+
+.context-meter-head:hover {
+  border-color: var(--c-border);
+  background: var(--c-surface);
 }
 
 .context-meter-title {
   color: var(--c-text-hint);
   font-weight: 500;
+  letter-spacing: 0;
 }
 
 .context-meter-value {
@@ -3636,8 +3654,8 @@ select,
   align-items: center;
   justify-content: center;
   gap: 4px;
-  height: 24px;
-  padding: 0 6px;
+  height: 20px;
+  padding: 0 4px;
   color: var(--c-text-hint);
   cursor: pointer;
   list-style: none;

--- a/client/src/components/ContextMeter.jsx
+++ b/client/src/components/ContextMeter.jsx
@@ -5,36 +5,26 @@ export function ContextMeter({ estimate }) {
   if (!estimate) return null;
 
   const percent = Math.max(0, Math.min(100, estimate.percent || 0));
-  const averagePercent = Math.max(0, Math.min(100, estimate.average?.percent || 0));
-  const showAverage = estimate.modelCount > 1;
   const actual = estimate.source === 'actual_prompt_usage';
   const promptPreview = estimate.promptPreview;
   const promptText = promptPreview?.text
     ? `${promptPreview.text}${promptPreview.truncated ? `\n\n${t('context.promptTruncated', { chars: promptPreview.chars })}` : ''}`
     : '';
+  const contextTitle = t(actual ? 'context.actualSummary' : 'context.summary', {
+    percent,
+    used: estimate.usedLabel,
+    limit: estimate.maxWindowLabel,
+  });
 
   return (
     <div className={`context-meter ${estimate.risk}${actual ? ' actual' : ''}`} aria-label={t(actual ? 'context.actualLabel' : 'context.label')}>
-      <div className="context-meter-head">
-        <span className="context-meter-title">{t(actual ? 'context.actualLabel' : 'context.label')}</span>
-        <span className="context-meter-value">{t(actual ? 'context.actualSummary' : 'context.summary', {
-          percent,
-          used: estimate.usedLabel,
-          limit: estimate.maxWindowLabel,
-        })}</span>
+      <div className="context-meter-head" title={contextTitle}>
+        <span className="context-meter-title">ctx</span>
+        <span className="context-meter-value">{estimate.usedLabel}</span>
       </div>
-      <div className="context-meter-track" aria-hidden="true">
-        <span className="context-meter-fill" style={{ width: `${percent}%` }} />
-      </div>
-      {showAverage && (
-        <div className="context-meter-sub">
-          <span>{t(actual ? 'context.actualMax' : 'context.max', { percent })}</span>
-          <span>{t(actual ? 'context.actualAvg' : 'context.avg', { percent: averagePercent })}</span>
-        </div>
-      )}
       {promptPreview?.text && (
         <details className="context-prompt-details">
-          <summary className="context-prompt-summary">
+          <summary className="context-prompt-summary" title={t('context.promptTitle')}>
             <span>{t('context.promptToggle')}</span>
             <span title={promptPreview.modelId || ''}>{t('context.promptMeta', {
               model: promptPreview.modelId || '-',

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -61,7 +61,8 @@ export const en = {
   'context.avg': 'Average first-request estimate {percent}%',
   'context.actualMax': 'Max actual {percent}%',
   'context.actualAvg': 'Average actual {percent}%',
-  'context.promptToggle': 'First prompt',
+  'context.promptToggle': 'prompt',
+  'context.promptTitle': 'View first prompt',
   'context.promptMeta': '{model} · {used} tok',
   'context.promptTruncated': 'Prompt is long and was truncated; full length {chars} chars.',
 

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -62,7 +62,8 @@ export const zh = {
   'context.avg': '平均首轮预估 {percent}%',
   'context.actualMax': '最大实际 {percent}%',
   'context.actualAvg': '平均实际 {percent}%',
-  'context.promptToggle': '首轮提示词',
+  'context.promptToggle': 'prompt',
+  'context.promptTitle': '查看首轮提示词',
   'context.promptMeta': '{model} · {used} tok',
   'context.promptTruncated': '提示词过长，已截断；完整长度 {chars} 字符。',
 


### PR DESCRIPTION
## Summary
- reduce the context token indicator to a subtle ctx chip
- move full context details into hover text
- shorten the prompt trigger label to reduce visual noise

## Tests
- npm run build:client
- npm run typecheck
- npm run lint
- npm test -- test/context-estimate.test.js test/context-usage.test.js test/agent-api.test.ts