### PR TITLE
Fix LLM log flush and model picker layout

### DIFF
--- a/agent/core/llm-logger.ts
+++ b/agent/core/llm-logger.ts
@@ -36,6 +36,8 @@ function timeStr() {
 }
 
 const writeQueue = new Map();
+const flushTimers = new Map();
+const activeFlushes = new Set<Promise<void>>();
 
 async function flushLog(filePath, lines) {
   try {
@@ -49,13 +51,37 @@ async function flushLog(filePath, lines) {
 function enqueueLog(filePath, line) {
   if (!writeQueue.has(filePath)) {
     writeQueue.set(filePath, []);
-    setTimeout(() => {
-      const pending = writeQueue.get(filePath);
-      writeQueue.delete(filePath);
-      flushLog(filePath, pending);
-    }, 100);
+    flushTimers.set(filePath, setTimeout(() => {
+      flushQueuedFile(filePath);
+    }, 100));
   }
   writeQueue.get(filePath).push(line);
+}
+
+function trackFlush(promise: Promise<void>) {
+  activeFlushes.add(promise);
+  promise.finally(() => activeFlushes.delete(promise));
+  return promise;
+}
+
+function flushQueuedFile(filePath) {
+  const timer = flushTimers.get(filePath);
+  if (timer) clearTimeout(timer);
+  flushTimers.delete(filePath);
+
+  const pending = writeQueue.get(filePath);
+  writeQueue.delete(filePath);
+  if (!pending?.length) return Promise.resolve();
+  return trackFlush(flushLog(filePath, pending));
+}
+
+export async function flushLlmLogs() {
+  do {
+    await Promise.all([...writeQueue.keys()].map(flushQueuedFile));
+    if (activeFlushes.size > 0) {
+      await Promise.allSettled([...activeFlushes]);
+    }
+  } while (writeQueue.size > 0 || activeFlushes.size > 0);
 }
 
 export function logLlmRequest(model, messages) {

--- a/agent/worker/agent-worker.ts
+++ b/agent/worker/agent-worker.ts
@@ -16,6 +16,8 @@ function createApprovalId() {
   return `worker_approval_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
+let flushLlmLogsBeforeExit = async () => {};
+
 function createWorkerApprovalStore() {
   const pending = new Map<string, (decision: string) => void>();
   return {
@@ -103,9 +105,10 @@ async function main() {
   const { createClients } = await import('../core/ai-client.ts');
   const { createProviderRegistry } = await import('../core/providers/registry.ts');
   const { createDesktopAgentRunner } = await import('../desktop/agent.ts');
-  const { initLlmLogger } = await import('../core/llm-logger.ts');
+  const { initLlmLogger, flushLlmLogs } = await import('../core/llm-logger.ts');
   const { runtimeConfig } = await import('../core/runtime-config.ts');
   const { DEFAULT_VISION_MODEL } = await import('../tools/vision/execute.ts');
+  flushLlmLogsBeforeExit = flushLlmLogs;
 
   const memoryDir = payload.memoryDir || process.env.MEMORY_DIR || 'data';
   await runtimeConfig.init(memoryDir);
@@ -161,12 +164,14 @@ async function main() {
     checkpointWriter,
   });
 
+  await flushLlmLogsBeforeExit();
   await writeProtocolAndWait({ type: 'result', result });
 }
 
 main()
   .then(() => process.exit(0))
   .catch(async err => {
+    await flushLlmLogsBeforeExit().catch(() => {});
     await writeProtocolAndWait(serializeError(err)).catch(() => {});
     process.exit(1);
   });

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1802,6 +1802,7 @@ select,
 .model-dropdown-main {
   display: inline-flex;
   align-items: center;
+  flex: 1 1 auto;
   gap: 6px;
   min-width: 0;
 }
@@ -1877,7 +1878,7 @@ select,
 .model-picker-mask {
   position: fixed;
   inset: 0;
-  z-index: 120;
+  z-index: 90;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1886,8 +1887,8 @@ select,
 }
 
 .model-picker-dialog {
-  width: min(960px, calc(100vw - 32px));
-  height: min(86dvh, 760px);
+  width: min(1280px, calc(100vw - 40px));
+  height: min(88dvh, 780px);
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -1902,6 +1903,7 @@ select,
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex: 0 0 auto;
   gap: 12px;
   padding: 9px 12px;
   border-bottom: 1px solid var(--c-border);
@@ -1946,6 +1948,7 @@ select,
 .model-picker-toolbar {
   display: grid;
   grid-template-columns: minmax(220px, 1fr) auto;
+  flex: 0 0 auto;
   gap: 8px;
   align-items: center;
   padding: 8px 12px;
@@ -1970,10 +1973,14 @@ select,
 .model-filter-grid {
   display: flex;
   flex-wrap: wrap;
+  flex: 0 0 auto;
   gap: 8px;
+  max-height: 132px;
+  overflow-y: auto;
   padding: 9px 12px;
   border-bottom: 1px solid var(--c-border);
   background: var(--c-surface-dim);
+  -webkit-overflow-scrolling: touch;
 }
 
 .model-filter-group {
@@ -2061,11 +2068,11 @@ select,
 .model-picker-body {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 14px;
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
-  padding: 10px 12px 12px;
+  padding: 12px 14px 14px;
 }
 
 .model-selected-group {
@@ -2086,13 +2093,38 @@ select,
 
 .model-picker-body .model-provider-tags {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 8px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 14px;
 }
 
 .model-picker-body .model-tag-wrapper,
 .model-picker-body .model-tag {
   width: 100%;
+}
+
+.model-picker-body .model-tag {
+  height: auto;
+  min-height: 96px;
+  padding: 16px 18px;
+  gap: 12px;
+}
+
+.model-selected-group .model-provider-tags {
+  gap: 8px;
+}
+
+.model-selected-group .model-tag {
+  min-height: 0;
+  padding: 12px 14px;
+  gap: 6px;
+}
+
+.model-selected-group .model-tag-label {
+  line-height: 1.25;
+}
+
+.model-selected-group .model-tag-description {
+  line-height: 1.35;
 }
 
 .model-dropdown-trigger.has-selection {
@@ -2101,7 +2133,7 @@ select,
 }
 
 .model-provider-group + .model-provider-group {
-  margin-top: 6px;
+  margin-top: 14px;
 }
 .model-provider-heading {
   padding: 6px 8px 4px;
@@ -2129,7 +2161,7 @@ select,
 .model-tags {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   max-height: 160px;
   overflow-y: auto;
 }
@@ -2151,14 +2183,15 @@ select,
 
 .model-tag {
   display: inline-flex;
-  align-items: flex-start;
+  align-items: stretch;
   flex-direction: column;
-  gap: 4px;
+  gap: 12px;
   flex: 1 1 auto;
   max-width: 100%;
   min-width: 0;
-  min-height: 34px;
-  padding: 6px 9px;
+  min-height: 96px;
+  height: auto;
+  padding: 16px 18px;
   border-radius: var(--r-sm);
   border: 1px solid var(--c-border);
   background: var(--c-surface);
@@ -2167,27 +2200,33 @@ select,
   cursor: pointer;
   outline: none;
   transition: all 0.15s;
-  white-space: nowrap;
+  white-space: normal;
+  text-align: left;
 }
 .model-tag-label {
   display: block;
+  width: 100%;
   max-width: 100%;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
+  line-height: 1.35;
+  font-weight: 600;
 }
 
 .model-tag-description {
-  display: -webkit-box;
+  display: block;
+  width: 100%;
   max-width: 100%;
-  overflow: hidden;
+  overflow: visible;
+  overflow-wrap: anywhere;
   color: var(--c-text-muted);
   font-size: var(--f-xs);
-  line-height: 1.35;
+  line-height: 1.45;
   text-align: left;
   white-space: normal;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
 }
 
 .model-tag.selected .model-tag-description {
@@ -2195,41 +2234,60 @@ select,
 }
 
 .model-tag-facts {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px 10px;
+  width: 100%;
   max-width: 100%;
+  margin-top: 2px;
+  padding-top: 12px;
+  border-top: 1px solid var(--c-border);
+  overflow: visible;
+}
+
+.model-tag.selected .model-tag-facts {
+  border-top-color: rgba(255, 255, 255, 0.2);
 }
 
 .model-tag-fact {
-  display: inline-flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: start;
+  column-gap: 8px;
   min-width: 0;
+  width: 100%;
   max-width: 100%;
-  height: 18px;
+  min-height: 0;
+  height: auto;
   border: 1px solid var(--c-border);
   border-radius: var(--r-sm);
   background: var(--c-surface-dim);
   color: var(--c-text-muted);
-  font-size: 10px;
-  line-height: 16px;
-  overflow: hidden;
+  font-size: 11px;
+  line-height: 1.4;
+  overflow: visible;
+  padding: 6px 8px;
 }
 
 .model-tag-fact-label {
-  flex: 0 0 auto;
-  padding: 0 4px;
-  border-right: 1px solid var(--c-border);
+  align-self: start;
+  display: block;
+  padding: 0;
+  border-right: none;
   color: var(--c-text-tertiary);
   font-weight: 700;
+  line-height: 1.4;
+  white-space: nowrap;
 }
 
 .model-tag-fact-value {
   min-width: 0;
-  padding: 0 5px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  padding: 0;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
+  line-height: 1.4;
 }
 
 .model-tag:hover {
@@ -2252,7 +2310,6 @@ select,
 }
 
 .model-tag.selected .model-tag-fact-label {
-  border-right-color: rgba(255, 255, 255, 0.24);
   color: rgba(255, 255, 255, 0.68);
 }
 
@@ -5381,9 +5438,11 @@ textarea:disabled {
   }
 
   .header-right {
-    flex: 0 0 auto;
+    flex: 1 1 100%;
     gap: 4px;
-    flex-wrap: wrap;
+    justify-content: flex-end;
+    flex-wrap: nowrap;
+    min-width: 0;
   }
 
   .header-session-title {
@@ -5413,6 +5472,10 @@ textarea:disabled {
     height: 26px;
     padding: 0 6px;
     font-size: 11px;
+  }
+
+  .model-picker-body .model-tag-facts {
+    grid-template-columns: 1fr;
   }
 
   .strategy-btn {
@@ -5821,19 +5884,56 @@ textarea:disabled {
     max-width: 100px;
   }
 
+  .model-select-row,
+  .model-dropdown {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .header-right .model-select-row {
+    flex: 1 1 auto;
+    justify-content: flex-end;
+    max-width: calc(100% - 104px);
+  }
+
+  .header-right .model-dropdown {
+    width: 100%;
+  }
+
   .model-dropdown {
     position: static;
   }
 
+  .model-dropdown-trigger,
+  .agent-composer--hero .model-dropdown-trigger {
+    width: min(100%, 176px);
+    max-width: 100%;
+    padding: 0 8px;
+  }
+
+  .header-right .model-dropdown-trigger {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .model-dropdown-provider {
+    max-width: 58px;
+  }
+
   .model-picker-mask {
-    align-items: stretch;
-    padding: 8px;
+    align-items: flex-end;
+    justify-content: stretch;
+    padding: max(8px, env(safe-area-inset-top)) 0 0;
   }
 
   .model-picker-dialog {
     width: 100%;
-    height: calc(100dvh - 16px);
-    border-radius: var(--r-md);
+    height: min(92dvh, 760px);
+    max-height: calc(100dvh - max(8px, env(safe-area-inset-top)));
+    border-right: none;
+    border-bottom: none;
+    border-left: none;
+    border-radius: var(--r-lg) var(--r-lg) 0 0;
   }
 
   .model-picker-header,
@@ -5843,25 +5943,97 @@ textarea:disabled {
     padding-right: 10px;
   }
 
+  .model-picker-header {
+    min-height: 48px;
+    flex: 0 0 auto;
+  }
+
+  .model-picker-title {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  .model-picker-subtitle {
+    white-space: normal;
+  }
+
+  .model-picker-close {
+    width: 36px;
+    height: 36px;
+  }
+
   .model-picker-toolbar {
     grid-template-columns: 1fr;
+    flex: 0 0 auto;
+  }
+
+  .model-picker-search {
+    height: 40px;
   }
 
   .model-picker-actions {
     justify-content: flex-start;
     flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .model-clear-btn {
+    min-height: 32px;
+    padding: 0 10px;
   }
 
   .model-filter-grid {
-    overflow: visible;
+    flex: 0 0 auto;
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(240px, 84vw);
+    grid-template-rows: none;
+    flex-wrap: nowrap;
+    gap: 10px;
+    max-height: 148px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    -webkit-overflow-scrolling: touch;
+    scroll-snap-type: x proximity;
   }
 
   .model-filter-group {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 6px;
     width: 100%;
+    min-width: 0;
+    scroll-snap-align: start;
+  }
+
+  .model-filter-label {
+    line-height: 1;
+  }
+
+  .model-filter-chips {
+    flex-wrap: nowrap;
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    padding-bottom: 2px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .model-filter-chip {
+    height: 34px;
+    max-width: 160px;
+    padding: 0 10px;
   }
 
   .model-picker-body {
+    flex: 1 1 0;
+    min-height: 0;
     padding: 10px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .model-picker-body .model-provider-tags {
@@ -5869,7 +6041,70 @@ textarea:disabled {
   }
 
   .model-selected-group {
-    max-height: 24dvh;
+    flex: 0 0 auto;
+    max-height: 22dvh;
+  }
+
+  .model-tags.model-picker-results {
+    flex: 0 0 auto;
+    max-height: none;
+    overflow: visible;
+    min-height: 0;
+  }
+
+  .model-provider-heading {
+    padding-left: 2px;
+  }
+
+  .model-picker-body .model-tag {
+    height: auto;
+    min-height: 112px;
+    padding: 14px;
+    gap: 12px;
+  }
+
+  .model-selected-group .model-tag {
+    min-height: 0;
+    padding: 12px;
+    gap: 6px;
+  }
+
+  .model-tag-description {
+    display: block;
+    overflow: visible;
+    -webkit-line-clamp: unset;
+    -webkit-box-orient: unset;
+  }
+
+  .model-tag-facts {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding-top: 12px;
+  }
+
+  .model-tag-fact {
+    grid-template-columns: 44px minmax(0, 1fr);
+    max-width: 100%;
+    padding: 8px 9px;
+  }
+
+  .model-tag-order {
+    min-width: 32px;
+  }
+
+  .order-arrow {
+    width: 28px;
+    height: 22px;
+  }
+
+  .model-picker-strategy {
+    align-self: stretch;
+    margin: 8px 10px 0;
+  }
+
+  .model-picker-strategy .strategy-btn {
+    flex: 1 1 0;
+    height: 34px;
   }
 
   .send-btn.stop {

--- a/client/src/components/ModelSelector.jsx
+++ b/client/src/components/ModelSelector.jsx
@@ -22,11 +22,17 @@ function asList(value) {
     : [];
 }
 
-function formatList(value, limit = 3) {
+function formatList(value) {
   const items = asList(value);
   if (!items.length) return null;
-  const visible = items.slice(0, limit).join('+');
-  return items.length > limit ? `${visible}+${items.length - limit}` : visible;
+  return items.join(', ');
+}
+
+function formatSummaryList(values, limit = 2) {
+  const items = Array.isArray(values) ? values.filter(Boolean) : asList(values);
+  if (!items.length) return null;
+  const visible = items.slice(0, limit).join(', ');
+  return items.length > limit ? `${visible} +${items.length - limit}` : visible;
 }
 
 function modelFacts(model) {
@@ -48,6 +54,26 @@ function modelFacts(model) {
   if (messageRoles) facts.push({ label: 'ROLE', value: messageRoles });
   if (methods) facts.push({ label: 'GEN', value: methods });
   if (parameters) facts.push({ label: 'CAP', value: parameters });
+  return facts;
+}
+
+function modelDisplayFacts(model) {
+  const facts = [];
+  const context = formatTokenLimit(model?.contextWindow || model?.context_length || model?.inputTokenLimit);
+  const output = formatTokenLimit(model?.maxOutputTokens || model?.outputTokenLimit);
+  const modalities = uniqueSorted([
+    ...asList(model?.inputModalities || model?.input_modalities),
+    ...asList(model?.outputModalities || model?.output_modalities),
+  ]);
+  const capabilities = uniqueSorted([
+    ...asList(model?.supportedParameters || model?.supported_parameters),
+    ...asList(model?.supportedGenerationMethods || model?.supported_generation_methods),
+  ]);
+
+  if (context) facts.push({ label: 'CTX', value: context });
+  if (output) facts.push({ label: 'MAX', value: output });
+  if (modalities.length) facts.push({ label: 'MOD', value: formatSummaryList(modalities, 3) });
+  if (capabilities.length) facts.push({ label: 'CAP', value: formatSummaryList(capabilities, 2) });
   return facts;
 }
 
@@ -153,7 +179,11 @@ function useModelPickerDialog() {
 
   useEffect(() => {
     if (!open) return undefined;
-    inputRef.current?.focus();
+    const coarsePointer = typeof window !== 'undefined'
+      && window.matchMedia?.('(hover: none) and (pointer: coarse)').matches;
+    if (!coarsePointer) {
+      inputRef.current?.focus();
+    }
     const onKeyDown = e => {
       if (e.key === 'Escape') setOpen(false);
     };
@@ -260,7 +290,7 @@ function AgentModelDropdown({
   const renderTag = item => {
     const isSelected = selectedSet.has(item.id);
     const orderIdx = selectedAgentModels.indexOf(item.id);
-    const facts = modelFacts(item);
+    const facts = isSelected ? [] : modelDisplayFacts(item);
     const factTitle = facts.map(fact => `${fact.label} ${fact.value}`).join(' · ');
     return (
       <span key={item.id} className={`model-tag-wrapper ${isSelected ? 'selected' : ''}`}>
@@ -325,8 +355,8 @@ function AgentModelDropdown({
         <ChevronDown size={14} />
       </button>
       {open && (
-        <div className="model-picker-mask" onMouseDown={() => setOpen(false)}>
-          <div className="model-picker-dialog" role="dialog" aria-modal="true" onMouseDown={e => e.stopPropagation()}>
+        <div className="model-picker-mask" onPointerDown={() => setOpen(false)}>
+          <div className="model-picker-dialog" role="dialog" aria-modal="true" onPointerDown={e => e.stopPropagation()}>
             <div className="model-picker-header">
               <div className="model-picker-title">
                 <span>{t('modelSelector.selectModels')}</span>

--- a/test/llm-logger.test.ts
+++ b/test/llm-logger.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { flushLlmLogs, initLlmLogger, logLlmResponse } from '../agent/core/llm-logger.ts';
+
+function todayDirName() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+describe('llm-logger', () => {
+  it('flushes queued response logs before the debounce timer fires', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-llm-logger-'));
+    try {
+      initLlmLogger(dir);
+      logLlmResponse('vendor/model', {
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+        choices: [],
+      });
+
+      await flushLlmLogs();
+
+      const file = path.join(dir, 'llm-logs', todayDirName(), 'vendor_model.jsonl');
+      const raw = await readFile(file, 'utf8');
+      expect(raw).toContain('"type":"response"');
+      expect(raw).toContain('"model":"vendor/model"');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Summary: flush queued LLM logs before worker exit so response records land in llm-logs; add regression coverage for debounced response log flushing; make the model picker mobile-friendly with roomier cards, selected-model summaries, and reduced pending metadata tags. Tests: npm test; npm run build.