### PR TITLE
Support Ctrl+Enter send shortcut

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -845,7 +845,8 @@ export default function App() {
 
   const handleKeyDown = e => {
     const isMobile = window.innerWidth < TABLET_BREAKPOINT;
-    if (e.key === 'Enter' && e.metaKey && !isMobile) {
+    const submitModifier = e.metaKey || e.ctrlKey;
+    if (e.key === 'Enter' && submitModifier && !isMobile) {
       e.preventDefault();
       handleSubmit();
     }

--- a/client/src/components/dialogs/QuestionDialog.jsx
+++ b/client/src/components/dialogs/QuestionDialog.jsx
@@ -7,7 +7,7 @@ export function QuestionDialog({ question, submitting, onSubmit, onSkip }) {
   if (!question) return null;
 
   const handleKeyDown = e => {
-    if (e.key === 'Enter' && e.metaKey) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       if (!submitting) onSubmit(response);
     }


### PR DESCRIPTION
Summary: Add Ctrl+Enter support for sending from the main composer on desktop, while preserving Cmd+Enter on macOS. Also applies the same Cmd/Ctrl+Enter behavior to the user-question dialog. Tests: npm run build:client. Closes #293.