### PR TITLE
Preserve agent run history in sessions

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2645,6 +2645,110 @@ select,
   color: var(--c-primary);
 }
 
+.agent-run-history {
+  margin: 8px 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agent-run-history-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--c-text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.agent-history-run {
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-sm);
+  background: var(--c-surface);
+  overflow: hidden;
+}
+
+.agent-history-run-toggle {
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.agent-history-run-toggle:hover {
+  background: var(--c-surface-hover);
+}
+
+.agent-history-run-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.agent-history-run-main strong {
+  color: var(--c-text);
+  font-size: var(--f-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-history-run-main span,
+.agent-history-run-side {
+  color: var(--c-text-secondary);
+  font-size: 11px;
+}
+
+.agent-history-run-side {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.agent-history-run-side svg {
+  color: var(--c-text-muted);
+}
+
+.agent-history-trace {
+  padding: 0 10px 10px;
+  border-top: 1px solid var(--c-border);
+}
+
+.agent-trace.agent-trace--history {
+  max-height: 360px;
+  margin-top: 8px;
+  padding-top: 2px;
+  flex: initial;
+  overflow-y: auto;
+}
+
+.agent-trace.agent-trace--history > :nth-last-child(2)::before {
+  bottom: -8px;
+}
+
+.agent-trace.agent-trace--history > :last-child::before {
+  bottom: 0;
+}
+
+.agent-history-empty {
+  padding: 10px 0 0;
+  color: var(--c-text-muted);
+  font-size: var(--f-xs);
+}
+
 .agent-empty {
   margin-top: 8px;
   padding: 16px 12px;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2574,6 +2574,23 @@ select,
   gap: 9px;
 }
 
+.agent-last-run-toggle {
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.agent-last-run-toggle:hover {
+  background: var(--c-surface-inline);
+}
+
+.agent-last-run-toggle:focus-visible {
+  outline: 2px solid var(--c-primary);
+  outline-offset: 2px;
+}
+
 .agent-last-run.error {
   border-color: var(--c-agent-stop-border);
   background: var(--c-agent-stop-bg);
@@ -2615,6 +2632,17 @@ select,
   color: var(--c-text-muted);
   font-size: var(--f-xs);
   white-space: nowrap;
+}
+
+.agent-last-run-status-wrap {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.agent-last-run-status-wrap svg {
+  color: var(--c-text-muted);
 }
 
 .agent-last-run-grid {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -25,7 +25,7 @@ import { NotificationBanner } from './components/NotificationBanner.jsx';
 import { AppHeader } from './components/AppHeader.jsx';
 import { HeroScreen } from './components/HeroScreen.jsx';
 import { useAgentRun } from './hooks/useAgentRun.js';
-import { createSession, getSessionTitle, normalizeChatState, touchSession, useChatSessions } from './hooks/useChatSessions.js';
+import { createSession, getSessionTitle, normalizeChatState, touchSession, upsertAgentRun, useChatSessions } from './hooks/useChatSessions.js';
 import { useProjects } from './hooks/useProjects.js';
 import { booleanStorage, usePersistentState, useProjectScopedState } from './hooks/usePersistentState.js';
 import { useResponsiveLayout } from './hooks/useResponsiveLayout.js';
@@ -451,24 +451,28 @@ export default function App() {
                       msgs.push({ role: 'user', content: reconnectTaskRef.current || data.task || t('agent.taskFallback'), ts: data.startedAt || Date.now(), ...(primaryDoneModel ? { model: primaryDoneModel } : {}), ...(modelsUsed.length > 0 ? { modelsUsed } : {}) });
                       msgs.push({ role: 'assistant', content: event.answer || t('agent.done'), ts: Date.now(), ...(primaryDoneModel ? { model: primaryDoneModel } : {}), ...(modelsUsed.length > 0 ? { modelsUsed } : {}) });
                     }
-                    return touchSession(session, {
+                    const nextSession = {
+                      ...session,
                       messages: msgs,
                       ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
                       agentRunId: data.runId,
                       agentTrace: nextTrace,
-                      agentMeta: buildAgentMetaFromSession({
-                        ...session,
-                        messages: msgs,
-                        ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
-                        agentRunId: data.runId,
-                      }, nextTrace, {
-                        task: reconnectTaskRef.current || data.task || t('agent.taskFallback'),
-                        startedAt: data.startedAt,
-                        models: modelsUsed,
-                        status: event.quality?.status || event.meta?.status || 'done',
-                        runId: data.runId,
-                      }),
+                    };
+                    const agentMeta = buildAgentMetaFromSession(nextSession, nextTrace, {
+                      task: reconnectTaskRef.current || data.task || t('agent.taskFallback'),
+                      startedAt: data.startedAt,
+                      models: modelsUsed,
+                      status: event.quality?.status || event.meta?.status || 'done',
+                      runId: data.runId,
                     });
+                    return touchSession(upsertAgentRun({
+                      ...nextSession,
+                      agentMeta,
+                    }, {
+                      runId: data.runId,
+                      trace: nextTrace,
+                      meta: agentMeta,
+                    }));
                   });
                   return nextTrace;
                 });
@@ -487,26 +491,29 @@ export default function App() {
                     } else if (!msgs.some(m => m.role === 'assistant' && m.content === content)) {
                       msgs.push({ role: 'assistant', content, ts: Date.now(), ...(activeRunPrimaryModel ? { model: activeRunPrimaryModel } : {}), ...(activeRunModels.length > 0 ? { modelsUsed: activeRunModels } : {}) });
                     }
-                    return touchSession(session, {
+                    const nextSession = {
+                      ...session,
                       messages: msgs,
                       ...(activeRunPrimaryModel ? { model: activeRunPrimaryModel } : {}),
                       ...(activeRunModels.length > 0 ? { modelsUsed: activeRunModels } : {}),
                       agentRunId: data.runId,
                       agentTrace: nextTrace,
-                      agentMeta: buildAgentMetaFromSession({
-                        ...session,
-                        messages: msgs,
-                        ...(activeRunPrimaryModel ? { model: activeRunPrimaryModel } : {}),
-                        ...(activeRunModels.length > 0 ? { modelsUsed: activeRunModels } : {}),
-                        agentRunId: data.runId,
-                      }, nextTrace, {
-                        task: reconnectTaskRef.current || data.task || t('agent.taskFallback'),
-                        startedAt: data.startedAt,
-                        models: activeRunModels,
-                        status: event.error === 'Agent 已取消' ? 'cancelled' : 'error',
-                        runId: data.runId,
-                      }),
+                    };
+                    const agentMeta = buildAgentMetaFromSession(nextSession, nextTrace, {
+                      task: reconnectTaskRef.current || data.task || t('agent.taskFallback'),
+                      startedAt: data.startedAt,
+                      models: activeRunModels,
+                      status: event.error === 'Agent 已取消' ? 'cancelled' : 'error',
+                      runId: data.runId,
                     });
+                    return touchSession(upsertAgentRun({
+                      ...nextSession,
+                      agentMeta,
+                    }, {
+                      runId: data.runId,
+                      trace: nextTrace,
+                      meta: agentMeta,
+                    }));
                   });
                   return nextTrace;
                 });
@@ -582,23 +589,27 @@ export default function App() {
             msgs.push({ role: 'assistant', content, ts: Date.now(), ...(primaryModel ? { model: primaryModel } : {}), ...(modelsUsed.length > 0 ? { modelsUsed } : {}) });
           }
           changed = true;
-          return touchSession(session, {
+          const nextSession = {
+            ...session,
             messages: msgs,
             ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
             agentRunId: rid,
             agentTrace: events,
-            agentMeta: buildAgentMetaFromSession({
-              ...session,
-              messages: msgs,
-              ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
-              agentRunId: rid,
-            }, events, {
-              task: lastAgentTaskRef.current || undefined,
-              models: modelsUsed,
-              status: terminal.type === 'done' ? (terminal.quality?.status || terminal.meta?.status || 'done') : (terminal.error === 'Agent 已取消' ? 'cancelled' : 'error'),
-              runId: rid,
-            }),
+          };
+          const agentMeta = buildAgentMetaFromSession(nextSession, events, {
+            task: lastAgentTaskRef.current || undefined,
+            models: modelsUsed,
+            status: terminal.type === 'done' ? (terminal.quality?.status || terminal.meta?.status || 'done') : (terminal.error === 'Agent 已取消' ? 'cancelled' : 'error'),
+            runId: rid,
           });
+          return touchSession(upsertAgentRun({
+            ...nextSession,
+            agentMeta,
+          }, {
+            runId: rid,
+            trace: events,
+            meta: agentMeta,
+          }));
         });
         if (!changed) return prev;
         return normalizeChatState({ ...prev, sessions });
@@ -641,17 +652,23 @@ export default function App() {
           const modelsUsed = getTraceModels(deduped);
           // 重建 trace 只是恢复客户端镜像，不算用户活动：保留原 updatedAt，
           // 否则每次切到/刷新一个 agent 会话都会把它的最近活动时间刷成当前时间。
-          updateSession(activeSession.id, session => ({
-            ...session,
-            agentRunId: savedRunId,
-            agentTrace: deduped,
-            ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
-            agentMeta: buildAgentMetaFromSession({
+          updateSession(activeSession.id, session => {
+            const nextSession = {
               ...session,
               agentRunId: savedRunId,
+              agentTrace: deduped,
               ...(modelsUsed.length > 0 ? { model: modelsUsed[0], modelsUsed } : {}),
-            }, deduped),
-          }));
+            };
+            const agentMeta = buildAgentMetaFromSession(nextSession, deduped);
+            return upsertAgentRun({
+              ...nextSession,
+              agentMeta,
+            }, {
+              runId: savedRunId,
+              trace: deduped,
+              meta: agentMeta,
+            });
+          });
         })
         .catch(() => {});
     } else {
@@ -1071,6 +1088,8 @@ export default function App() {
                   trace={agentTrace}
                   startedAt={agentStartedAt}
                   lastRun={activeAgentMeta}
+                  previousRuns={activeSession.agentRuns || []}
+                  projectId={activeSession.projectId ?? null}
                   modelList={availableModels}
                   collapsed={agentCollapsed}
                   onToggleCollapse={() => setAgentCollapsed(c => !c)}

--- a/client/src/components/agent/AgentPanel.jsx
+++ b/client/src/components/agent/AgentPanel.jsx
@@ -13,6 +13,8 @@ import { TraceDebugPanel } from './TraceDebugPanel.jsx';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { useT } from '../../i18n/I18nProvider.jsx';
 import { formatFullTime, formatRelativeTime } from '../../utils/format.js';
+import { fetchAgentTrace } from '../../api/streams.js';
+import { appendUniqueTraceEvent } from '../../utils/agent-trace.js';
 
 // AgentPanel 既是执行面板，也是运行时仪表盘：
 // - 负责展示 trace
@@ -31,19 +33,41 @@ function statusLabel(status, t) {
   return t('agentStats.statusDone');
 }
 
-export function AgentPanel({ running, trace, startedAt, lastRun, modelList, collapsed, onToggleCollapse, onStop, agentStopping, pendingApproval, onRollback, rollbackLoading }) {
+function traceRunId(trace) {
+  if (!Array.isArray(trace)) return null;
+  for (let i = trace.length - 1; i >= 0; i -= 1) {
+    const runId = trace[i]?.runId;
+    if (typeof runId === 'string' && runId) return runId;
+  }
+  return null;
+}
+
+function runKey(run, index = 0) {
+  return run?.runId || run?.meta?.runId || `${run?.meta?.startedAt || ''}:${run?.meta?.task || ''}:${index}`;
+}
+
+function shouldHideTimelineEvent(event) {
+  if (event.type === 'session_checkpoint') return true;
+  return event.type === 'status' && (event.status === 'starting' || event.status === 'browser_ready');
+}
+
+export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = [], projectId = null, modelList, collapsed, onToggleCollapse, onStop, agentStopping, pendingApproval, onRollback, rollbackLoading }) {
   const t = useT();
   const traceBottomRef = useRef(null);
   const traceStickyRef = useRef(true);
   const isMobile = useIsMobile(PHONE_BREAKPOINT);
   const [lightboxSrc, setLightboxSrc] = useState(null);
   const [cardsExpanded, setCardsExpanded] = useState(null); // null=auto, true=all open, false=all closed
+  const [expandedHistoryRun, setExpandedHistoryRun] = useState(null);
+  const [historyTraceCache, setHistoryTraceCache] = useState({});
+  const [historyTraceLoading, setHistoryTraceLoading] = useState(null);
 
   // onRollback 来自上层且每次 render 是新引用；用 ref 包出稳定回调，
   // 这样 memo 化的 TraceItem 不会因为回调引用变化而整片重渲。
   const rollbackRef = useRef(onRollback);
   useEffect(() => { rollbackRef.current = onRollback; }, [onRollback]);
   const stableRollback = useCallback(step => rollbackRef.current?.(step), []);
+  const disabledRollback = useCallback(() => {}, []);
 
   // 以下派生值原先每次 render（含每秒计时 tick）都对整条 trace 做 some/reduce/find，
   // 现在统一 memo 化，只在 trace/running 变化时重算。
@@ -102,6 +126,29 @@ export function AgentPanel({ running, trace, startedAt, lastRun, modelList, coll
     () => (lastRun?.models || []).map(model => modelList.find(item => item.id === model)?.label || model),
     [lastRun, modelList],
   );
+  const currentRunId = lastRun?.runId || traceRunId(trace);
+  const historyRuns = useMemo(
+    () => previousRuns.filter((run, index) => runKey(run, index) !== currentRunId).slice(0, 8),
+    [currentRunId, previousRuns],
+  );
+
+  const toggleHistoryRun = useCallback(async (run, index) => {
+    const key = runKey(run, index);
+    const nextExpanded = expandedHistoryRun === key ? null : key;
+    setExpandedHistoryRun(nextExpanded);
+    if (!nextExpanded || historyTraceCache[key] || run.trace?.length > 0 || !run.runId) return;
+
+    setHistoryTraceLoading(key);
+    try {
+      const events = await fetchAgentTrace(run.runId, { projectId });
+      const deduped = events.reduce((acc, event) => appendUniqueTraceEvent(acc, event), []);
+      setHistoryTraceCache(prev => ({ ...prev, [key]: deduped }));
+    } catch {
+      setHistoryTraceCache(prev => ({ ...prev, [key]: [] }));
+    } finally {
+      setHistoryTraceLoading(prev => (prev === key ? null : prev));
+    }
+  }, [expandedHistoryRun, historyTraceCache, projectId]);
 
   // ESC closes lightbox
   useEffect(() => {
@@ -207,6 +254,70 @@ export function AgentPanel({ running, trace, startedAt, lastRun, modelList, coll
             </div>
           )}
 
+          {historyRuns.length > 0 && (
+            <div className="agent-run-history">
+              <div className="agent-run-history-head">
+                <span>{t('agentPanel.previousRuns')}</span>
+                <span>{historyRuns.length}</span>
+              </div>
+              {historyRuns.map((run, index) => {
+                const key = runKey(run, index);
+                const meta = run.meta || {};
+                const title = meta.task || t('agent.taskFallback');
+                const expanded = expandedHistoryRun === key;
+                const cachedTrace = historyTraceCache[key];
+                const historyTrace = Array.isArray(run.trace) && run.trace.length > 0 ? run.trace : (cachedTrace || []);
+                const loading = historyTraceLoading === key;
+                const models = (meta.models || []).map(model => modelList.find(item => item.id === model)?.label || model);
+                return (
+                  <div className="agent-history-run" key={key}>
+                    <button className="agent-history-run-toggle" onClick={() => toggleHistoryRun(run, index)}>
+                      <span className="agent-history-run-main">
+                        <strong title={title}>{title}</strong>
+                        <span>
+                          {formatDurationMs(meta.elapsedMs || 0)} · {formatTokenCount(meta.totalTokens || 0)} tok · {t('agentPanel.stepCount', { n: meta.stepCount || 0 })}
+                        </span>
+                      </span>
+                      <span className="agent-history-run-side">
+                        <span>{models.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
+                        <span title={meta.endedAt ? formatFullTime(meta.endedAt) : ''}>
+                          {meta.endedAt ? formatRelativeTime(meta.endedAt) : statusLabel(meta.status, t)}
+                        </span>
+                        {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                      </span>
+                    </button>
+                    {expanded && (
+                      <div className="agent-history-trace">
+                        {loading ? (
+                          <div className="agent-history-empty">{t('agentPanel.historyLoading')}</div>
+                        ) : historyTrace.length === 0 ? (
+                          <div className="agent-history-empty">{t('agentPanel.historyTraceUnavailable')}</div>
+                        ) : (
+                          <div className="agent-trace agent-trace--history">
+                            {historyTrace.map((event, eventIndex) => {
+                              if (shouldHideTimelineEvent(event)) return null;
+                              return (
+                                <TraceItem
+                                  key={`${key}-${event.type}-${event.step ?? eventIndex}-${event.stage ?? eventIndex}-${eventIndex}`}
+                                  event={event}
+                                  modelList={modelList}
+                                  onRollback={disabledRollback}
+                                  rollbackLoading
+                                  openLightbox={setLightboxSrc}
+                                  t={t}
+                                />
+                              );
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
           {trace.length > 0 && <TraceDebugPanel metrics={metrics} t={t} />}
 
               {trace.length === 0 && running ? (
@@ -226,8 +337,7 @@ export function AgentPanel({ running, trace, startedAt, lastRun, modelList, coll
           {trace.map((event, index) => {
             // 系统级提示不进时间线：启动提示 / 浏览器就绪 / 后台健康快照都是噪音，
             // 不是 agent 的实质步骤；断点恢复 status='resuming' 有信息量，保留。
-            if (event.type === 'session_checkpoint') return null;
-            if (event.type === 'status' && (event.status === 'starting' || event.status === 'browser_ready')) return null;
+            if (shouldHideTimelineEvent(event)) return null;
             // ── model_plan ──
             if (event.type === 'model_plan') {
               // start：多模型渲染对比卡组；单模型并入 StepCard，不单独渲染

--- a/client/src/components/agent/AgentPanel.jsx
+++ b/client/src/components/agent/AgentPanel.jsx
@@ -331,37 +331,6 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
             {t('agentPanel.note')}
           </p>
 
-          {!running && lastRun && (
-            <LastRunFrame
-              className={lastRunClassName}
-              {...(canToggleRecentRun ? {
-                type: 'button',
-                onClick: () => setRecentRunExpanded(v => !v),
-                'aria-expanded': recentRunExpanded,
-              } : {})}
-            >
-              <div className="agent-last-run-head">
-                <div>
-                  <span className="agent-last-run-kicker">{t('agentPanel.recentRun')}</span>
-                  <strong title={lastRun.task}>{lastRun.task || t('agent.taskFallback')}</strong>
-                </div>
-                <span className="agent-last-run-status-wrap">
-                  <span className="agent-last-run-status" title={lastRun.endedAt ? formatFullTime(lastRun.endedAt) : ''}>
-                    {lastRun.endedAt ? formatRelativeTime(lastRun.endedAt) : statusLabel(lastRun.status, t)}
-                  </span>
-                  {canToggleRecentRun && (recentRunExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />)}
-                </span>
-              </div>
-              <div className="agent-last-run-grid">
-                <span><Clock3 size={13} />{formatDurationMs(lastRun.elapsedMs)}</span>
-                <span><ListChecks size={13} />{t('agentPanel.stepCount', { n: lastRun.stepCount })}</span>
-                <span><Coins size={13} />{formatTokenCount(lastRun.totalTokens)} tok</span>
-                <span><Bot size={13} />{lastRunModels.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
-                <span><Trophy size={13} />{strategyLabel(lastRun.strategy, t)}</span>
-              </div>
-            </LastRunFrame>
-          )}
-
           {historyRuns.length > 0 && (
             <div className="agent-run-history">
               <div className="agent-run-history-head">
@@ -420,6 +389,37 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
                 );
               })}
             </div>
+          )}
+
+          {!running && lastRun && (
+            <LastRunFrame
+              className={lastRunClassName}
+              {...(canToggleRecentRun ? {
+                type: 'button',
+                onClick: () => setRecentRunExpanded(v => !v),
+                'aria-expanded': recentRunExpanded,
+              } : {})}
+            >
+              <div className="agent-last-run-head">
+                <div>
+                  <span className="agent-last-run-kicker">{t('agentPanel.recentRun')}</span>
+                  <strong title={lastRun.task}>{lastRun.task || t('agent.taskFallback')}</strong>
+                </div>
+                <span className="agent-last-run-status-wrap">
+                  <span className="agent-last-run-status" title={lastRun.endedAt ? formatFullTime(lastRun.endedAt) : ''}>
+                    {lastRun.endedAt ? formatRelativeTime(lastRun.endedAt) : statusLabel(lastRun.status, t)}
+                  </span>
+                  {canToggleRecentRun && (recentRunExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />)}
+                </span>
+              </div>
+              <div className="agent-last-run-grid">
+                <span><Clock3 size={13} />{formatDurationMs(lastRun.elapsedMs)}</span>
+                <span><ListChecks size={13} />{t('agentPanel.stepCount', { n: lastRun.stepCount })}</span>
+                <span><Coins size={13} />{formatTokenCount(lastRun.totalTokens)} tok</span>
+                <span><Bot size={13} />{lastRunModels.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
+                <span><Trophy size={13} />{strategyLabel(lastRun.strategy, t)}</span>
+              </div>
+            </LastRunFrame>
           )}
 
           {trace.length > 0 && showCurrentTrace && <TraceDebugPanel metrics={metrics} t={t} />}

--- a/client/src/components/agent/AgentPanel.jsx
+++ b/client/src/components/agent/AgentPanel.jsx
@@ -51,6 +51,127 @@ function shouldHideTimelineEvent(event) {
   return event.type === 'status' && (event.status === 'starting' || event.status === 'browser_ready');
 }
 
+function AgentTraceTimeline({
+  trace,
+  running,
+  modelList,
+  cardsExpanded,
+  onManualToggle,
+  onRollback,
+  rollbackLoading,
+  openLightbox,
+  t,
+  bottomRef = null,
+  history = false,
+}) {
+  const metrics = useMemo(() => computeTraceMetrics(trace), [trace]);
+  const agentFinished = useMemo(
+    () => !running && trace.some(e => e.type === 'done' || e.type === 'error'),
+    [running, trace],
+  );
+  const eventsByStep = useMemo(() => {
+    const map = new Map();
+    for (const e of trace) {
+      if (e.step == null) continue;
+      let arr = map.get(e.step);
+      if (!arr) { arr = []; map.set(e.step, arr); }
+      arr.push(e);
+    }
+    return map;
+  }, [trace]);
+  const multiModelSteps = useMemo(() => {
+    const set = new Set();
+    for (const e of trace) {
+      if (e.type === 'model_plan' && e.stage === 'start' && e.models?.length > 1) set.add(e.step);
+    }
+    return set;
+  }, [trace]);
+  const singleModelSteps = useMemo(() => {
+    const set = new Set();
+    for (const e of trace) {
+      if (e.type === 'model_plan' && e.stage === 'start' && e.models?.length === 1) set.add(e.step);
+    }
+    return set;
+  }, [trace]);
+
+  return (
+    <div className={`agent-trace${history ? ' agent-trace--history' : ''}`}>
+      {trace.map((event, index) => {
+        // 系统级提示不进时间线：启动提示 / 浏览器就绪 / 后台健康快照都是噪音，
+        // 不是 agent 的实质步骤；断点恢复 status='resuming' 有信息量，保留。
+        if (shouldHideTimelineEvent(event)) return null;
+        // ── model_plan ──
+        if (event.type === 'model_plan') {
+          // start：多模型渲染对比卡组；单模型并入 StepCard，不单独渲染
+          if (event.stage === 'start') {
+            return event.models?.length > 1 ? (
+              <ModelPlanGroup
+                key={`model-plan-step-${event.step ?? index}-${index}`}
+                events={eventsByStep.get(event.step) || []}
+                step={event.step}
+                models={event.models}
+                modelList={modelList}
+                agentFinished={agentFinished}
+                cardsExpanded={cardsExpanded}
+                onManualToggle={onManualToggle}
+                onRollback={onRollback}
+                rollbackLoading={rollbackLoading}
+                openLightbox={openLightbox}
+              />
+            ) : null;
+          }
+          // consensus 落到底部 TraceItem 单独展示；其它阶段在卡组内显示，跳过
+          if (event.stage !== 'consensus') return null;
+        }
+
+        // ── step ──
+        if (event.type === 'step') {
+          // 单模型：observe/action/result 合并成一张 StepCard，只在 observe 处渲染一次
+          if (singleModelSteps.has(event.step)) {
+            return event.stage === 'observe' ? (
+              <StepCard
+                key={`step-card-${event.step ?? index}`}
+                events={eventsByStep.get(event.step) || []}
+                step={event.step}
+                active={running && event.step === metrics.lastStep}
+                modelList={modelList}
+                onRollback={onRollback}
+                rollbackLoading={rollbackLoading}
+                openLightbox={openLightbox}
+                forceExpanded={cardsExpanded}
+                onManualToggle={onManualToggle}
+                t={t}
+              />
+            ) : null;
+          }
+          // 多模型：observe/action/result 都并入决策卡组（与单模型 StepCard 一致，一步一节点），这里跳过
+          if (multiModelSteps.has(event.step) && (event.stage === 'observe' || event.stage === 'action' || event.stage === 'result')) {
+            return null;
+          }
+        }
+
+        if (event.type === 'terminal_output' && (singleModelSteps.has(event.step) || multiModelSteps.has(event.step))) {
+          return null;
+        }
+
+        // consensus + 其余事件（status/notification/approval/done/error/...）
+        return (
+          <TraceItem
+            key={`${event.type}-${event.step ?? index}-${event.stage ?? index}-${index}`}
+            event={event}
+            modelList={modelList}
+            onRollback={onRollback}
+            rollbackLoading={rollbackLoading}
+            openLightbox={openLightbox}
+            t={t}
+          />
+        );
+      })}
+      {bottomRef && <div ref={bottomRef} />}
+    </div>
+  );
+}
+
 export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = [], projectId = null, modelList, collapsed, onToggleCollapse, onStop, agentStopping, pendingApproval, onRollback, rollbackLoading }) {
   const t = useT();
   const traceBottomRef = useRef(null);
@@ -61,6 +182,7 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
   const [expandedHistoryRun, setExpandedHistoryRun] = useState(null);
   const [historyTraceCache, setHistoryTraceCache] = useState({});
   const [historyTraceLoading, setHistoryTraceLoading] = useState(null);
+  const [recentRunExpanded, setRecentRunExpanded] = useState(true);
 
   // onRollback 来自上层且每次 render 是新引用；用 ref 包出稳定回调，
   // 这样 memo 化的 TraceItem 不会因为回调引用变化而整片重渲。
@@ -77,43 +199,11 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
     [trace],
   );
   const doneEvent = useMemo(() => trace.find(e => e.type === 'done'), [trace]);
-  const agentFinished = useMemo(
-    () => !running && trace.some(e => e.type === 'done' || e.type === 'error'),
-    [running, trace],
-  );
   // Detect if waiting for user question
   const hasPendingQuestion = useMemo(
     () => running && trace.some(e => e.type === 'question_required') && !trace.some(e => e.type === 'user_response'),
     [running, trace],
   );
-  // 把事件按 step 预分组一次，供 ModelPlanGroup 直接取用，避免每个 group 再各自
-  // 遍历整条 trace（否则 S 步 × N 事件 = O(N²)）。
-  const eventsByStep = useMemo(() => {
-    const map = new Map();
-    for (const e of trace) {
-      if (e.step == null) continue;
-      let arr = map.get(e.step);
-      if (!arr) { arr = []; map.set(e.step, arr); }
-      arr.push(e);
-    }
-    return map;
-  }, [trace]);
-  // 多模型规划的步：其 action/result 展示在模型卡片内部，trace 里需跳过单独项。
-  const multiModelSteps = useMemo(() => {
-    const set = new Set();
-    for (const e of trace) {
-      if (e.type === 'model_plan' && e.stage === 'start' && e.models?.length > 1) set.add(e.step);
-    }
-    return set;
-  }, [trace]);
-  // 单模型的步：observe/action/result 合并成一张 StepCard，model_plan 折叠废卡不再单独渲染。
-  const singleModelSteps = useMemo(() => {
-    const set = new Set();
-    for (const e of trace) {
-      if (e.type === 'model_plan' && e.stage === 'start' && e.models?.length === 1) set.add(e.step);
-    }
-    return set;
-  }, [trace]);
 
   const doneMeta = doneEvent?.meta || {};
   const doneStatus = doneEvent?.quality?.status || doneMeta.status || 'done';
@@ -127,10 +217,18 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
     [lastRun, modelList],
   );
   const currentRunId = lastRun?.runId || traceRunId(trace);
+  const canToggleRecentRun = !running && trace.length > 0 && !!lastRun;
+  const showCurrentTrace = running || !canToggleRecentRun || recentRunExpanded;
+  const LastRunFrame = canToggleRecentRun ? 'button' : 'div';
+  const lastRunClassName = `agent-last-run${lastRun?.status === 'error' ? ' error' : ''}${canToggleRecentRun ? ' agent-last-run-toggle' : ''}`;
   const historyRuns = useMemo(
     () => previousRuns.filter((run, index) => runKey(run, index) !== currentRunId).slice(0, 8),
     [currentRunId, previousRuns],
   );
+
+  useEffect(() => {
+    setRecentRunExpanded(true);
+  }, [currentRunId]);
 
   const toggleHistoryRun = useCallback(async (run, index) => {
     const key = runKey(run, index);
@@ -195,7 +293,7 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
             </button>
           )}
           <div className="agent-head-actions">
-            {hasModelCards && !collapsed && (
+            {hasModelCards && !collapsed && showCurrentTrace && (
               <>
                 <button className="agent-collapse-btn agent-expand-all" onClick={e => { e.stopPropagation(); setCardsExpanded(true); }} title={t('agentPanel.expandAllTitle')}>
                   <ChevronsDown size={12} /> {t('agentPanel.expand')}
@@ -234,14 +332,24 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
           </p>
 
           {!running && lastRun && (
-            <div className={`agent-last-run ${lastRun.status === 'error' ? 'error' : ''}`}>
+            <LastRunFrame
+              className={lastRunClassName}
+              {...(canToggleRecentRun ? {
+                type: 'button',
+                onClick: () => setRecentRunExpanded(v => !v),
+                'aria-expanded': recentRunExpanded,
+              } : {})}
+            >
               <div className="agent-last-run-head">
                 <div>
                   <span className="agent-last-run-kicker">{t('agentPanel.recentRun')}</span>
                   <strong title={lastRun.task}>{lastRun.task || t('agent.taskFallback')}</strong>
                 </div>
-                <span className="agent-last-run-status" title={lastRun.endedAt ? formatFullTime(lastRun.endedAt) : ''}>
-                  {lastRun.endedAt ? formatRelativeTime(lastRun.endedAt) : statusLabel(lastRun.status, t)}
+                <span className="agent-last-run-status-wrap">
+                  <span className="agent-last-run-status" title={lastRun.endedAt ? formatFullTime(lastRun.endedAt) : ''}>
+                    {lastRun.endedAt ? formatRelativeTime(lastRun.endedAt) : statusLabel(lastRun.status, t)}
+                  </span>
+                  {canToggleRecentRun && (recentRunExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />)}
                 </span>
               </div>
               <div className="agent-last-run-grid">
@@ -251,7 +359,7 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
                 <span><Bot size={13} />{lastRunModels.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
                 <span><Trophy size={13} />{strategyLabel(lastRun.strategy, t)}</span>
               </div>
-            </div>
+            </LastRunFrame>
           )}
 
           {historyRuns.length > 0 && (
@@ -293,22 +401,18 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
                         ) : historyTrace.length === 0 ? (
                           <div className="agent-history-empty">{t('agentPanel.historyTraceUnavailable')}</div>
                         ) : (
-                          <div className="agent-trace agent-trace--history">
-                            {historyTrace.map((event, eventIndex) => {
-                              if (shouldHideTimelineEvent(event)) return null;
-                              return (
-                                <TraceItem
-                                  key={`${key}-${event.type}-${event.step ?? eventIndex}-${event.stage ?? eventIndex}-${eventIndex}`}
-                                  event={event}
-                                  modelList={modelList}
-                                  onRollback={disabledRollback}
-                                  rollbackLoading
-                                  openLightbox={setLightboxSrc}
-                                  t={t}
-                                />
-                              );
-                            })}
-                          </div>
+                          <AgentTraceTimeline
+                            trace={historyTrace}
+                            running={false}
+                            modelList={modelList}
+                            cardsExpanded={false}
+                            onManualToggle={disabledRollback}
+                            onRollback={disabledRollback}
+                            rollbackLoading
+                            openLightbox={setLightboxSrc}
+                            t={t}
+                            history
+                          />
                         )}
                       </div>
                     )}
@@ -318,96 +422,34 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
             </div>
           )}
 
-          {trace.length > 0 && <TraceDebugPanel metrics={metrics} t={t} />}
+          {trace.length > 0 && showCurrentTrace && <TraceDebugPanel metrics={metrics} t={t} />}
 
-              {trace.length === 0 && running ? (
-                <div className="agent-skeleton">
-                  <div className="agent-skeleton-line agent-skeleton-line--w60" />
-                  <div className="agent-skeleton-line agent-skeleton-line--w90" />
-                  <div className="agent-skeleton-line agent-skeleton-line--w70" />
-                  <Loader2 size={14} className="agent-skeleton-spinner" />
-                </div>
-              ) : trace.length === 0 ? (
-                <div className="agent-empty">
-                  <Monitor size={28} className="agent-empty-icon" />
-                  <span>{t('agentPanel.emptyHint')}</span>
-                </div>
-              ) : (
-                <div className="agent-trace">
-          {trace.map((event, index) => {
-            // 系统级提示不进时间线：启动提示 / 浏览器就绪 / 后台健康快照都是噪音，
-            // 不是 agent 的实质步骤；断点恢复 status='resuming' 有信息量，保留。
-            if (shouldHideTimelineEvent(event)) return null;
-            // ── model_plan ──
-            if (event.type === 'model_plan') {
-              // start：多模型渲染对比卡组；单模型并入 StepCard，不单独渲染
-              if (event.stage === 'start') {
-                return event.models?.length > 1 ? (
-                  <ModelPlanGroup
-                    key={`model-plan-step-${event.step ?? index}-${index}`}
-                    events={eventsByStep.get(event.step) || []}
-                    step={event.step}
-                    models={event.models}
-                    modelList={modelList}
-                    agentFinished={agentFinished}
-                    cardsExpanded={cardsExpanded}
-                    onManualToggle={() => setCardsExpanded(null)}
-                    onRollback={stableRollback}
-                    rollbackLoading={rollbackLoading}
-                    openLightbox={setLightboxSrc}
-                  />
-                ) : null;
-              }
-              // consensus 落到底部 TraceItem 单独展示；其它阶段在卡组内显示，跳过
-              if (event.stage !== 'consensus') return null;
-            }
-
-            // ── step ──
-            if (event.type === 'step') {
-              // 单模型：observe/action/result 合并成一张 StepCard，只在 observe 处渲染一次
-              if (singleModelSteps.has(event.step)) {
-                return event.stage === 'observe' ? (
-                  <StepCard
-                    key={`step-card-${event.step ?? index}`}
-                    events={eventsByStep.get(event.step) || []}
-                    step={event.step}
-                    active={running && event.step === metrics.lastStep}
-                    modelList={modelList}
-                    onRollback={stableRollback}
-                    rollbackLoading={rollbackLoading}
-                    openLightbox={setLightboxSrc}
-                    forceExpanded={cardsExpanded}
-                    onManualToggle={() => setCardsExpanded(null)}
-                    t={t}
-                  />
-                ) : null;
-              }
-              // 多模型：observe/action/result 都并入决策卡组（与单模型 StepCard 一致，一步一节点），这里跳过
-              if (multiModelSteps.has(event.step) && (event.stage === 'observe' || event.stage === 'action' || event.stage === 'result')) {
-                return null;
-              }
-            }
-
-            if (event.type === 'terminal_output' && (singleModelSteps.has(event.step) || multiModelSteps.has(event.step))) {
-              return null;
-            }
-
-            // consensus + 其余事件（status/notification/approval/done/error/...）
-            return (
-              <TraceItem
-                key={`${event.type}-${event.step ?? index}-${event.stage ?? index}`}
-                event={event}
-                modelList={modelList}
-                onRollback={stableRollback}
-                rollbackLoading={rollbackLoading}
-                openLightbox={setLightboxSrc}
-                t={t}
-              />
-            );
-          })}
-          <div ref={traceBottomRef} />
-        </div>
-      )}
+          {trace.length === 0 && running ? (
+            <div className="agent-skeleton">
+              <div className="agent-skeleton-line agent-skeleton-line--w60" />
+              <div className="agent-skeleton-line agent-skeleton-line--w90" />
+              <div className="agent-skeleton-line agent-skeleton-line--w70" />
+              <Loader2 size={14} className="agent-skeleton-spinner" />
+            </div>
+          ) : trace.length === 0 ? (
+            <div className="agent-empty">
+              <Monitor size={28} className="agent-empty-icon" />
+              <span>{t('agentPanel.emptyHint')}</span>
+            </div>
+          ) : showCurrentTrace ? (
+            <AgentTraceTimeline
+              trace={trace}
+              running={running}
+              modelList={modelList}
+              cardsExpanded={cardsExpanded}
+              onManualToggle={() => setCardsExpanded(null)}
+              onRollback={stableRollback}
+              rollbackLoading={rollbackLoading}
+              openLightbox={setLightboxSrc}
+              t={t}
+              bottomRef={traceBottomRef}
+            />
+          ) : null}
             </>
       </div>
     </section>

--- a/client/src/hooks/useAgentTransport.js
+++ b/client/src/hooks/useAgentTransport.js
@@ -1,7 +1,7 @@
 import { streamAgentRun, submitAgentApproval } from '../api/streams.js';
 import { apiFetch } from '../api/http.js';
 import { showAgentNotification } from '../notifications.js';
-import { touchSession } from './useChatSessions.js';
+import { touchSession, upsertAgentRun } from './useChatSessions.js';
 import { PHONE_BREAKPOINT } from '../utils/constants.js';
 import { useT } from '../i18n/I18nProvider.jsx';
 import { agentTraceEventKey, appendUniqueTraceEvent } from '../utils/agent-trace.js';
@@ -100,16 +100,21 @@ export function useAgentTransport({
       : [...messages, { role: 'user', content: text, ts: now, model: primaryModel, modelsUsed: runModels }];
 
     if (!isRetry) {
-      updateSession(sessionId, session =>
-        touchSession(session, {
+      updateSession(sessionId, session => {
+        const archivedSession = upsertAgentRun(session, {
+          runId: session.agentRunId,
+          trace: session.agentTrace,
+          meta: buildAgentMetaFromSession(session, session.agentTrace),
+        });
+        return touchSession(archivedSession, {
           messages: [...history, { role: 'assistant', content: t('agent.running'), pending: 'run', ts: now, model: primaryModel, modelsUsed: runModels }],
           model: primaryModel,
           modelsUsed: runModels,
           agentTrace: [],
           agentRunId: null,
           agentMeta: null,
-        })
-      );
+        });
+      });
       setInput('');
       setAgentTrace([]);
       agentRunIdRef.current = null;
@@ -226,27 +231,30 @@ export function useAgentTransport({
                   model: modelsUsed[0] || primaryModel,
                   modelsUsed,
                 };
-                return touchSession(session, {
+                const nextSession = {
+                  ...session,
                   messages: nextMessages,
                   model: modelsUsed[0] || primaryModel,
                   modelsUsed,
                   agentTrace: nextTrace,
                   agentRunId: agentRunIdRef.current,
-                  agentMeta: buildAgentMetaFromSession({
-                    ...session,
-                    messages: nextMessages,
-                    model: modelsUsed[0] || primaryModel,
-                    modelsUsed,
-                    agentRunId: agentRunIdRef.current,
-                  }, nextTrace, {
-                    task: text,
-                    startedAt: now,
-                    models: modelsUsed,
-                    strategy: runStrategy,
-                    status: event.quality?.status || event.meta?.status || 'done',
-                    runId: agentRunIdRef.current,
-                  }),
+                };
+                const agentMeta = buildAgentMetaFromSession(nextSession, nextTrace, {
+                  task: text,
+                  startedAt: now,
+                  models: modelsUsed,
+                  strategy: runStrategy,
+                  status: event.quality?.status || event.meta?.status || 'done',
+                  runId: agentRunIdRef.current,
                 });
+                return touchSession(upsertAgentRun({
+                  ...nextSession,
+                  agentMeta,
+                }, {
+                  runId: agentRunIdRef.current,
+                  trace: nextTrace,
+                  meta: agentMeta,
+                }));
               });
               return nextTrace;
             });
@@ -270,27 +278,30 @@ export function useAgentTransport({
                   model: modelsUsed[0] || primaryModel,
                   modelsUsed,
                 };
-                return touchSession(session, {
+                const nextSession = {
+                  ...session,
                   messages: nextMessages,
                   model: modelsUsed[0] || primaryModel,
                   modelsUsed,
                   agentTrace: nextTrace,
                   agentRunId: agentRunIdRef.current,
-                  agentMeta: buildAgentMetaFromSession({
-                    ...session,
-                    messages: nextMessages,
-                    model: modelsUsed[0] || primaryModel,
-                    modelsUsed,
-                    agentRunId: agentRunIdRef.current,
-                  }, nextTrace, {
-                    task: text,
-                    startedAt: now,
-                    models: modelsUsed,
-                    strategy: runStrategy,
-                    status: event.error === 'Agent 已取消' ? 'cancelled' : 'error',
-                    runId: agentRunIdRef.current,
-                  }),
+                };
+                const agentMeta = buildAgentMetaFromSession(nextSession, nextTrace, {
+                  task: text,
+                  startedAt: now,
+                  models: modelsUsed,
+                  strategy: runStrategy,
+                  status: event.error === 'Agent 已取消' ? 'cancelled' : 'error',
+                  runId: agentRunIdRef.current,
                 });
+                return touchSession(upsertAgentRun({
+                  ...nextSession,
+                  agentMeta,
+                }, {
+                  runId: agentRunIdRef.current,
+                  trace: nextTrace,
+                  meta: agentMeta,
+                }));
               });
               return nextTrace;
             });
@@ -336,49 +347,56 @@ export function useAgentTransport({
               } else {
                 next[lastIdx] = { role: 'assistant', content: t('agent.failed', { error: errorEvent.error || t('agent.connectionLostShort') }), ts: Date.now(), model: modelsUsed[0] || primaryModel, modelsUsed };
               }
-              return touchSession(session, {
+              const nextSession = {
+                ...session,
                 messages: next,
                 model: modelsUsed[0] || primaryModel,
                 modelsUsed,
                 agentTrace: prev,
                 agentRunId: agentRunIdRef.current,
-                agentMeta: buildAgentMetaFromSession({
-                  ...session,
-                  messages: next,
-                  model: modelsUsed[0] || primaryModel,
-                  modelsUsed,
-                  agentRunId: agentRunIdRef.current,
-                }, prev, {
-                  task: text,
-                  startedAt: now,
-                  models: modelsUsed,
-                  strategy: runStrategy,
-                  status: doneEvent ? (doneEvent.quality?.status || doneEvent.meta?.status || 'done') : (errorEvent.error === 'Agent 已取消' ? 'cancelled' : 'error'),
-                  runId: agentRunIdRef.current,
-                }),
-              });
-            }
-            const terminalEvent = doneEvent || errorEvent;
-            const modelsUsed = getEventModels(terminalEvent, runModels);
-            return touchSession(session, {
-              model: modelsUsed[0] || primaryModel,
-              modelsUsed,
-              agentTrace: prev,
-              agentRunId: agentRunIdRef.current,
-              agentMeta: buildAgentMetaFromSession({
-                ...session,
-                model: modelsUsed[0] || primaryModel,
-                modelsUsed,
-                agentRunId: agentRunIdRef.current,
-              }, prev, {
+              };
+              const agentMeta = buildAgentMetaFromSession(nextSession, prev, {
                 task: text,
                 startedAt: now,
                 models: modelsUsed,
                 strategy: runStrategy,
                 status: doneEvent ? (doneEvent.quality?.status || doneEvent.meta?.status || 'done') : (errorEvent.error === 'Agent 已取消' ? 'cancelled' : 'error'),
                 runId: agentRunIdRef.current,
-              }),
+              });
+              return touchSession(upsertAgentRun({
+                ...nextSession,
+                agentMeta,
+              }, {
+                runId: agentRunIdRef.current,
+                trace: prev,
+                meta: agentMeta,
+              }));
+            }
+            const terminalEvent = doneEvent || errorEvent;
+            const modelsUsed = getEventModels(terminalEvent, runModels);
+            const nextSession = {
+              ...session,
+              model: modelsUsed[0] || primaryModel,
+              modelsUsed,
+              agentTrace: prev,
+              agentRunId: agentRunIdRef.current,
+            };
+            const agentMeta = buildAgentMetaFromSession(nextSession, prev, {
+              task: text,
+              startedAt: now,
+              models: modelsUsed,
+              strategy: runStrategy,
+              status: doneEvent ? (doneEvent.quality?.status || doneEvent.meta?.status || 'done') : (errorEvent.error === 'Agent 已取消' ? 'cancelled' : 'error'),
+              runId: agentRunIdRef.current,
             });
+            return touchSession(upsertAgentRun({
+              ...nextSession,
+              agentMeta,
+            }, {
+              runId: agentRunIdRef.current,
+              trace: prev,
+              meta: agentMeta,
+            }));
           });
         } else if (prev.length === 0 || !prev.some(e => e.type === 'done' || e.type === 'error')) {
           // No events received at all or SSE disconnected without done/error

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -6,6 +6,7 @@ const LEGACY_MESSAGES_KEY = 'nvidia_chat_messages';
 const LEGACY_MODEL_KEY = 'nvidia_chat_model';
 const SESSIONS_KEY = 'nvidia_chat_sessions';
 const ACTIVE_SESSION_KEY = 'nvidia_chat_active_session';
+const MAX_AGENT_RUN_HISTORY = 30;
 
 function generateSessionId() {
   return `session_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
@@ -40,6 +41,60 @@ function normalizeModelId(value) {
   return typeof value === 'string' && value.trim() ? value : null;
 }
 
+function traceRunId(trace) {
+  if (!Array.isArray(trace)) {
+    return null;
+  }
+
+  for (let i = trace.length - 1; i >= 0; i -= 1) {
+    const runId = normalizeModelId(trace[i]?.runId);
+    if (runId) return runId;
+  }
+  return null;
+}
+
+function agentRunKey(run) {
+  return run?.runId || `${run?.meta?.startedAt || ''}:${run?.meta?.endedAt || ''}:${run?.meta?.task || ''}`;
+}
+
+function normalizeAgentRun(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const trace = Array.isArray(value.trace) ? value.trace : [];
+  const meta = normalizeAgentMeta(value.meta);
+  const runId = normalizeModelId(value.runId) || meta?.runId || traceRunId(trace);
+
+  if (!runId && !meta && trace.length === 0) {
+    return null;
+  }
+
+  return {
+    runId,
+    trace,
+    meta,
+  };
+}
+
+function normalizeAgentRuns(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set();
+  const runs = [];
+  for (const item of value) {
+    const run = normalizeAgentRun(item);
+    if (!run) continue;
+    const key = agentRunKey(run);
+    if (key && seen.has(key)) continue;
+    if (key) seen.add(key);
+    runs.push(run);
+  }
+  return runs.slice(0, MAX_AGENT_RUN_HISTORY);
+}
+
 export function createSession({
   id = generateSessionId(),
   messages = [],
@@ -48,6 +103,7 @@ export function createSession({
   agentTrace = [],
   agentRunId = null,
   agentMeta = null,
+  agentRuns = [],
   projectId = null,
   createdAt = Date.now(),
   updatedAt = Date.now(),
@@ -60,10 +116,30 @@ export function createSession({
     agentTrace: Array.isArray(agentTrace) ? agentTrace : [],
     agentRunId: typeof agentRunId === 'string' ? agentRunId : null,
     agentMeta: normalizeAgentMeta(agentMeta),
+    agentRuns: normalizeAgentRuns(agentRuns),
     // 会话归属的项目；null = 无项目（全局态，向后兼容旧会话）。
     projectId: typeof projectId === 'string' && projectId ? projectId : null,
     createdAt,
     updatedAt,
+  };
+}
+
+export function upsertAgentRun(session, runInput = {}) {
+  const run = normalizeAgentRun(runInput);
+  if (!session || !run) {
+    return session;
+  }
+
+  const key = agentRunKey(run);
+  const existingRuns = normalizeAgentRuns(session.agentRuns);
+  const nextRuns = [
+    run,
+    ...existingRuns.filter(item => agentRunKey(item) !== key),
+  ];
+
+  return {
+    ...session,
+    agentRuns: normalizeAgentRuns(nextRuns),
   };
 }
 
@@ -83,6 +159,7 @@ export function normalizeChatState(rawState) {
             agentTrace: session.agentTrace,
             agentRunId: session.agentRunId,
             agentMeta: session.agentMeta,
+            agentRuns: session.agentRuns,
             projectId: session.projectId,
             createdAt: Number.isFinite(session.createdAt) ? session.createdAt : Date.now(),
             updatedAt: Number.isFinite(session.updatedAt) ? session.updatedAt : Date.now(),
@@ -157,15 +234,25 @@ function isQuotaError(err) {
     || err.code === 1014;
 }
 
+function stripAgentRunTraces(agentRuns) {
+  return normalizeAgentRuns(agentRuns).map(run => (
+    run.trace && run.trace.length > 0
+      ? { ...run, trace: [] }
+      : run
+  ));
+}
+
 function stripAgentTrace(sessions) {
   // agentTrace 是 SSE 事件流的客户端镜像，单个 run 可达几 MB。
   // 服务端已经在 data/traces/<runId>.jsonl 全量落盘，并通过 /api/agent/traces/:runId 提供按需拉取，
   // localStorage 只需要保存 agentRunId，刷新后由 App.jsx 的 useEffect 触发拉取重建。
-  return sessions.map(session => (
-    session.agentTrace && session.agentTrace.length
-      ? { ...session, agentTrace: [] }
-      : session
-  ));
+  return sessions.map(session => {
+    const agentRuns = stripAgentRunTraces(session.agentRuns);
+    if ((session.agentTrace && session.agentTrace.length) || agentRuns !== session.agentRuns) {
+      return { ...session, agentTrace: [], agentRuns };
+    }
+    return session;
+  });
 }
 
 function persistSessions(sessions) {

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -194,6 +194,9 @@ export const en = {
   'agentPanel.metricSlowestStep': 'Slowest',
   'agentPanel.stepLatency': 'Step latency',
   'agentPanel.recentRun': 'Recent run',
+  'agentPanel.previousRuns': 'Previous runs',
+  'agentPanel.historyLoading': 'Loading previous steps…',
+  'agentPanel.historyTraceUnavailable': 'No saved steps were found for this run',
 
   // Agent stats
   'agentStats.eyebrow': 'Current project',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -195,6 +195,9 @@ export const zh = {
   'agentPanel.metricSlowestStep': '最慢步骤',
   'agentPanel.stepLatency': '步骤耗时',
   'agentPanel.recentRun': '最近执行',
+  'agentPanel.previousRuns': '历史执行',
+  'agentPanel.historyLoading': '正在加载历史步骤…',
+  'agentPanel.historyTraceUnavailable': '未找到这次执行的历史步骤',
 
   // Agent 统计
   'agentStats.eyebrow': '当前项目',

--- a/client/src/utils/agent-stats.js
+++ b/client/src/utils/agent-stats.js
@@ -244,12 +244,35 @@ export function buildAgentMetaFromSession(session, traceInput, overrides = {}) {
 }
 
 export function buildAgentStats(sessions, { now = Date.now(), days = 7 } = {}) {
+  const seen = new Set();
   const records = (Array.isArray(sessions) ? sessions : [])
-    .map(session => {
-      const meta = buildAgentMetaFromSession(session);
-      return meta ? { ...meta, sessionId: session.id } : null;
+    .flatMap(session => {
+      const runs = Array.isArray(session.agentRuns) ? session.agentRuns : [];
+      const metas = runs
+        .map(run => buildAgentMetaFromSession({
+          ...session,
+          agentRunId: run.runId || session.agentRunId,
+          agentTrace: Array.isArray(run.trace) ? run.trace : [],
+          agentMeta: run.meta || null,
+        }, Array.isArray(run.trace) ? run.trace : [], {
+          runId: run.runId || run.meta?.runId,
+        }))
+        .filter(Boolean);
+
+      const currentMeta = buildAgentMetaFromSession(session);
+      if (currentMeta) {
+        metas.push(currentMeta);
+      }
+
+      return metas
+        .map(meta => {
+          const key = meta.runId || `${meta.startedAt || ''}:${meta.endedAt || ''}:${meta.task || ''}`;
+          if (key && seen.has(key)) return null;
+          if (key) seen.add(key);
+          return { ...meta, sessionId: session.id };
+        })
+        .filter(Boolean);
     })
-    .filter(Boolean)
     .sort((a, b) => (b.endedAt || b.startedAt || 0) - (a.endedAt || a.startedAt || 0));
 
   const todayStart = startOfDay(now);

--- a/test/agent-stats.test.js
+++ b/test/agent-stats.test.js
@@ -119,4 +119,67 @@ describe('buildAgentStats', () => {
     expect(stats.recentRuns.map(item => item.sessionId)).toEqual(['today', 'yesterday']);
     expect(stats.dailyData.at(-1)).toMatchObject({ date: '2026-06-30', tokens: 1500, runs: 1 });
   });
+
+  it('统计同一会话内的多次 agentRuns，并按 runId 去重当前 run', () => {
+    const now = at(2026, 5, 30, 12, 0);
+    const first = at(2026, 5, 30, 9, 0);
+    const second = at(2026, 5, 30, 10, 0);
+    const sessions = [
+      {
+        id: 'multi-run-session',
+        agentRunId: 'run_second',
+        agentMeta: {
+          task: '第二次问题',
+          startedAt: second,
+          endedAt: second + 2000,
+          elapsedMs: 2000,
+          totalTokens: 700,
+          stepCount: 2,
+          models: ['m2'],
+          strategy: 'race',
+          status: 'done',
+          runId: 'run_second',
+        },
+        agentRuns: [
+          {
+            runId: 'run_second',
+            meta: {
+              task: '第二次问题',
+              startedAt: second,
+              endedAt: second + 2000,
+              elapsedMs: 2000,
+              totalTokens: 700,
+              stepCount: 2,
+              models: ['m2'],
+              strategy: 'race',
+              status: 'done',
+              runId: 'run_second',
+            },
+          },
+          {
+            runId: 'run_first',
+            meta: {
+              task: '第一次问题',
+              startedAt: first,
+              endedAt: first + 1000,
+              elapsedMs: 1000,
+              totalTokens: 300,
+              stepCount: 1,
+              models: ['m1'],
+              strategy: 'race',
+              status: 'done',
+              runId: 'run_first',
+            },
+          },
+        ],
+      },
+    ];
+
+    const stats = buildAgentStats(sessions, { now });
+
+    expect(stats.totalRuns).toBe(2);
+    expect(stats.todayRuns).toBe(2);
+    expect(stats.todayTokens).toBe(1000);
+    expect(stats.recentRuns.map(item => item.runId)).toEqual(['run_second', 'run_first']);
+  });
 });


### PR DESCRIPTION
Summary: Preserve completed Agent runs in session history so a second task no longer clears earlier steps. Add an expandable history section with compact step-grouped timelines, make the recent run collapsible, and place the recent run below historical runs. Tests: npm run lint; npm run build:client; npm run typecheck; npm test.