### PR TITLE
Use structured step result status

### DIFF
--- a/agent/core/checkpoint.ts
+++ b/agent/core/checkpoint.ts
@@ -112,8 +112,11 @@ function failedPath(dir: string, runId: string, step: number) {
   return join(sessionDir(dir, runId), `session-failed-${step}.json`);
 }
 
-function assessHealth(result: any) {
+function assessHealth(result: any, resultStatus?: any) {
+  if (resultStatus === 'failed') return 'unhealthy';
+  if (resultStatus === 'rejected') return 'degraded';
   if (!result || typeof result !== 'string') return 'unknown';
+  // Legacy snapshots from before resultStatus existed.
   if (result.startsWith('执行失败')) return 'unhealthy';
   if (result.startsWith('操作未获批准')) return 'degraded';
   return 'healthy';
@@ -154,7 +157,7 @@ async function pruneSnapshots(dir: string, runId: string, type: string, keepCoun
   } catch { /* ignore */ }
 }
 
-export async function saveHealthySnapshot({ dir, runId, step, history, state, result, usage = {} }: { dir: any; runId: any; step: any; history: any; state: any; result: any; usage?: any }) {
+export async function saveHealthySnapshot({ dir, runId, step, history, state, result, resultStatus, resultError, usage = {} }: { dir: any; runId: any; step: any; history: any; state: any; result: any; resultStatus?: any; resultError?: any; usage?: any }) {
   const cpDir = sessionDir(dir, runId);
   await mkdir(cpDir, { recursive: true });
 
@@ -167,13 +170,17 @@ export async function saveHealthySnapshot({ dir, runId, step, history, state, re
       rationale: h.rationale,
       action: h.action,
       result: typeof h.result === 'string' ? h.result.slice(0, 2000) : '',
+      resultStatus: h.resultStatus,
+      resultError: h.resultError,
       url: h.url,
       title: h.title,
       observation: h.observation ? { url: h.observation.url, title: h.observation.title, text: typeof h.observation.text === 'string' ? h.observation.text.slice(0, 500) : undefined } : undefined,
     })),
     state: sanitizeState(state),
     usage: usage || {},
-    health: assessHealth(result),
+    health: assessHealth(result, resultStatus),
+    resultStatus,
+    resultError,
     timestamp: Date.now(),
   };
 

--- a/agent/core/result-quality.ts
+++ b/agent/core/result-quality.ts
@@ -33,6 +33,25 @@ function textOf(value: any) {
   return value == null ? '' : String(value);
 }
 
+function normalizeResultStatus(step: any) {
+  const value = typeof step?.resultStatus === 'string'
+    ? step.resultStatus
+    : (typeof step?.status === 'string' ? step.status : '');
+  const status = value.trim().toLowerCase();
+  if (status === 'success' || status === 'failed' || status === 'rejected') return status;
+  return '';
+}
+
+function legacyResultMatchesFailure(result: string) {
+  return FAILURE_PATTERNS.some(pattern => pattern.test(result));
+}
+
+function stepFailed(step: any) {
+  const status = normalizeResultStatus(step);
+  if (status) return status === 'failed';
+  return legacyResultMatchesFailure(textOf(step?.result));
+}
+
 function urlsFromText(text: string) {
   return Array.from(text.matchAll(/https?:\/\/[^\s)\]"'<>，。]+/g)).map(match => match[0]);
 }
@@ -60,7 +79,7 @@ function resultHasUsableOfficialContent(step: any) {
   if (!hasOfficialUrl(url) && !hasOfficialUrl(result)) {
     return false;
   }
-  if (FAILURE_PATTERNS.some(pattern => pattern.test(result))) {
+  if (stepFailed(step) || legacyResultMatchesFailure(result)) {
     return false;
   }
   return result.trim().length >= 80;
@@ -84,7 +103,7 @@ function browseStepProducedContent(step: any) {
   // 浏览类工具的"成功观测"判定：result 非空、不命中失败模式、且包含 url 或 ≥200 字正文。
   const result = textOf(step?.result);
   if (!result.trim()) return false;
-  if (FAILURE_PATTERNS.some(pattern => pattern.test(result))) return false;
+  if (stepFailed(step) || legacyResultMatchesFailure(result)) return false;
   if (/https?:\/\//.test(result) && result.length >= 200) return true;
   return result.length >= 400;
 }
@@ -98,7 +117,7 @@ export function assessResultQuality({ task, steps = [], answer = '' }: { task: s
     // 不应被当作失败步骤。
     const actionType = step?.action?.type;
     if (actionType === 'chrome_list_tools' || actionType === 'ide_list_tools') return false;
-    return FAILURE_PATTERNS.some(pattern => pattern.test(textOf(step?.result)));
+    return stepFailed(step);
   });
   const officialSourceSteps = steps.filter(resultHasUsableOfficialContent);
   const browseSteps = steps.filter(isBrowseStep);

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -147,6 +147,32 @@ function resultFingerprint(result) {
   return String(result ?? '').replace(/\s+/g, ' ').trim().slice(0, 2000);
 }
 
+function normalizeResultStatus(status) {
+  const value = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  if (value === 'success' || value === 'failed' || value === 'rejected') return value;
+  return '';
+}
+
+function normalizeActionResult(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const isStructuredResult = Object.prototype.hasOwnProperty.call(value, 'resultStatus')
+      || Object.prototype.hasOwnProperty.call(value, 'result')
+      || Object.prototype.hasOwnProperty.call(value, 'ok')
+      || Object.prototype.hasOwnProperty.call(value, 'error')
+      || Object.prototype.hasOwnProperty.call(value, 'message');
+    if (!isStructuredResult) {
+      return { result: value, resultStatus: 'success', resultError: null };
+    }
+    const resultStatus = normalizeResultStatus(value.resultStatus || value.status)
+      || (value.ok === false ? 'failed' : 'success');
+    const resultError = value.error == null ? null : String(value.error);
+    const result = value.result ?? value.message ?? resultError ?? '';
+    return { result, resultStatus, resultError };
+  }
+
+  return { result: value, resultStatus: 'success', resultError: null };
+}
+
 function isVisionImageAnalyze(action) {
   return action?.tool === 'vision' && action?.type === 'image_analyze' && typeof action?.image === 'string';
 }
@@ -363,12 +389,16 @@ export async function runAgentRuntime({
 
       if (authorization?.status === "rejected") {
         const result = authorization.message || "操作未获批准";
+        const resultStatus = "rejected";
+        const resultError = result;
         const url = actionTargetUrl(decision.action) || observation?.url;
         history.push({
           step,
           rationale: decision.rationale,
           action: decision.action,
           result,
+          resultStatus,
+          resultError,
           url,
           title: observation?.title,
         });
@@ -378,6 +408,8 @@ export async function runAgentRuntime({
           step,
           stage: "result",
           result,
+          resultStatus,
+          resultError,
         });
         continue;
       }
@@ -393,15 +425,20 @@ export async function runAgentRuntime({
 
       // ---- 执行 ----
       let result;
+      let resultStatus = "success";
+      let resultError = null;
       try {
-        result = await execute(state, decision.action, {
+        const rawResult = await execute(state, decision.action, {
           task,
           step,
           history,
           observation,
           authorization,
         });
+        ({ result, resultStatus, resultError } = normalizeActionResult(rawResult));
       } catch (execErr) {
+        resultStatus = "failed";
+        resultError = execErr.message;
         result = `执行失败: ${execErr.message}`;
         log.error(`[Runtime] step ${step} execute error: ${execErr.message}`);
       }
@@ -415,6 +452,8 @@ export async function runAgentRuntime({
         rationale: decision.rationale,
         action: decision.action,
         result,
+        resultStatus,
+        resultError,
         url: actionTargetUrl(decision.action) || observation?.url,
         title: observation?.title,
       });
@@ -425,6 +464,8 @@ export async function runAgentRuntime({
           step,
           stage: "result",
           result,
+          resultStatus,
+          resultError,
         });
       }
 
@@ -441,6 +482,8 @@ export async function runAgentRuntime({
           history: history.map(h => ({ ...h })),
           state: saveSessionSnapshot ? sanitizeStateForSnapshot(state) : { ...state },
           result,
+          resultStatus,
+          resultError,
           usage: decision.usage,
         };
         const saveSnapshot = saveSessionSnapshot || saveHealthySnapshot;

--- a/client/src/components/agent/ModelPlanGroup.jsx
+++ b/client/src/components/agent/ModelPlanGroup.jsx
@@ -15,6 +15,7 @@ export function ModelPlanGroup({ events, step, models, modelList, agentFinished,
   let consensusEvent = null;
   const modelEvents = {};
   let stepResult = null;
+  let stepResultEvent = null;
   let observation = null;
   const terminalEvents = [];
 
@@ -30,6 +31,7 @@ export function ModelPlanGroup({ events, step, models, modelList, agentFinished,
       }
       modelEvents[e.model] = e;
     } else if (e.type === 'step' && e.stage === 'result') {
+      stepResultEvent = e;
       stepResult = e.result;
     } else if (e.type === 'step' && e.stage === 'observe') {
       observation = e.observation;
@@ -51,7 +53,8 @@ export function ModelPlanGroup({ events, step, models, modelList, agentFinished,
   const collapsedModels = models.filter(m => { const s = getEvent(m).stage; return s === 'cancelled' || s === 'failed' || s === 'rate_limited'; });
 
   // 这步执行结果命中失败模式时整节点标红（与单模型 StepCard 一致；截图结果不判失败）
-  const failed = !!stepResult && !resultScreenshot(stepResult) && isFailureResult(stepResult);
+  const stepResultStatus = stepResultEvent?.resultStatus || stepResultEvent?.status;
+  const failed = !resultScreenshot(stepResult) && isFailureResult(stepResult, stepResultStatus);
 
   // winner 排第一行——它带 step 号与回滚，等价于单模型那一行。
   const orderedVisible = winnerModel && visibleModels.includes(winnerModel)
@@ -97,7 +100,7 @@ export function ModelPlanGroup({ events, step, models, modelList, agentFinished,
         <ObserveSummary observation={observation} openLightbox={openLightbox} t={t} />
         <TerminalProcess events={terminalEvents} running={!agentFinished && !stepResult} t={t} />
         {/* 执行结果：节点底部统一展示（winner 的结果），与单模型 StepCard 口径一致 */}
-        <ResultSummary result={stepResult} openLightbox={openLightbox} forceExpanded={cardsExpanded} onManualToggle={onManualToggle} t={t} />
+        <ResultSummary result={stepResult} resultStatus={stepResultStatus} openLightbox={openLightbox} forceExpanded={cardsExpanded} onManualToggle={onManualToggle} t={t} />
       </div>
     </div>
   );

--- a/client/src/components/agent/ResultSummary.jsx
+++ b/client/src/components/agent/ResultSummary.jsx
@@ -10,7 +10,7 @@ import { resultScreenshot, splitFailureHighlights } from './result-status.js';
 
 const CLAMP_THRESHOLD = 80; // 超过该长度才显示「展开/收起」
 
-export function ResultSummary({ result, openLightbox, forceExpanded, onManualToggle, t }) {
+export function ResultSummary({ result, resultStatus, openLightbox, forceExpanded, onManualToggle, t }) {
   const [open, setOpen] = useState(false);
   const eff = forceExpanded != null ? forceExpanded : open;
   if (!result) return null;
@@ -34,7 +34,7 @@ export function ResultSummary({ result, openLightbox, forceExpanded, onManualTog
       <div className="step-card-result-body">
         <CornerDownRight size={12} className="step-card-result-icon" />
         <p className={eff ? '' : 'clamp-2'}>
-          {splitFailureHighlights(result).map((seg, i) => (
+          {splitFailureHighlights(result, resultStatus).map((seg, i) => (
             seg.hit ? <span key={i} className="result-keyword">{seg.text}</span> : seg.text
           ))}
         </p>

--- a/client/src/components/agent/StepCard.jsx
+++ b/client/src/components/agent/StepCard.jsx
@@ -32,12 +32,12 @@ export const StepCard = memo(function StepCard({ events, step, active, modelList
 
   // 从本步事件切片里拆出各阶段。action 信息优先取 step/action 事件，
   // 缺失时（如授权被拒只有 result）回退到 model_plan 决策事件。
-  let observation = null, actionEvent = null, result = null, modelEvent = null;
+  let observation = null, actionEvent = null, resultEvent = null, result = null, modelEvent = null;
   const terminalEvents = [];
   for (const e of events) {
     if (e.type === 'step' && e.stage === 'observe') observation = e.observation;
     else if (e.type === 'step' && e.stage === 'action') actionEvent = e;
-    else if (e.type === 'step' && e.stage === 'result') result = e.result;
+    else if (e.type === 'step' && e.stage === 'result') { resultEvent = e; result = e.result; }
     else if (e.type === 'model_plan' && (e.stage === 'success' || e.stage === 'winner')) modelEvent = e;
     else if (e.type === 'terminal_output') terminalEvents.push(e);
   }
@@ -51,7 +51,8 @@ export const StepCard = memo(function StepCard({ events, step, active, modelList
   const modelLabel = modelEvent ? getModelLabel(modelEvent.model, modelList) : null;
 
   // 文本结果命中失败模式时整卡标红（截图结果不参与判定）
-  const failed = !!result && !resultScreenshot(result) && isFailureResult(result);
+  const resultStatus = resultEvent?.resultStatus || resultEvent?.status;
+  const failed = !resultScreenshot(result) && isFailureResult(result, resultStatus);
 
   // 切换本地展开态；若当前受 forceExpanded 接管，先通知父组件解除接管再翻转本地态。
   const toggle = setter => () => { if (forceExpanded != null) onManualToggle?.(); setter(v => !v); };
@@ -112,7 +113,7 @@ export const StepCard = memo(function StepCard({ events, step, active, modelList
         <TerminalProcess events={terminalEvents} running={active && !result} t={t} />
 
         {/* 执行结果（与多模型卡组共用同一组件，口径一致） */}
-        <ResultSummary result={result} openLightbox={openLightbox} forceExpanded={forceExpanded} onManualToggle={onManualToggle} t={t} />
+        <ResultSummary result={result} resultStatus={resultStatus} openLightbox={openLightbox} forceExpanded={forceExpanded} onManualToggle={onManualToggle} t={t} />
       </div>
     </div>
   );

--- a/client/src/components/agent/result-status.js
+++ b/client/src/components/agent/result-status.js
@@ -1,21 +1,33 @@
-// 单步 result 的成败判定：与后端 agent/core/result-quality.ts 的 FAILURE_PATTERNS 同源，
-// 让前端能把「失败/异常的那一步」在时间线上标红，无需后端额外下发逐步状态字段。
+// 单步 result 的成败判定：新 trace 优先使用后端下发的结构化 resultStatus，
+// 老 trace 没有 resultStatus 时才回退到文本关键词。
 //
-// ⚠️ 两处正则需同步维护：后端据此把整体质量降级为 done_degraded，前端据此给 StepCard 着色。
-// 误报代价仅是多标一个红点，故宁可与后端保持一致，不在前端自行收紧。
+// ⚠️ 关键词只用于历史兼容；不要再把它作为新执行的主判定方式，否则会误标
+// “未找到明显问题”这类正常结果。
 
 const FAILURE_PATTERN = /执行失败|操作失败|访问失败|导航超时|访问超时|timeout|timed out|404 Not Found|403 Forbidden|already running|反爬|验证码|人机验证|安全验证|滑块|页面内容为空|未找到|不存在|撤稿|删除|rate.?limit|429|请求已中断|Web应用防护|Web安全风险|访问不合规|已阻止访问搜索引擎/i;
 
-// result 命中失败模式时返回 true。非字符串/空值视为「无失败信号」。
-export function isFailureResult(result) {
+function normalizeResultStatus(status) {
+  const value = typeof status === 'string' ? status.trim().toLowerCase() : '';
+  if (value === 'success' || value === 'failed' || value === 'rejected') return value;
+  return '';
+}
+
+// 新 trace 有 resultStatus 时按状态返回；旧 trace 没有状态时才用关键词 fallback。
+export function isFailureResult(result, resultStatus) {
+  const status = normalizeResultStatus(resultStatus);
+  if (status) return status === 'failed';
   if (!result || typeof result !== 'string') return false;
   return FAILURE_PATTERN.test(result);
 }
 
 // 把结果文本切成片段，命中失败关键词的片段标记 hit=true——供前端只高亮关键词，
 // 而非整段标红（主体文字保持正常可读）。与 isFailureResult 用同一套模式，口径一致。
-export function splitFailureHighlights(text) {
+export function splitFailureHighlights(text, resultStatus) {
   if (!text || typeof text !== 'string') return [];
+  const status = normalizeResultStatus(resultStatus);
+  if (status && status !== 'failed') {
+    return [{ text, hit: false }];
+  }
   const re = new RegExp(FAILURE_PATTERN.source, 'gi');
   const parts = [];
   let last = 0, m;

--- a/client/src/components/agent/trace-metrics.js
+++ b/client/src/components/agent/trace-metrics.js
@@ -108,7 +108,7 @@ export function computeTraceMetrics(trace) {
     if (event.type === 'step' && event.step != null && event.stage === 'result') {
       const step = getStep(event.step);
       step.hasResult = true;
-      step.failed = isFailureResult(event.result);
+      step.failed = isFailureResult(event.result, event.resultStatus || event.status);
     }
     if (event.type === 'done' && Number.isFinite(event.meta?.elapsed_ms)) {
       doneElapsedMs = event.meta.elapsed_ms;

--- a/test/result-quality.test.ts
+++ b/test/result-quality.test.ts
@@ -24,6 +24,31 @@ describe('result quality assessment', () => {
     expect(quality.failure_steps).toEqual([1, 2]);
   });
 
+  it('prefers structured resultStatus over failure keywords for new traces', () => {
+    const quality = assessResultQuality({
+      task: '检查代码问题',
+      steps: [
+        {
+          step: 1,
+          action: { tool: 'fs', type: 'search_files' },
+          result: '未找到明显问题',
+          resultStatus: 'success',
+        },
+        {
+          step: 2,
+          action: { tool: 'terminal', type: 'run_safe' },
+          result: 'command exited without details',
+          resultStatus: 'failed',
+          resultError: 'exit code 1',
+        },
+      ],
+      answer: '完成',
+    });
+
+    expect(quality.status).toBe('done_degraded');
+    expect(quality.failure_steps).toEqual([2]);
+  });
+
   it('uses nested action arguments URL when checking official sources', () => {
     const quality = assessResultQuality({
       task: '查询医保政策',

--- a/test/result-status.test.js
+++ b/test/result-status.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { isFailureResult, splitFailureHighlights } from '../client/src/components/agent/result-status.js';
+
+describe('agent result status helpers', () => {
+  it('uses structured result status before legacy keywords', () => {
+    expect(isFailureResult('未找到明显问题', 'success')).toBe(false);
+    expect(isFailureResult('未找到明显问题', 'rejected')).toBe(false);
+    expect(isFailureResult('command exited without keywords', 'failed')).toBe(true);
+  });
+
+  it('does not highlight legacy failure keywords for structured non-failures', () => {
+    expect(splitFailureHighlights('未找到明显问题', 'success')).toEqual([
+      { text: '未找到明显问题', hit: false },
+    ]);
+    expect(splitFailureHighlights('未找到明显问题', 'rejected')).toEqual([
+      { text: '未找到明显问题', hit: false },
+    ]);
+  });
+});

--- a/test/session-checkpoint.test.ts
+++ b/test/session-checkpoint.test.ts
@@ -161,6 +161,39 @@ describe('runtime: session checkpoint integration', () => {
     expect(result.steps[0].url).toBe('https://target.example/page');
   });
 
+  it('emits structured result status for execution failures', async () => {
+    const cancelSignal = new AbortController().signal;
+    const { log: evtLog, onEvent } = events();
+
+    const result = await runAgentRuntime({
+      task: 'run command',
+      maxSteps: 2,
+      onEvent,
+      cancelSignal,
+      initialize: noop,
+      observe: noop,
+      decide: ({ step }) => step === 1
+        ? { action: { tool: 'terminal', type: 'run_safe', command: 'bad' }, rationale: 'run' }
+        : { action: { type: 'finish', answer: 'done' }, rationale: 'finish' },
+      authorize: noop,
+      execute: (_state, action) => {
+        if (action.type === 'finish') return action.answer;
+        throw new Error('exit code 1');
+      },
+      cleanup: noop,
+    });
+
+    const resultEvent = evtLog.find(e => e.type === 'step' && e.stage === 'result');
+    expect(resultEvent).toMatchObject({
+      resultStatus: 'failed',
+      resultError: 'exit code 1',
+    });
+    expect(result.steps[0]).toMatchObject({
+      resultStatus: 'failed',
+      resultError: 'exit code 1',
+    });
+  });
+
   it('stops before repeatedly executing the same action with the same result', async () => {
     const cancelSignal = new AbortController().signal;
     const { log: evtLog, onEvent } = events();

--- a/test/trace-metrics.test.js
+++ b/test/trace-metrics.test.js
@@ -45,4 +45,23 @@ describe('trace metrics', () => {
     expect(metrics.slowestStep).toMatchObject({ step: 1, status: 'failed' });
     expect(formatDurationMs(metrics.slowestStep.durationMs)).toBe('13s');
   });
+
+  it('prefers structured resultStatus over legacy keyword matching', () => {
+    const trace = [
+      { type: 'step', step: 1, stage: 'observe', timestamp: 0 },
+      { type: 'step', step: 1, stage: 'action', action: { tool: 'fs', type: 'search_files' }, timestamp: 100 },
+      { type: 'step', step: 1, stage: 'result', result: '未找到明显问题', resultStatus: 'success', timestamp: 200 },
+      { type: 'step', step: 2, stage: 'observe', timestamp: 300 },
+      { type: 'step', step: 2, stage: 'action', action: { tool: 'terminal', type: 'run_safe' }, timestamp: 400 },
+      { type: 'step', step: 2, stage: 'result', result: 'process exited', resultStatus: 'failed', timestamp: 500 },
+    ];
+
+    const metrics = computeTraceMetrics(trace);
+
+    expect(metrics.toolFailures).toBe(1);
+    expect(metrics.stepDurations.map(step => [step.step, step.status])).toEqual([
+      [1, 'fast'],
+      [2, 'failed'],
+    ]);
+  });
 });


### PR DESCRIPTION
Summary: Emit structured resultStatus/resultError for step results and snapshots. Prefer resultStatus over legacy keyword matching in backend quality checks, frontend status, and highlighting. Add tests for keyword false positives and structured failures. Tests: npm run lint, npm run typecheck, npm run build:client, npm test.