### PR TITLE
feat: refine agent history and appearance settings

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -162,6 +162,28 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
+:root[data-font-size="small"] {
+  --f-micro: 10px;
+  --f-xs: 11px;
+  --f-sm: 12px;
+  --f-base: 13px;
+  --f-md: 15px;
+  --f-lg: 17px;
+  --f-xl: 20px;
+  --f-display: 26px;
+}
+
+:root[data-font-size="large"] {
+  --f-micro: 12px;
+  --f-xs: 13px;
+  --f-sm: 14px;
+  --f-base: 16px;
+  --f-md: 18px;
+  --f-lg: 20px;
+  --f-xl: 24px;
+  --f-display: 32px;
+}
+
 /* ── 暗色主题：仅覆盖语义变量，规则本身不必改动 ── */
 :root[data-theme="dark"] {
   --c-primary: #7a70e6;
@@ -3351,6 +3373,24 @@ a.model-encyclopedia-field-value:hover {
 
 .agent-collapse-btn:hover { background: var(--c-surface-hover); }
 
+.agent-history-btn {
+  gap: 4px;
+  padding: 0 7px;
+}
+
+.agent-history-btn-count {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: var(--r-pill);
+  background: var(--c-surface-hover);
+  color: var(--c-text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+}
+
 .agent-memory-btn {
   width: 28px;
   height: 28px;
@@ -3505,6 +3545,84 @@ a.model-encyclopedia-field-value:hover {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.agent-history-dialog-mask {
+  position: fixed;
+  inset: 0;
+  z-index: 190;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.48);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.agent-history-dialog {
+  width: min(760px, 100%);
+  max-height: min(760px, calc(100vh - 48px));
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-lg);
+  background: var(--c-surface);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.agent-history-dialog-head {
+  min-height: 54px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--c-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.agent-history-dialog-head > div {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.agent-history-dialog-head h3 {
+  margin: 0;
+  color: var(--c-text);
+  font-size: var(--f-base);
+}
+
+.agent-history-dialog-head span {
+  color: var(--c-text-muted);
+  font-size: var(--f-xs);
+}
+
+.agent-history-dialog-close {
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--c-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.agent-history-dialog-close:hover { background: var(--c-surface-hover); }
+
+.agent-run-history--dialog {
+  margin: 0;
+  padding: 12px;
+  overflow-y: auto;
+}
+
+@media (max-width: 639px) {
+  .agent-history-dialog-mask { padding: 10px; }
+  .agent-history-dialog { max-height: calc(100vh - 20px); }
+  .agent-history-btn > span:not(.agent-history-btn-count) { display: none; }
+  .agent-history-run-side > span:first-child { display: none; }
 }
 
 .agent-run-history-head {
@@ -5243,7 +5361,7 @@ textarea:disabled {
   background: var(--c-overlay);
 }
 .settings-mask {
-  background: var(--c-settings-mask);
+  z-index: 100;
 }
 
 .dialog {
@@ -5304,38 +5422,34 @@ textarea:disabled {
 
 /* ── Settings dialog ── */
 
-/* 固定高度:切换分组时弹窗不再跳动;标题/底部按钮固定,内容区内部滚动 */
+/* 与模型选择器共用 mask / dialog / header，设置页只定义尺寸和内容布局。 */
 .settings-dialog {
-  position: relative;
-  width: min(720px, 94vw);
-  height: min(540px, 86vh);
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--c-settings-glass-border);
-  background: var(--c-settings-glass);
-  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.42);
-  backdrop-filter: blur(22px) saturate(1.35);
-  -webkit-backdrop-filter: blur(22px) saturate(1.35);
+  width: min(820px, calc(100vw - 40px));
+  height: min(76dvh, 620px);
 }
-.settings-dialog .dialog-title,
-.settings-dialog .dialog-actions { flex-shrink: 0; }
-.settings-dialog .dialog-title { padding-right: 40px; }
+
+.settings-dialog-header { min-height: 46px; }
 
 /* 左导航 + 右内容两栏布局 */
-.settings-layout { display: flex; gap: 20px; flex: 1; min-height: 0; }
+.settings-layout { display: flex; gap: 0; flex: 1; min-height: 0; }
+.settings-dialog-body { overflow: hidden; }
 .settings-nav {
   flex-shrink: 0;
-  width: 132px;
+  width: 156px;
+  padding: 12px 10px;
+  border-right: 1px solid var(--c-border);
+  background: var(--c-surface-dim);
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
 .settings-nav-btn {
   display: flex;
   align-items: center;
   gap: 8px;
   text-align: left;
-  padding: 8px 12px;
+  min-height: 38px;
+  padding: 8px 10px;
   border: none;
   border-radius: var(--r-sm);
   background: transparent;
@@ -5350,8 +5464,10 @@ textarea:disabled {
 .settings-nav-btn.active { background: var(--c-primary-bg); color: var(--c-primary); font-weight: 600; }
 .settings-nav-btn.active .settings-nav-icon { opacity: 1; }
 .settings-content { flex: 1; min-width: 0; overflow-y: auto; }
+.settings-dialog-content { padding: 20px 22px; }
 .settings-content .settings-section:last-child { margin-bottom: 0; }
-.settings-close-btn {
+
+.project-dialog .settings-close-btn {
   position: absolute;
   top: 16px;
   right: 16px;
@@ -5367,13 +5483,22 @@ textarea:disabled {
   cursor: pointer;
   transition: all 0.15s;
 }
-.settings-close-btn:hover:not(:disabled) {
+
+.project-dialog .settings-close-btn:hover:not(:disabled) {
   background: var(--c-surface-hover);
   color: var(--c-text);
 }
-.settings-close-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-.settings-dialog .dialog-actions {
-  justify-content: space-between;
+
+.project-dialog .settings-close-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.settings-dialog-footer {
+  min-height: 58px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--c-border);
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  flex: 0 0 auto;
 }
 
 .project-dialog {
@@ -5429,12 +5554,24 @@ textarea:disabled {
   justify-content: flex-end;
 }
 
-.settings-section { margin-bottom: 20px; }
-.settings-section-title { font-size: var(--f-sm); font-weight: 600; margin-bottom: 4px; }
+.settings-section { margin-bottom: 0; }
+.settings-section-title { margin: 0 0 6px; font-size: var(--f-md); font-weight: 700; color: var(--c-text); }
+.settings-section > .dialog-desc { margin-bottom: 16px; }
 
-.settings-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px 16px; }
-.settings-field { display: flex; flex-direction: column; gap: 4px; font-size: var(--f-sm); color: var(--c-text-secondary); }
-.settings-field-switch { flex-direction: row; align-items: center; justify-content: space-between; grid-column: 1 / -1; }
+.settings-appearance-stack {
+  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-appearance-stack .settings-field-switch {
+  min-height: 48px;
+}
+
+.settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.settings-field { display: flex; flex-direction: column; gap: 6px; font-size: var(--f-sm); color: var(--c-text-secondary); }
+.settings-field-switch { min-height: 42px; padding: 0 12px; border: 1px solid var(--c-border); border-radius: var(--r-sm); background: var(--c-surface-inline); flex-direction: row; align-items: center; justify-content: space-between; grid-column: 1 / -1; }
 .settings-field-switch input { width: 18px; height: 18px; }
 .settings-stepper {
   display: grid;
@@ -5477,10 +5614,10 @@ textarea:disabled {
   white-space: nowrap;
 }
 
-.settings-keys { display: flex; flex-direction: column; gap: 8px; }
+.settings-keys { display: flex; flex-direction: column; gap: 8px; margin-top: 4px; }
 .settings-key-row {
   display: flex; align-items: center; justify-content: space-between;
-  padding: 8px 12px; border: 1px solid var(--c-border); border-radius: var(--r-sm); background: var(--c-settings-glass-inner); font-size: var(--f-sm);
+  min-height: 42px; padding: 8px 12px; border: 1px solid var(--c-border); border-radius: var(--r-sm); background: var(--c-surface-inline); font-size: var(--f-sm);
 }
 .settings-key-provider { font-weight: 600; text-transform: capitalize; }
 .settings-key-status.on { color: var(--c-success); font-family: monospace; }
@@ -5515,25 +5652,26 @@ textarea:disabled {
 
 @media (max-width: 560px) {
   .settings-dialog {
-    width: calc(100vw - 16px);
-    height: calc(100dvh - 16px);
-    max-height: calc(100dvh - 16px);
-    padding: 16px;
+    width: 100%;
+    height: min(92dvh, 760px);
+    max-height: calc(100dvh - max(8px, env(safe-area-inset-top)));
   }
-  .settings-layout { flex-direction: column; gap: 12px; }
+  .settings-layout { flex-direction: column; }
   .settings-nav {
     width: 100%;
     flex-direction: row;
     flex-wrap: nowrap;
     overflow-x: auto;
-    padding-bottom: 2px;
+    padding: 8px 10px;
+    border-right: 0;
+    border-bottom: 1px solid var(--c-border);
   }
   .settings-nav-btn {
     flex: 0 0 auto;
     min-height: 36px;
     padding: 8px 10px;
   }
-  .settings-content { padding-right: 2px; }
+  .settings-dialog-content { padding: 16px 14px; }
   .settings-grid { grid-template-columns: 1fr; }
   .settings-field-switch {
     align-items: flex-start;
@@ -5545,10 +5683,7 @@ textarea:disabled {
     flex-direction: column;
   }
   .settings-key-status { overflow-wrap: anywhere; }
-  .settings-dialog .dialog-actions {
-    justify-content: space-between;
-  }
-  .settings-dialog .dialog-btn { flex: 0 1 calc(50% - 4px); }
+  .settings-dialog-footer .dialog-btn { flex: 0 1 calc(50% - 4px); justify-content: center; }
   .project-dialog {
     width: calc(100vw - 16px);
     height: auto;

--- a/client/src/components/agent/AgentPanel.jsx
+++ b/client/src/components/agent/AgentPanel.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Square, ChevronDown, ChevronUp, ChevronsDown, ChevronsUp,
-  Monitor, Loader2, Bot, Clock3, Coins, ListChecks, Trophy,
+  Monitor, Loader2, Bot, Clock3, Coins, ListChecks, Trophy, History, X,
 } from 'lucide-react';
 import { PHONE_BREAKPOINT } from '../../utils/constants.js';
 import { ModelPlanGroup } from './ModelPlanGroup.jsx';
@@ -182,6 +182,7 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
   const [expandedHistoryRun, setExpandedHistoryRun] = useState(null);
   const [historyTraceCache, setHistoryTraceCache] = useState({});
   const [historyTraceLoading, setHistoryTraceLoading] = useState(null);
+  const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
   const [recentRunExpanded, setRecentRunExpanded] = useState(true);
 
   // onRollback 来自上层且每次 render 是新引用；用 ref 包出稳定回调，
@@ -248,13 +249,17 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
     }
   }, [expandedHistoryRun, historyTraceCache, projectId]);
 
-  // ESC closes lightbox
+  // ESC closes the topmost overlay.
   useEffect(() => {
-    if (!lightboxSrc) return;
-    const handler = e => { if (e.key === 'Escape') setLightboxSrc(null); };
+    if (!lightboxSrc && !historyDialogOpen) return;
+    const handler = e => {
+      if (e.key !== 'Escape') return;
+      if (lightboxSrc) setLightboxSrc(null);
+      else setHistoryDialogOpen(false);
+    };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [lightboxSrc]);
+  }, [historyDialogOpen, lightboxSrc]);
 
   useEffect(() => {
     if (!traceStickyRef.current) return;
@@ -293,6 +298,17 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
             </button>
           )}
           <div className="agent-head-actions">
+            {historyRuns.length > 0 && (
+              <button
+                className="agent-collapse-btn agent-history-btn"
+                onClick={e => { e.stopPropagation(); setHistoryDialogOpen(true); }}
+                title={t('agentPanel.previousRuns')}
+              >
+                <History size={12} />
+                <span>{t('agentPanel.previousRuns')}</span>
+                <span className="agent-history-btn-count">{historyRuns.length}</span>
+              </button>
+            )}
             {hasModelCards && !collapsed && showCurrentTrace && (
               <>
                 <button className="agent-collapse-btn agent-expand-all" onClick={e => { e.stopPropagation(); setCardsExpanded(true); }} title={t('agentPanel.expandAllTitle')}>
@@ -330,66 +346,6 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
           <p className="agent-panel-note">
             {t('agentPanel.note')}
           </p>
-
-          {historyRuns.length > 0 && (
-            <div className="agent-run-history">
-              <div className="agent-run-history-head">
-                <span>{t('agentPanel.previousRuns')}</span>
-                <span>{historyRuns.length}</span>
-              </div>
-              {historyRuns.map((run, index) => {
-                const key = runKey(run, index);
-                const meta = run.meta || {};
-                const title = meta.task || t('agent.taskFallback');
-                const expanded = expandedHistoryRun === key;
-                const cachedTrace = historyTraceCache[key];
-                const historyTrace = Array.isArray(run.trace) && run.trace.length > 0 ? run.trace : (cachedTrace || []);
-                const loading = historyTraceLoading === key;
-                const models = (meta.models || []).map(model => modelList.find(item => item.id === model)?.label || model);
-                return (
-                  <div className="agent-history-run" key={key}>
-                    <button className="agent-history-run-toggle" onClick={() => toggleHistoryRun(run, index)}>
-                      <span className="agent-history-run-main">
-                        <strong title={title}>{title}</strong>
-                        <span>
-                          {formatDurationMs(meta.elapsedMs || 0)} · {formatTokenCount(meta.totalTokens || 0)} tok · {t('agentPanel.stepCount', { n: meta.stepCount || 0 })}
-                        </span>
-                      </span>
-                      <span className="agent-history-run-side">
-                        <span>{models.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
-                        <span title={meta.endedAt ? formatFullTime(meta.endedAt) : ''}>
-                          {meta.endedAt ? formatRelativeTime(meta.endedAt) : statusLabel(meta.status, t)}
-                        </span>
-                        {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-                      </span>
-                    </button>
-                    {expanded && (
-                      <div className="agent-history-trace">
-                        {loading ? (
-                          <div className="agent-history-empty">{t('agentPanel.historyLoading')}</div>
-                        ) : historyTrace.length === 0 ? (
-                          <div className="agent-history-empty">{t('agentPanel.historyTraceUnavailable')}</div>
-                        ) : (
-                          <AgentTraceTimeline
-                            trace={historyTrace}
-                            running={false}
-                            modelList={modelList}
-                            cardsExpanded={false}
-                            onManualToggle={disabledRollback}
-                            onRollback={disabledRollback}
-                            rollbackLoading
-                            openLightbox={setLightboxSrc}
-                            t={t}
-                            history
-                          />
-                        )}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
 
           {!running && lastRun && (
             <LastRunFrame
@@ -453,6 +409,59 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
             </>
       </div>
     </section>
+    {historyDialogOpen && (
+      <div className="agent-history-dialog-mask" onPointerDown={() => setHistoryDialogOpen(false)}>
+        <div className="agent-history-dialog" role="dialog" aria-modal="true" aria-labelledby="agent-history-dialog-title" onPointerDown={e => e.stopPropagation()}>
+          <div className="agent-history-dialog-head">
+            <div>
+              <h3 id="agent-history-dialog-title">{t('agentPanel.previousRuns')}</h3>
+              <span>{historyRuns.length}</span>
+            </div>
+            <button type="button" className="agent-history-dialog-close" onClick={() => setHistoryDialogOpen(false)} title={t('common.close')}>
+              <X size={16} />
+            </button>
+          </div>
+          <div className="agent-run-history agent-run-history--dialog">
+            {historyRuns.map((run, index) => {
+              const key = runKey(run, index);
+              const meta = run.meta || {};
+              const title = meta.task || t('agent.taskFallback');
+              const expanded = expandedHistoryRun === key;
+              const cachedTrace = historyTraceCache[key];
+              const historyTrace = Array.isArray(run.trace) && run.trace.length > 0 ? run.trace : (cachedTrace || []);
+              const loading = historyTraceLoading === key;
+              const models = (meta.models || []).map(model => modelList.find(item => item.id === model)?.label || model);
+              return (
+                <div className="agent-history-run" key={key}>
+                  <button className="agent-history-run-toggle" onClick={() => toggleHistoryRun(run, index)}>
+                    <span className="agent-history-run-main">
+                      <strong title={title}>{title}</strong>
+                      <span>{formatDurationMs(meta.elapsedMs || 0)} · {formatTokenCount(meta.totalTokens || 0)} tok · {t('agentPanel.stepCount', { n: meta.stepCount || 0 })}</span>
+                    </span>
+                    <span className="agent-history-run-side">
+                      <span>{models.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
+                      <span title={meta.endedAt ? formatFullTime(meta.endedAt) : ''}>{meta.endedAt ? formatRelativeTime(meta.endedAt) : statusLabel(meta.status, t)}</span>
+                      {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                    </span>
+                  </button>
+                  {expanded && (
+                    <div className="agent-history-trace">
+                      {loading ? (
+                        <div className="agent-history-empty">{t('agentPanel.historyLoading')}</div>
+                      ) : historyTrace.length === 0 ? (
+                        <div className="agent-history-empty">{t('agentPanel.historyTraceUnavailable')}</div>
+                      ) : (
+                        <AgentTraceTimeline trace={historyTrace} running={false} modelList={modelList} cardsExpanded={false} onManualToggle={disabledRollback} onRollback={disabledRollback} rollbackLoading openLightbox={setLightboxSrc} t={t} history />
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    )}
     {lightboxSrc && (
       <div className="screenshot-lightbox" onClick={() => setLightboxSrc(null)}>
         <img className="screenshot-lightbox-img" src={lightboxSrc} alt="screenshot" />

--- a/client/src/components/dialogs/SettingsDialog.jsx
+++ b/client/src/components/dialogs/SettingsDialog.jsx
@@ -33,6 +33,12 @@ const THEME_OPTIONS = [
   { value: 'system', labelKey: 'appearance.theme.system' },
 ];
 
+const FONT_SIZE_OPTIONS = [
+  { value: 'small', labelKey: 'appearance.fontSize.small' },
+  { value: 'standard', labelKey: 'appearance.fontSize.standard' },
+  { value: 'large', labelKey: 'appearance.fontSize.large' },
+];
+
 // 设置分组：左侧导航 → 右侧内容。
 const GROUPS = [
   { id: 'appearance', labelKey: 'settings.group.appearance', Icon: Palette },
@@ -46,7 +52,7 @@ const GROUPS = [
 // 记忆（记忆开关为前端偏好即时生效 + 记忆最大条数后端参数）、API Key 只读展示。
 export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
   const t = useT();
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, fontSize, setFontSize } = useTheme();
   const { locale, setLocale } = useI18n();
   const [activeGroup, setActiveGroup] = useState('appearance');
   const [agent, setAgent] = useState(null);
@@ -163,31 +169,47 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
       return (
         <div className="settings-section">
           <p className="settings-section-title">{t('appearance.title')}</p>
-          <div className="settings-field settings-field-switch">
-            <span>{t('appearance.theme')}</span>
-            <div className="settings-segment">
-              {THEME_OPTIONS.map(opt => (
-                <button
-                  key={opt.value}
-                  className={`settings-segment-btn${theme === opt.value ? ' active' : ''}`}
-                  onClick={() => setTheme(opt.value)}
-                >
-                  {t(opt.labelKey)}
-                </button>
-              ))}
+          <div className="settings-appearance-stack">
+            <div className="settings-field settings-field-switch">
+              <span>{t('appearance.theme')}</span>
+              <div className="settings-segment">
+                {THEME_OPTIONS.map(opt => (
+                  <button
+                    key={opt.value}
+                    className={`settings-segment-btn${theme === opt.value ? ' active' : ''}`}
+                    onClick={() => setTheme(opt.value)}
+                  >
+                    {t(opt.labelKey)}
+                  </button>
+                ))}
+              </div>
             </div>
-          </div>
-          <div className="settings-field settings-field-switch">
-            <span>{t('appearance.language')}</span>
-            <div className="settings-segment">
-              <button
-                className={`settings-segment-btn${locale === 'zh' ? ' active' : ''}`}
-                onClick={() => setLocale('zh')}
-              >中文</button>
-              <button
-                className={`settings-segment-btn${locale === 'en' ? ' active' : ''}`}
-                onClick={() => setLocale('en')}
-              >English</button>
+            <div className="settings-field settings-field-switch">
+              <span>{t('appearance.language')}</span>
+              <div className="settings-segment">
+                <button
+                  className={`settings-segment-btn${locale === 'zh' ? ' active' : ''}`}
+                  onClick={() => setLocale('zh')}
+                >中文</button>
+                <button
+                  className={`settings-segment-btn${locale === 'en' ? ' active' : ''}`}
+                  onClick={() => setLocale('en')}
+                >English</button>
+              </div>
+            </div>
+            <div className="settings-field settings-field-switch">
+              <span>{t('appearance.fontSize')}</span>
+              <div className="settings-segment">
+                {FONT_SIZE_OPTIONS.map(opt => (
+                  <button
+                    key={opt.value}
+                    className={`settings-segment-btn${fontSize === opt.value ? ' active' : ''}`}
+                    onClick={() => setFontSize(opt.value)}
+                  >
+                    {t(opt.labelKey)}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
         </div>
@@ -267,23 +289,29 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
 
   // 保存/重置只对后端 agent 配置生效，外观/记忆开关是前端偏好（即时生效，无需保存）。
   const showSaveBar = activeGroup === 'agent' || activeGroup === 'memory' || activeGroup === 'apiKeys';
+  const activeGroupLabel = t(GROUPS.find(group => group.id === activeGroup)?.labelKey || 'settings.title');
 
   return (
-    <div className="dialog-mask settings-mask" onClick={onClose}>
-      <div className="dialog settings-dialog" onClick={e => e.stopPropagation()}>
-        <button
-          type="button"
-          className="settings-close-btn"
-          onClick={onClose}
-          disabled={saving}
-          aria-label={t('common.close')}
-          title={t('common.close')}
-        >
-          <X size={18} strokeWidth={2} />
-        </button>
-        <p className="dialog-title">{t('settings.title')}</p>
+    <div className="model-picker-mask settings-mask" onPointerDown={onClose}>
+      <div className="model-picker-dialog settings-dialog" role="dialog" aria-modal="true" aria-labelledby="settings-dialog-title" onPointerDown={e => e.stopPropagation()}>
+        <div className="model-picker-header settings-dialog-header">
+          <div className="model-picker-title">
+            <span id="settings-dialog-title">{t('settings.title')}</span>
+            <span className="model-picker-subtitle">{activeGroupLabel}</span>
+          </div>
+          <button
+            type="button"
+            className="model-picker-close"
+            onClick={onClose}
+            disabled={saving}
+            aria-label={t('common.close')}
+            title={t('common.close')}
+          >
+            <X size={16} strokeWidth={2} />
+          </button>
+        </div>
 
-        <div className="settings-layout">
+        <div className="settings-layout settings-dialog-body">
           <nav className="settings-nav">
             {GROUPS.map(g => (
               <button
@@ -297,7 +325,7 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
             ))}
           </nav>
 
-          <div className="settings-content">
+          <div className="settings-content settings-dialog-content">
             {renderGroup()}
             {showSaveBar && error && <p className="settings-error">{error}</p>}
             {showSaveBar && saved && !error && <p className="settings-ok">{t('common.saved')}</p>}
@@ -305,7 +333,7 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
         </div>
 
         {showSaveBar && (
-          <div className="dialog-actions">
+          <div className="settings-dialog-footer">
             <button type="button" className="dialog-btn" onClick={handleReset} disabled={loading || saving || !agent}>{t('common.resetDefault')}</button>
             <button type="button" className="dialog-btn primary" onClick={handleSave} disabled={loading || saving || !agent}>{t('common.save')}</button>
           </div>

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -21,6 +21,10 @@ export const en = {
   'appearance.theme.dark': 'Dark',
   'appearance.theme.system': 'System',
   'appearance.language': 'Language',
+  'appearance.fontSize': 'Overall text size',
+  'appearance.fontSize.small': 'Small',
+  'appearance.fontSize.standard': 'Default',
+  'appearance.fontSize.large': 'Large',
   'appearance.toggleTheme': 'Toggle theme',
 
   // Header

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -22,6 +22,10 @@ export const zh = {
   'appearance.theme.dark': '深色',
   'appearance.theme.system': '跟随系统',
   'appearance.language': '语言',
+  'appearance.fontSize': '总体字号',
+  'appearance.fontSize.small': '小',
+  'appearance.fontSize.standard': '标准',
+  'appearance.fontSize.large': '大',
   'appearance.toggleTheme': '切换深浅色',
 
   // 顶栏

--- a/client/src/theme/ThemeProvider.jsx
+++ b/client/src/theme/ThemeProvider.jsx
@@ -8,6 +8,7 @@ import { usePersistentState } from '../hooks/usePersistentState.js';
 // resolvedTheme 是 system 折算后的最终值（只会是 light 或 dark），
 // CSS 用 <html data-theme="light|dark"> 选择器消费它。
 const THEME_KEY = 'app_theme';
+const FONT_SIZE_KEY = 'app_font_size';
 
 const ThemeContext = createContext(null);
 
@@ -24,6 +25,7 @@ function resolveTheme(theme, systemDark) {
 
 export function ThemeProvider({ children }) {
   const [theme, setTheme] = usePersistentState(THEME_KEY, 'system');
+  const [fontSize, setFontSize] = usePersistentState(FONT_SIZE_KEY, 'standard');
   const [systemDark, setSystemDark] = useState(() => matchDark()?.matches ?? false);
 
   // 监听系统主题变化：只有在 theme === 'system' 时才会影响 resolvedTheme，
@@ -42,6 +44,10 @@ export function ThemeProvider({ children }) {
     document.documentElement.dataset.theme = resolvedTheme;
   }, [resolvedTheme]);
 
+  useEffect(() => {
+    document.documentElement.dataset.fontSize = ['small', 'large'].includes(fontSize) ? fontSize : 'standard';
+  }, [fontSize]);
+
   // 顶栏一键切换：在 light/dark 间翻转。若当前是 system，则相对当前呈现取反，
   // 切换后变成显式 light/dark（符合“点一下就立刻反过来”的直觉）。
   const toggleTheme = useCallback(() => {
@@ -49,8 +55,8 @@ export function ThemeProvider({ children }) {
   }, [resolvedTheme, setTheme]);
 
   const value = useMemo(
-    () => ({ theme, setTheme, resolvedTheme, toggleTheme }),
-    [theme, setTheme, resolvedTheme, toggleTheme]
+    () => ({ theme, setTheme, resolvedTheme, toggleTheme, fontSize, setFontSize }),
+    [theme, setTheme, resolvedTheme, toggleTheme, fontSize, setFontSize]
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;


### PR DESCRIPTION
## Summary
- move previous Agent runs into a dedicated history dialog opened from the Agent header
- align the settings dialog with the model picker dialog shell and improve spacing/layout
- add persistent global text-size preferences with small, default, and large options
- refine responsive behavior and preserve screenshot lightbox layering

## Validation
- npm run typecheck
- npm run build:client
- npm run lint
- npm test (36 files, 199 tests)