### PR TITLE
Keep settings API available when models fail

### DIFF
--- a/agent/core/ai-client.ts
+++ b/agent/core/ai-client.ts
@@ -59,9 +59,5 @@ export function createClients() {
     ? new GoogleGenAI({ apiKey: geminiKey })
     : null;
 
-  if (!openai_client && !gemini_client) {
-    throw new Error('至少需要配置 NVIDIA_API_KEY / GEMINI_API_KEY 之一');
-  }
-
   return { openai_client, gemini_client };
 }

--- a/agent/core/providers/registry.ts
+++ b/agent/core/providers/registry.ts
@@ -3,7 +3,7 @@
  *
  * 装配所有已配置的 LLMProvider，对外提供：
  *   - resolve(model, modelConfig): 把模型路由到认领它的 provider（兜底 openai-compat）
- *   - loadModelConfig(): 合并所有 provider 的模型列表；全部获取失败则抛错中止启动
+ *   - loadModelConfig(): 合并所有 provider 的模型列表；全部获取失败则抛错交给 server 降级启动
  *   - providers: provider 列表（server resume / banner 等处遍历用）
  *
  * 加第四家供应商：写 createXxxProvider() 实现 LLMProvider 接口，在下方
@@ -34,10 +34,6 @@ export function createProviderRegistry({
   if (gemini_client) providers.push(createGeminiProvider(gemini_client));
   if (openai_client) providers.push(createOpenAICompatProvider(openai_client));
 
-  if (providers.length === 0) {
-    throw new Error('至少需要配置 NVIDIA_API_KEY / GEMINI_API_KEY 之一');
-  }
-
   function resolve(model: string, modelConfig?: ModelInfo[] | null): LLMProvider {
     const owner = providers.find(p => p.ownsModel(model, modelConfig));
     if (owner) return owner;
@@ -47,6 +43,10 @@ export function createProviderRegistry({
   }
 
   async function loadModelConfig(): Promise<ModelInfo[]> {
+    if (providers.length === 0) {
+      throw new Error('未配置任何供应商，请设置 NVIDIA_API_KEY 或 GEMINI_API_KEY');
+    }
+
     const results = await Promise.allSettled(providers.map(p => p.listModels()));
     const merged: ModelInfo[] = [];
     const failures: string[] = [];

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const apiTarget = process.env.VITE_API_TARGET || `http://127.0.0.1:${process.env.PORT || 3001}`
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
@@ -11,9 +13,9 @@ export default defineConfig({
     host: '0.0.0.0',
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:3001',
-      '/v1': 'http://localhost:3001',
-      '/screenshots': 'http://localhost:3001',
+      '/api': apiTarget,
+      '/v1': apiTarget,
+      '/screenshots': apiTarget,
     },
   },
 })

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import process from 'node:process'
 
 const apiTarget = process.env.VITE_API_TARGET || `http://127.0.0.1:${process.env.PORT || 3001}`
 

--- a/routes/completions.ts
+++ b/routes/completions.ts
@@ -4,11 +4,19 @@ import { buildOpenAiError } from '../helpers/streaming.ts';
 import { log } from '../helpers/logger.ts';
 import type { ProviderRegistry } from '../agent/core/providers/registry.ts';
 
-export function createCompletionsRouter({ registry, modelConfig }: { registry: ProviderRegistry; modelConfig: any[] }) {
+export function createCompletionsRouter({
+  registry,
+  modelConfig,
+  modelConfigError = null,
+}: {
+  registry: ProviderRegistry;
+  modelConfig: any[];
+  modelConfigError?: string | null;
+}) {
   const router = Router();
 
   router.get('/api/models', (_req, res) => {
-    res.json({ models: modelConfig });
+    res.json({ models: modelConfig, error: modelConfigError });
   });
 
   router.get('/v1/models', (_req, res) => {
@@ -70,6 +78,8 @@ export function createCompletionsRouter({ registry, modelConfig }: { registry: P
     res.json({
       status: 'ok',
       browser_agent: 'enabled',
+      models_available: modelConfig.length > 0,
+      models_error: modelConfigError,
     })
   );
 

--- a/server.ts
+++ b/server.ts
@@ -62,10 +62,12 @@ app.use(express.json({ limit: '25mb' }));
 
 const { openai_client, gemini_client } = createClients();
 const registry = createProviderRegistry({ openai_client, gemini_client });
-// 启动时同步拉取模型列表；全部供应商失败则中止启动并打印原因，不再兜底默认模型。
+// 启动时同步拉取模型列表；失败时仍启动后端，让设置页可打开以修复 API Key / BASE_URL。
+let modelConfigError: string | null = null;
 const modelConfig = await registry.loadModelConfig().catch((err: any) => {
-  log.error(`[启动失败] ${err.message}`);
-  process.exit(1);
+  modelConfigError = err?.message || String(err);
+  log.error(`[Models] 模型列表获取失败，后端将以空模型列表继续启动:\n${modelConfigError}`);
+  return [];
 });
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -122,7 +124,7 @@ const SCREENSHOT_DIR = path.join(MEMORY_DIR, 'screenshots');
 app.use('/screenshots', express.static(SCREENSHOT_DIR));
 
 app.use(createAgentRouter({ runDesktopAgent, agentRunStore, approvalStore, memoryDir: MEMORY_DIR, checkpointDir: CHECKPOINT_DIR, domainRules: runDesktopAgent.domainRules, modelConfig, registry, runtimeConfig, projectStore }));
-app.use(createCompletionsRouter({ registry, modelConfig }));
+app.use(createCompletionsRouter({ registry, modelConfig, modelConfigError }));
 app.use(createSuggestionsRouter({ store: createSuggestionStore(path.join(__dirname, 'data')) }));
 
 if (fs.existsSync(path.join(CLIENT_DIST_DIR, 'index.html'))) {
@@ -235,7 +237,8 @@ const httpServer = app.listen(Number(PORT), HOST, async () => {
   ╔${dLine.slice(2)}╗
   ${row('🚀 Sagent Server', `http://${HOST}:${PORT}`)}
   ╠${dLine.slice(2)}╣
-  ${row('Models', modelConfig.map(m => m.id).join(', '))}
+  ${row('Models', modelConfig.length > 0 ? modelConfig.map(m => m.id).join(', ') : 'unavailable')}
+  ${modelConfigError ? row('Models Error', modelConfigError.replace(/\s+/g, ' ').slice(0, 160)) : ''}
   ${multiModels.length > 0 ? row('MultiModel', multiModels.join(', ')) : ''}
   ${row('VISION_MODEL', VISION_MODEL)}
   ${hLine}

--- a/test/completions.test.ts
+++ b/test/completions.test.ts
@@ -2,6 +2,35 @@ import { describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import { createCompletionsRouter } from '../routes/completions.ts';
+import { createProviderRegistry } from '../agent/core/providers/registry.ts';
+
+describe('GET /api/models', () => {
+  it('returns model loading errors without failing the settings API surface', async () => {
+    const registry: any = {
+      resolve: vi.fn(),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use(createCompletionsRouter({
+      registry,
+      modelConfig: [],
+      modelConfigError: 'catalog unavailable',
+    }));
+
+    const res = await request(app).get('/api/models');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ models: [], error: 'catalog unavailable' });
+  });
+});
+
+describe('provider registry startup behavior', () => {
+  it('allows construction without configured providers so config routes can still start', async () => {
+    const registry = createProviderRegistry({});
+
+    await expect(registry.loadModelConfig()).rejects.toThrow('未配置任何供应商');
+  });
+});
 
 describe('POST /v1/chat/completions', () => {
   it('requires an explicit model', async () => {


### PR DESCRIPTION
Summary:
- allow backend startup when providers are missing or model listing fails, so settings can still load
- expose model loading errors via /api/models and /health
- make the Vite API proxy follow PORT or VITE_API_TARGET for Termux

Tests:
- npm run typecheck
- npm test
- npm run build