### PR TITLE
Improve agent retry handling and recent run UI

### DIFF
--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -28,6 +28,48 @@ function buildRecentUrlsHint(history: any[], lookback = 5): string | null {
   return `最近访问过的 URL（避免重复访问相同页面，除非有明确新目的）：\n${lines.join('\n')}`;
 }
 
+function searchResultFailed(entry: any) {
+  const status = typeof entry?.resultStatus === 'string'
+    ? entry.resultStatus.trim().toLowerCase()
+    : '';
+  const result = String(entry?.result ?? '').trim();
+  return status === 'failed' || /^web_search\s+失败/.test(result);
+}
+
+function buildRecentSearchesHint(history: any[], lookback = 6): string | null {
+  if (!Array.isArray(history) || history.length === 0) return null;
+  const recent = history.slice(-lookback);
+  const counts = new Map<string, { count: number; failed: number }>();
+  const order: string[] = [];
+
+  for (const entry of recent) {
+    const action = entry?.action || {};
+    if (action.tool !== 'search' || action.type !== 'web_search') continue;
+    const query = typeof action.query === 'string' ? action.query.trim() : '';
+    if (!query) continue;
+    if (!counts.has(query)) {
+      order.push(query);
+      counts.set(query, { count: 0, failed: 0 });
+    }
+    const item = counts.get(query)!;
+    item.count += 1;
+    if (searchResultFailed(entry)) item.failed += 1;
+  }
+
+  const lines = order
+    .map(query => ({ query, stats: counts.get(query)! }))
+    .filter(({ stats }) => stats.count >= 2 || stats.failed > 0)
+    .map(({ query, stats }) => {
+      const markers = [];
+      if (stats.count >= 2) markers.push(`已搜索 ${stats.count} 次`);
+      if (stats.failed > 0) markers.push(`失败 ${stats.failed} 次`);
+      return `- "${query}" ${markers.join('，')}【不要原样重复，换关键词、换来源或停止说明限制】`;
+    });
+
+  if (lines.length === 0) return null;
+  return `最近搜索过的 query（避免在失败或重复后原样重试）：\n${lines.join('\n')}`;
+}
+
 export function buildDesktopAgentSystemPrompt(systemPrompt: string | null) {
   const ideLines = buildIdePromptLines();
   const chromeLines = buildChromePromptLines();
@@ -82,9 +124,10 @@ export function buildClaudeTaskMessages({
     }
   }
   const recentUrlsHint = buildRecentUrlsHint(history);
+  const recentSearchesHint = buildRecentSearchesHint(history);
   messages.push({
     role: 'user',
-    content: JSON.stringify({ task, step, history, observation, ...(recentUrlsHint ? { recentUrlsHint } : {}) }),
+    content: JSON.stringify({ task, step, history, observation, ...(recentUrlsHint ? { recentUrlsHint } : {}), ...(recentSearchesHint ? { recentSearchesHint } : {}) }),
   });
   return messages;
 }
@@ -111,9 +154,10 @@ export function buildGeminiTaskMessages({
     }
   }
   const recentUrlsHint = buildRecentUrlsHint(history);
+  const recentSearchesHint = buildRecentSearchesHint(history);
   contents.push({
     role: 'user',
-    parts: [{ text: JSON.stringify({ task, step, history, observation, ...(recentUrlsHint ? { recentUrlsHint } : {}) }) }],
+    parts: [{ text: JSON.stringify({ task, step, history, observation, ...(recentUrlsHint ? { recentUrlsHint } : {}), ...(recentSearchesHint ? { recentSearchesHint } : {}) }) }],
   });
   return { contents };
 }
@@ -144,6 +188,7 @@ export function buildNvidiaTaskMessages({
     : '';
 
   const recentUrlsHint = buildRecentUrlsHint(history);
+  const recentSearchesHint = buildRecentSearchesHint(history);
 
   return [
     {
@@ -225,7 +270,7 @@ export function buildNvidiaTaskMessages({
     },
     {
       role: 'user',
-      content: JSON.stringify({ task, step, history, observation, ...(recentUrlsHint ? { recentUrlsHint } : {}) }),
+      content: JSON.stringify({ task, step, history, observation, ...(recentUrlsHint ? { recentUrlsHint } : {}), ...(recentSearchesHint ? { recentSearchesHint } : {}) }),
     },
   ];
 }

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -153,10 +153,15 @@ function normalizeResultStatus(status) {
   return '';
 }
 
+function historyEntryFailed(entry) {
+  return normalizeResultStatus(entry?.resultStatus || entry?.status) === 'failed';
+}
+
 function normalizeActionResult(value) {
   if (value && typeof value === 'object' && !Array.isArray(value)) {
     const isStructuredResult = Object.prototype.hasOwnProperty.call(value, 'resultStatus')
       || Object.prototype.hasOwnProperty.call(value, 'result')
+      || Object.prototype.hasOwnProperty.call(value, 'resultError')
       || Object.prototype.hasOwnProperty.call(value, 'ok')
       || Object.prototype.hasOwnProperty.call(value, 'error')
       || Object.prototype.hasOwnProperty.call(value, 'message');
@@ -165,7 +170,9 @@ function normalizeActionResult(value) {
     }
     const resultStatus = normalizeResultStatus(value.resultStatus || value.status)
       || (value.ok === false ? 'failed' : 'success');
-    const resultError = value.error == null ? null : String(value.error);
+    const resultError = value.resultError != null
+      ? String(value.resultError)
+      : (value.error == null ? null : String(value.error));
     const result = value.result ?? value.message ?? resultError ?? '';
     return { result, resultStatus, resultError };
   }
@@ -187,6 +194,7 @@ function detectRepeatedActionLoop(history, action) {
 
   let count = 0;
   let fingerprint = null;
+  let allFailed = true;
   for (let i = history.length - 1; i >= 0; i -= 1) {
     const entry = history[i];
     if (actionLoopKey(entry?.action) !== key) break;
@@ -198,11 +206,13 @@ function detectRepeatedActionLoop(history, action) {
     } else if (fingerprint !== current) {
       break;
     }
+    if (!historyEntryFailed(entry)) allFailed = false;
     count += 1;
   }
 
+  if (count >= 1 && allFailed) return { count, key, result: fingerprint || '', failed: true };
   if (count < LOOP_REPEAT_THRESHOLD) return null;
-  return { count, key, result: fingerprint || '' };
+  return { count, key, result: fingerprint || '', failed: false };
 }
 
 function detectRepeatedVisionLoop(history, action) {
@@ -356,7 +366,9 @@ export async function runAgentRuntime({
       const repeatedLoop = detectRepeatedActionLoop(history, decision.action);
       if (repeatedLoop) {
         const actionSummary = summarizeActionForLoop(decision.action);
-        finalAnswer = `检测到 Agent 连续 ${repeatedLoop.count + 1} 次准备重复执行同一动作（${actionSummary}），且前 ${repeatedLoop.count} 次返回结果相同。为避免继续无意义重复，已自动停止。\n\n请补充更具体的期望、差异点或允许我换一种方式继续。`;
+        finalAnswer = repeatedLoop.failed
+          ? `检测到 Agent 准备重复执行刚失败的同一动作（${actionSummary}）。为避免继续无意义重复，已自动停止。\n\n请补充更具体的期望、差异点或允许我换一种方式继续。`
+          : `检测到 Agent 连续 ${repeatedLoop.count + 1} 次准备重复执行同一动作（${actionSummary}），且前 ${repeatedLoop.count} 次返回结果相同。为避免继续无意义重复，已自动停止。\n\n请补充更具体的期望、差异点或允许我换一种方式继续。`;
         onEvent?.({
           type: "notification",
           level: "warning",

--- a/agent/tools/browser/execute.ts
+++ b/agent/tools/browser/execute.ts
@@ -61,6 +61,14 @@ function blockedSearchEngineResult(url) {
   ].join('\n');
 }
 
+function failedResult(result, error = result) {
+  return {
+    result,
+    resultStatus: 'failed',
+    resultError: String(error || result),
+  };
+}
+
 // 浏览器冷启动期的偶发超时往往一次重试就成功（trace 中 fabiaoqing 连续两次超时第三次成功）
 // 仅对超时错误重试 1 次，证书/DNS/HTTP 错误不重试
 async function navigateWithRetry(view, url, firstTimeoutMs, retryTimeoutMs, errMessage) {
@@ -157,6 +165,14 @@ function checkBlocked(title, url, body) {
   return false;
 }
 
+function checkUnavailablePage(title, body) {
+  const shortBody = String(body || '').replace(/\s+/g, ' ').trim();
+  const titleText = String(title || '').trim();
+  if (/^页面没有找到$|^404\b|not found/i.test(titleText) && shortBody.length < 500) return true;
+  if (/^页面没有找到\b|^404\b|not found/i.test(shortBody) && shortBody.length < 500) return true;
+  return false;
+}
+
 function blockedHint() {
   if (!isChromeMcpEnabled()) return '';
   return '\n\n⚠️ 页面可能被反爬拦截，建议改用 Chrome MCP 工具（chrome_call_tool → navigate_page / take_snapshot）操作真实 Chrome 浏览器访问。';
@@ -211,10 +227,10 @@ export async function executeBrowserAction(view, action) {
   } catch (err) {
     const msg = err.message || String(err);
     if (/timeout|waiting for|not found|selector|元素不存在/i.test(msg)) {
-      return `浏览器操作失败: ${msg.slice(0, 200)}。可能原因: 元素不存在或页面未加载完成，请重新观察页面后使用 observation 中存在的 elementId。`;
+      return failedResult(`浏览器操作失败: ${msg.slice(0, 200)}。可能原因: 元素不存在或页面未加载完成，请重新观察页面后使用 observation 中存在的 elementId。`, msg);
     }
     if (/execution context was destroyed|net::err_|connection.*closed|navigation/i.test(msg)) {
-      return `浏览器操作失败: ${msg.slice(0, 200)}。可能原因: 页面导航失败或连接中断，请尝试重新打开页面或使用其他网站。`;
+      return failedResult(`浏览器操作失败: ${msg.slice(0, 200)}。可能原因: 页面导航失败或连接中断，请尝试重新打开页面或使用其他网站。`, msg);
     }
     throw err;
   }
@@ -228,7 +244,7 @@ async function _executeBrowserAction(view, action) {
       return `内置浏览器不支持打开本地文件。请使用 notify_user 告知用户文件路径（${localPath}），或使用 terminal run_confirmed 执行 open "${localPath}" 让系统默认浏览器打开。`;
     }
     if (isBlockedSearchEngineUrl(action.url)) {
-      return blockedSearchEngineResult(action.url);
+      return failedResult(blockedSearchEngineResult(action.url), '已阻止访问搜索引擎搜索页');
     }
     try {
       await withTimeout(safeNavigate(view, action.url), FETCH_TIMEOUT_MS, `导航超时: ${action.url}`);
@@ -241,7 +257,7 @@ async function _executeBrowserAction(view, action) {
       } catch { /* ignore detection failure */ }
       return `已打开 ${action.url}`;
     } catch (err) {
-      return `无法打开 ${action.url}: ${err.message?.slice(0, 150) || '连接失败'}。请尝试其他网址或使用 fetch 工具。`;
+      return failedResult(`无法打开 ${action.url}: ${err.message?.slice(0, 150) || '连接失败'}。请尝试其他网址或使用 fetch 工具。`, err.message || '连接失败');
     }
   }
 
@@ -336,32 +352,43 @@ async function _executeBrowserAction(view, action) {
     if (!action.url) throw new Error('http_fetch 缺少 url');
     const url = normalizeHttpUrl(action.url);
     if (isBlockedSearchEngineUrl(url)) {
-      return blockedSearchEngineResult(url);
+      return failedResult(blockedSearchEngineResult(url), '已阻止访问搜索引擎搜索页');
     }
     try {
       await navigateWithRetry(view, url, FETCH_TIMEOUT_MS, FETCH_TIMEOUT_RETRY_MS, `访问超时: ${url}`);
       await delay(1000);
     } catch (err) {
-      return `http_fetch ${url}: 浏览器访问失败 (${(err.message || '').slice(0, 120)})。`;
+      const error = (err.message || '').slice(0, 120);
+      return failedResult(`http_fetch ${url}: 浏览器访问失败 (${error})。`, error);
     }
     try {
       const pageInfo = await detectBlockedPage(view);
       if (checkBlocked(pageInfo.title, pageInfo.url, pageInfo.body)) {
-        return `http_fetch ${url} 被反爬拦截（标题: ${pageInfo.title.slice(0, 80)}）。${blockedHint()}`;
+        const message = `http_fetch ${url} 被反爬拦截（标题: ${pageInfo.title.slice(0, 80)}）。${blockedHint()}`;
+        return failedResult(message, '页面被反爬拦截');
+      }
+      if (checkUnavailablePage(pageInfo.title, pageInfo.body)) {
+        const body = String(pageInfo.body || '').replace(/\s+/g, ' ').trim().slice(0, 160);
+        return failedResult(`http_fetch ${url}: 页面不可用（标题: ${pageInfo.title.slice(0, 80)}）。${body}`, '页面不可用');
       }
     } catch { /* ignore detection failure */ }
     const content = await extractPageTextOrLinks(view, url, action.extractLinks);
-    return content || `http_fetch ${url}: 页面内容为空。`;
+    if (!content) {
+      return failedResult(`http_fetch ${url}: 页面内容为空。`, '页面内容为空');
+    }
+    return content;
   }
 
   if (action.type === 'parallel_fetch') {
     const urls = Array.isArray(action.urls) ? action.urls : [];
     if (urls.length === 0) throw new Error('parallel_fetch 缺少 urls');
     const results = [];
+    let failures = 0;
     for (const u of urls.slice(0, 5)) {
       const url = normalizeHttpUrl(u);
       if (isBlockedSearchEngineUrl(url)) {
         results.push(blockedSearchEngineResult(url));
+        failures += 1;
         continue;
       }
       try {
@@ -370,15 +397,32 @@ async function _executeBrowserAction(view, action) {
         const pageInfo = await detectBlockedPage(view);
         if (checkBlocked(pageInfo.title, pageInfo.url, pageInfo.body)) {
           results.push(`http_fetch ${url} 被反爬拦截（标题: ${pageInfo.title.slice(0, 80)}）。${blockedHint()}`);
+          failures += 1;
+          continue;
+        }
+        if (checkUnavailablePage(pageInfo.title, pageInfo.body)) {
+          const body = String(pageInfo.body || '').replace(/\s+/g, ' ').trim().slice(0, 160);
+          results.push(`http_fetch ${url}: 页面不可用（标题: ${pageInfo.title.slice(0, 80)}）。${body}`);
+          failures += 1;
           continue;
         }
         const content = await extractPageTextOrLinks(view, url, action.extractLinks);
-        results.push(`http_fetch ${url}:\n${content || '页面内容为空'}`);
+        if (content) {
+          results.push(`http_fetch ${url}:\n${content}`);
+        } else {
+          results.push(`http_fetch ${url}: 页面内容为空`);
+          failures += 1;
+        }
       } catch (err) {
         results.push(`http_fetch ${url}: 失败 (${(err.message || '').slice(0, 100)})`);
+        failures += 1;
       }
     }
-    return results.join('\n\n---\n\n');
+    const result = results.join('\n\n---\n\n');
+    if (results.length > 0 && failures === results.length) {
+      return failedResult(result, 'parallel_fetch 所有 URL 均失败');
+    }
+    return result;
   }
 
   throw new Error(`不支持的动作类型: ${action.type}`);

--- a/agent/tools/search/execute.ts
+++ b/agent/tools/search/execute.ts
@@ -5,7 +5,7 @@
  * 解析其中 .result-link / .result-snippet 节点，
  * 返回 title + url + snippet 的纯文本列表给 LLM。
  *
- * 不需要 API key、无明显限流。失败时返回错误说明，由上层 router 转换为 observation。
+ * 不需要 API key、无明显限流。失败时返回结构化状态，避免上层把错误文本误判为成功。
  */
 
 const ENDPOINT = 'https://lite.duckduckgo.com/lite/';
@@ -103,6 +103,14 @@ function formatResults(query, results) {
   return `web_search 结果（query="${query}", count=${results.length}）:\n${lines.join('\n\n')}`;
 }
 
+function failedResult(result, error = result) {
+  return {
+    result,
+    resultStatus: 'failed',
+    resultError: String(error || result),
+  };
+}
+
 async function fetchHtml(query) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -129,7 +137,7 @@ async function fetchHtml(query) {
 export async function executeSearchAction(action) {
   const query = typeof action?.query === 'string' ? action.query.trim() : '';
   if (!query) {
-    return 'web_search 失败：query 为空';
+    return failedResult('web_search 失败：query 为空');
   }
   const maxResults = Number.isFinite(Number(action?.maxResults))
     ? Math.min(Math.max(Number(action.maxResults), 1), 10)
@@ -138,12 +146,12 @@ export async function executeSearchAction(action) {
   try {
     const html = await fetchHtml(query);
     if (html.includes('anomaly-modal') || html.includes('challenge-form')) {
-      return 'web_search 失败：DuckDuckGo 触发反爬验证。请稍后重试或改用 http_fetch 直接抓取目标站点。';
+      return failedResult('web_search 失败：DuckDuckGo 触发反爬验证。请稍后重试或改用 http_fetch 直接抓取目标站点。', 'DuckDuckGo 触发反爬验证');
     }
     const results = parseResults(html, maxResults);
     return formatResults(query, results);
   } catch (err: any) {
     const msg = err?.message || String(err);
-    return `web_search 失败：${msg}。建议改用 http_fetch 直接抓取目标站点，或检查网络。`;
+    return failedResult(`web_search 失败：${msg}。建议改用 http_fetch 直接抓取目标站点，或检查网络。`, msg);
   }
 }

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1314,13 +1314,13 @@ select,
 .agent-stats-runs {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
 .agent-stats-run {
   width: 100%;
   min-width: 0;
-  padding: 9px 10px;
+  padding: 7px 8px;
   border: 1px solid var(--c-border);
   border-radius: var(--r-sm);
   background: var(--c-surface);
@@ -1328,7 +1328,7 @@ select,
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 2px;
   text-align: left;
   transition: all var(--ease);
 }
@@ -1353,22 +1353,22 @@ select,
 }
 
 .agent-stats-run-title {
-  font-size: var(--f-sm);
+  font-size: var(--f-xs);
   font-weight: 600;
 }
 
 .agent-stats-run-meta {
   color: var(--c-text-muted);
-  font-size: var(--f-xs);
+  font-size: 10px;
 }
 
 .agent-stats-run-foot {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
   color: var(--c-text-hint);
-  font-size: 10px;
+  font-size: 9px;
 }
 
 .agent-token-chart {
@@ -2564,14 +2564,14 @@ select,
 }
 
 .agent-last-run {
-  margin: 8px 0 4px;
-  padding: 10px;
+  margin: 6px 0 3px;
+  padding: 7px 8px;
   border: 1px solid var(--c-border);
   border-radius: var(--r-sm);
   background: var(--c-surface-hover);
   display: flex;
   flex-direction: column;
-  gap: 9px;
+  gap: 6px;
 }
 
 .agent-last-run-toggle {
@@ -2598,9 +2598,9 @@ select,
 
 .agent-last-run-head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px;
 }
 
 .agent-last-run-head > div {
@@ -2609,19 +2609,19 @@ select,
 
 .agent-last-run-kicker {
   display: block;
-  margin-bottom: 2px;
+  margin-bottom: 1px;
   color: var(--c-text-muted);
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: 0;
   text-transform: uppercase;
 }
 
 .agent-last-run-head strong {
   display: block;
   color: var(--c-text);
-  font-size: var(--f-sm);
-  line-height: 1.35;
+  font-size: var(--f-xs);
+  line-height: 1.25;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2630,7 +2630,7 @@ select,
 .agent-last-run-status {
   flex-shrink: 0;
   color: var(--c-text-muted);
-  font-size: var(--f-xs);
+  font-size: 10px;
   white-space: nowrap;
 }
 
@@ -2638,7 +2638,7 @@ select,
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
 }
 
 .agent-last-run-status-wrap svg {
@@ -2646,26 +2646,31 @@ select,
 }
 
 .agent-last-run-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .agent-last-run-grid span {
   min-width: 0;
-  height: 26px;
-  padding: 0 8px;
+  height: 20px;
+  padding: 0 6px;
   border: 1px solid var(--c-border);
   border-radius: var(--r-sm);
   background: var(--c-surface);
   color: var(--c-text-secondary);
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: var(--f-xs);
+  gap: 4px;
+  font-size: 10px;
+  flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.agent-last-run-grid span:nth-child(4) {
+  flex: 1 1 88px;
 }
 
 .agent-last-run-grid svg {

--- a/client/src/components/agent/AgentPanel.jsx
+++ b/client/src/components/agent/AgentPanel.jsx
@@ -413,11 +413,11 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
                 </span>
               </div>
               <div className="agent-last-run-grid">
-                <span><Clock3 size={13} />{formatDurationMs(lastRun.elapsedMs)}</span>
-                <span><ListChecks size={13} />{t('agentPanel.stepCount', { n: lastRun.stepCount })}</span>
-                <span><Coins size={13} />{formatTokenCount(lastRun.totalTokens)} tok</span>
-                <span><Bot size={13} />{lastRunModels.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
-                <span><Trophy size={13} />{strategyLabel(lastRun.strategy, t)}</span>
+                <span><Clock3 size={11} />{formatDurationMs(lastRun.elapsedMs)}</span>
+                <span><ListChecks size={11} />{t('agentPanel.stepCount', { n: lastRun.stepCount })}</span>
+                <span><Coins size={11} />{formatTokenCount(lastRun.totalTokens)} tok</span>
+                <span><Bot size={11} />{lastRunModels.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
+                <span><Trophy size={11} />{strategyLabel(lastRun.strategy, t)}</span>
               </div>
             </LastRunFrame>
           )}

--- a/test/browser-webview.test.ts
+++ b/test/browser-webview.test.ts
@@ -28,7 +28,7 @@ class FakeWebView {
     this.url = url;
   }
 
-  async evaluate(script) {
+  async evaluate(script): Promise<any> {
     this.calls.push(['evaluate', script]);
     if (script.includes('querySelectorAll')) {
       return {
@@ -62,6 +62,23 @@ class FakeWebView {
   async close() {
     this.closed = true;
     this.calls.push(['close']);
+  }
+}
+
+class NotFoundWebView extends FakeWebView {
+  async evaluate(script): Promise<any> {
+    this.calls.push(['evaluate', script]);
+    if (script.includes('document.title')) {
+      return {
+        title: '页面没有找到',
+        url: 'https://example.com/missing',
+        body: '页面没有找到 5秒钟之后将会带您进入首页!',
+      };
+    }
+    if (script.includes('document.body?.innerText')) {
+      return '页面没有找到 5秒钟之后将会带您进入首页!';
+    }
+    return super.evaluate(script);
   }
 }
 
@@ -135,5 +152,17 @@ describe('Bun.WebView browser actions', () => {
     expect(view.calls).toContainEqual(['click', '[data-agent-node-id="2"]', { timeout: 10000 }]);
     expect(view.calls).toContainEqual(['type', '[data-agent-node-id="3"]', 'hello']);
     expect(view.calls).toContainEqual(['press', 'Enter']);
+  });
+
+  it('marks unavailable http_fetch pages as structured failures', async () => {
+    const view = new NotFoundWebView();
+
+    const result = await executeBrowserAction(view, { type: 'http_fetch', url: 'https://example.com/missing' });
+
+    expect(result).toMatchObject({
+      resultStatus: 'failed',
+      resultError: '页面不可用',
+    });
+    expect(result.result).toContain('页面不可用');
   });
 });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildGeminiTaskMessages } from '../agent/core/prompts.ts';
+
+describe('agent prompts', () => {
+  it('adds a recent search hint for repeated or failed web_search queries', () => {
+    const { contents } = buildGeminiTaskMessages({
+      task: '白天的a股呢',
+      step: 3,
+      history: [
+        {
+          step: 1,
+          action: { tool: 'search', type: 'web_search', query: '2026年7月3日 A股收盘行情' },
+          result: 'web_search 失败：DuckDuckGo 触发反爬验证。',
+          resultStatus: 'failed',
+        },
+      ],
+      observation: {},
+    });
+
+    const payload = JSON.parse(contents.at(-1)!.parts[0].text);
+
+    expect(payload.recentSearchesHint).toContain('2026年7月3日 A股收盘行情');
+    expect(payload.recentSearchesHint).toContain('不要原样重复');
+  });
+});

--- a/test/search-tool.test.ts
+++ b/test/search-tool.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { executeSearchAction } from '../agent/tools/search/execute.ts';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubFetchHtml(html: string, ok = true) {
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok,
+    status: ok ? 200 : 503,
+    statusText: ok ? 'OK' : 'Service Unavailable',
+    text: async () => html,
+  })));
+}
+
+describe('search tool', () => {
+  it('returns structured failure when DuckDuckGo shows a challenge page', async () => {
+    stubFetchHtml('<form class="challenge-form"></form>');
+
+    const result: any = await executeSearchAction({ type: 'web_search', query: 'A股收盘行情' });
+
+    expect(result).toMatchObject({
+      resultStatus: 'failed',
+      resultError: 'DuckDuckGo 触发反爬验证',
+    });
+    expect(result.result).toContain('web_search 失败');
+  });
+
+  it('keeps successful search results as plain content', async () => {
+    stubFetchHtml(`
+      <a class="result-link" href="https://example.com/a">Example A</a>
+      <td class="result-snippet">Snippet A</td>
+    `);
+
+    const result = await executeSearchAction({ type: 'web_search', query: 'Example' });
+
+    expect(result).toContain('web_search 结果');
+    expect(result).toContain('Example A');
+  });
+});

--- a/test/session-checkpoint.test.ts
+++ b/test/session-checkpoint.test.ts
@@ -224,6 +224,40 @@ describe('runtime: session checkpoint integration', () => {
     expect(evtLog.some(e => e.type === 'notification' && e.level === 'warning')).toBe(true);
   });
 
+  it('stops before retrying the same readonly action after a structured failure', async () => {
+    const cancelSignal = new AbortController().signal;
+    const { log: evtLog, onEvent } = events();
+    let executeCalls = 0;
+
+    const result = await runAgentRuntime({
+      task: 'search market data',
+      maxSteps: 4,
+      onEvent,
+      cancelSignal,
+      initialize: noop,
+      observe: noop,
+      decide: () => ({
+        action: { tool: 'search', type: 'web_search', query: '2026年7月3日 A股收盘行情' },
+        rationale: 'search',
+      }),
+      authorize: () => ({ status: 'approved' }),
+      execute: () => {
+        executeCalls += 1;
+        return {
+          result: 'web_search 失败：DuckDuckGo 触发反爬验证。',
+          resultStatus: 'failed',
+          resultError: 'DuckDuckGo 触发反爬验证',
+        };
+      },
+      cleanup: noop,
+    });
+
+    expect(executeCalls).toBe(1);
+    expect(result.steps).toHaveLength(1);
+    expect(result.answer).toContain('刚失败的同一动作');
+    expect(evtLog.some(e => e.type === 'notification' && e.level === 'warning')).toBe(true);
+  });
+
   it('saves snapshots at interval steps', async () => {
     const runId = 'run_rt2';
     const runRecord = { runId, pendingRollback: null };


### PR DESCRIPTION
Summary:
- Return structured failed statuses for web_search and browser fetch failures so failed tool results are not treated as success.
- Stop earlier when the agent prepares to retry the same readonly action after a structured failure, and add recent web_search query hints to prompts.
- Make recent run UI cards/lists more compact.

Tests:
- npm run lint
- npm run typecheck
- npm run build:client
- npm test