### PR TITLE
Refactor agent core contracts and validate project roots

### DIFF
--- a/BACKEND_TODO.md
+++ b/BACKEND_TODO.md
@@ -14,6 +14,7 @@
 - [ ] 使用原子 Run 锁消除并发启动竞态；取消中的 Run 继续占用运行锁。
 - [ ] 统一模型、工具、worker、子 Agent 的 `AbortSignal` 和 deadline，确保超时真正终止底层任务。
 - [ ] 修复 spawn 子 Agent 超时未传递的问题。
+- [x] 项目创建、更新、激活和 Agent Run 启动前校验根目录，失效时返回明确错误。
 - [ ] 强化项目目录隔离：读写都使用 canonical realpath，阻止绝对路径和 symlink 越界。
 - [ ] 让子 Agent 使用真正的只读工具集合，禁止终端写入和浏览器交互副作用。
 - [ ] 修复项目 Run 取消和 SSE 重连错误使用全局 checkpoint/trace 目录的问题。
@@ -27,4 +28,3 @@
 - [ ] 自动恢复任务完成后，正确写入本轮项目记忆。
 - [ ] 对 LLM 日志、trace、终端输出和截图增加敏感信息脱敏。
 - [ ] 继续收紧 provider、工具实现和 checkpoint 边界中的遗留 `any`。
-

--- a/BACKEND_TODO.md
+++ b/BACKEND_TODO.md
@@ -1,0 +1,30 @@
+# Sagent Backend TODO
+
+按优先级逐项处理。每完成一项，补充对应测试并从本列表勾选。
+
+## P0 — 安全边界
+
+- [ ] 重构 `terminal.run_safe`：改为无 shell 的命令 + 参数白名单，移除可写/可执行子命令。
+- [ ] 为局域网 API 增加认证、严格 CORS 和安全的默认监听地址。
+- [ ] 审批接口校验 `approvalId` 与 `runId` 的归属关系。
+
+## P1 — 核心正确性
+
+- [x] 建立 `AgentAction`、`AgentEvent`、`RunRecord` 判别联合与明确的 Run 状态机。
+- [ ] 使用原子 Run 锁消除并发启动竞态；取消中的 Run 继续占用运行锁。
+- [ ] 统一模型、工具、worker、子 Agent 的 `AbortSignal` 和 deadline，确保超时真正终止底层任务。
+- [ ] 修复 spawn 子 Agent 超时未传递的问题。
+- [ ] 强化项目目录隔离：读写都使用 canonical realpath，阻止绝对路径和 symlink 越界。
+- [ ] 让子 Agent 使用真正的只读工具集合，禁止终端写入和浏览器交互副作用。
+- [ ] 修复项目 Run 取消和 SSE 重连错误使用全局 checkpoint/trace 目录的问题。
+- [ ] 为 checkpoint/trace/memory 建立串行持久化队列，结束前 flush，消除写入与清理竞态。
+
+## P2 — 稳定性与可维护性
+
+- [ ] 为 SSE 事件增加单调序号和 cursor 重连，避免重放重复与乱序。
+- [ ] 限制内存事件和 trace promise 数量，增加日志大小与保留周期配置。
+- [ ] 将 memory 持久化纳入可等待的后台任务队列，shutdown 时统一 flush。
+- [ ] 自动恢复任务完成后，正确写入本轮项目记忆。
+- [ ] 对 LLM 日志、trace、终端输出和截图增加敏感信息脱敏。
+- [ ] 继续收紧 provider、工具实现和 checkpoint 边界中的遗留 `any`。
+

--- a/agent/core/action-types.ts
+++ b/agent/core/action-types.ts
@@ -9,6 +9,8 @@
  *     调用 inferTool(action.type) 补全，再根据 tool 路由到对应的 normalize 函数
  */
 
+import type { AgentTool } from './contracts.ts';
+
 export const ACTION_TYPE_TO_TOOL = {
   // browser
   navigate: 'browser',
@@ -63,8 +65,10 @@ export const ACTION_TYPE_TO_TOOL = {
   done: 'core',
   ask_user: 'core',
   notify_user: 'core',
-};
+} as const satisfies Record<string, AgentTool>;
 
-export function inferTool(type) {
+export type KnownActionType = keyof typeof ACTION_TYPE_TO_TOOL;
+
+export function inferTool(type: string): AgentTool | '' {
   return ACTION_TYPE_TO_TOOL[type] ?? '';
 }

--- a/agent/core/approval-store.ts
+++ b/agent/core/approval-store.ts
@@ -13,21 +13,27 @@
  *   - routes/agent.js 的 POST /api/agent finally → rejectAll（运行结束时清理）
  */
 
+import type { ApprovalPayload, ApprovalStore } from './contracts.ts';
+
 function createApprovalId() {
   return `approval_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function serializeApproval(approval: any) {
-  const payload = approval.payload && typeof approval.payload === 'object' ? approval.payload : {};
+interface ApprovalRecord {
+  approvalId: string;
+  payload: ApprovalPayload;
+  resolve: (decision: string) => void;
+}
+
+function serializeApproval(approval: ApprovalRecord) {
   return {
-    ...payload,
+    ...approval.payload,
     approvalId: approval.approvalId,
   };
 }
 
-export function createApprovalStore() {
-  /** @type {Map<string, {approvalId: string, payload: Object, resolve: Function}>} approvalId → 审批记录 */
-  const pending = new Map();
+export function createApprovalStore(): ApprovalStore {
+  const pending = new Map<string, ApprovalRecord>();
 
   return {
     /**
@@ -37,15 +43,15 @@ export function createApprovalStore() {
      * @param {string} requestedApprovalId - worker bridge 已发给前端的审批 ID
      * @returns {{ approvalId: string, promise: Promise<string> }}
      */
-    request(payload = {}, requestedApprovalId?: string) {
+    request(payload: ApprovalPayload, requestedApprovalId?: string) {
       const approvalId = requestedApprovalId || createApprovalId();
       if (pending.has(approvalId)) {
         throw new Error(`审批已存在: ${approvalId}`);
       }
       let settled = false;
-      let resolvePromise;
+      let resolvePromise: (decision: string) => void = () => {};
 
-      const promise = new Promise(resolve => {
+      const promise = new Promise<string>(resolve => {
         resolvePromise = decision => {
           if (settled) return;
           settled = true;
@@ -69,7 +75,7 @@ export function createApprovalStore() {
      * @param {'approve'|'reject'|string} decision
      * @returns {Object} 审批时传入的 payload
      */
-    resolve(approvalId, decision) {
+    resolve(approvalId: string, decision: string) {
       const approval = pending.get(approvalId);
       if (!approval) {
         throw new Error(`审批不存在: ${approvalId}`);

--- a/agent/core/contracts.ts
+++ b/agent/core/contracts.ts
@@ -1,0 +1,354 @@
+/**
+ * Agent 内部核心契约。
+ *
+ * 外部模型/SDK 的未知数据应在 adapter/schema 边界被校验，进入 runtime 后只使用
+ * 这里定义的归一化 Action、Event、Step 和 Run 类型。
+ */
+
+export type JsonObject = Record<string, unknown>;
+
+export interface TokenUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  output_tokens?: number;
+  total_tokens?: number;
+}
+
+export type CoreAction =
+  | { tool: 'core'; type: 'finish'; answer: string }
+  | { tool: 'core'; type: 'ask_user'; question: string }
+  | { tool: 'core'; type: 'notify_user'; message: string; level: 'info' | 'warning' | 'discovery' };
+
+export type BrowserAction =
+  | { tool: 'browser'; type: 'navigate'; url: string }
+  | { tool: 'browser'; type: 'click'; elementId: string }
+  | { tool: 'browser'; type: 'type'; elementId: string; text: string; submit: boolean }
+  | { tool: 'browser'; type: 'wait'; seconds: number }
+  | { tool: 'browser'; type: 'scroll'; direction: 'up' | 'down'; amount: number }
+  | { tool: 'browser'; type: 'get_page_content' }
+  | { tool: 'browser'; type: 'http_fetch'; url: string; extractLinks: boolean }
+  | { tool: 'browser'; type: 'parallel_fetch'; urls: string[]; extractLinks: boolean };
+
+export type FsAction =
+  | { tool: 'fs'; type: 'list_dir'; path: string }
+  | { tool: 'fs'; type: 'get_file_info'; path: string }
+  | { tool: 'fs'; type: 'read_file'; path: string; maxBytes: number }
+  | { tool: 'fs'; type: 'write_file'; path: string; content: string; append: boolean }
+  | { tool: 'fs'; type: 'search_files'; query: string; path: string; include: string; maxResults: number };
+
+export type TerminalAction = {
+  tool: 'terminal';
+  type: 'run_safe' | 'run_confirmed' | 'run_review';
+  command: string;
+  cwd: string;
+  timeoutMs: number;
+};
+
+export type MacOSAction =
+  | { tool: 'macos'; type: 'open_app' | 'activate_app'; app: string }
+  | { tool: 'macos'; type: 'list_windows' | 'capture_screen' }
+  | { tool: 'macos'; type: 'type_text'; text: string }
+  | { tool: 'macos'; type: 'press_key'; key: string; modifiers: string[] }
+  | { tool: 'macos'; type: 'click_at'; x: number; y: number };
+
+export type IdeAction =
+  | { tool: 'ide'; type: 'ide_list_tools'; refresh: boolean }
+  | { tool: 'ide'; type: 'ide_call_tool'; toolName: string; arguments: JsonObject; refreshTools: boolean };
+
+export type ChromeAction =
+  | { tool: 'chrome'; type: 'chrome_list_tools'; refresh: boolean }
+  | { tool: 'chrome'; type: 'chrome_call_tool'; toolName: string; arguments: JsonObject; refreshTools: boolean };
+
+export type AgentAction =
+  | CoreAction
+  | BrowserAction
+  | FsAction
+  | TerminalAction
+  | MacOSAction
+  | IdeAction
+  | ChromeAction
+  | { tool: 'search'; type: 'web_search'; query: string; maxResults: number }
+  | { tool: 'codegraph'; type: 'codegraph_query'; query: string }
+  | { tool: 'vision'; type: 'image_analyze'; image: string; question: string }
+  | { tool: 'spawn'; type: 'spawn'; tasks: string[] };
+
+export type AgentTool = AgentAction['tool'];
+export type ActionForTool<T extends AgentTool> = Extract<AgentAction, { tool: T }>;
+
+export interface AgentDecision {
+  rationale: string;
+  action: AgentAction;
+  usage?: TokenUsage | null;
+  reasoning?: string | null;
+  model?: string;
+  consensus?: JsonObject;
+}
+
+export type ActionResultStatus = 'success' | 'failed' | 'rejected';
+
+export interface AgentStep {
+  step: number;
+  rationale: string;
+  action: AgentAction;
+  result: unknown;
+  resultStatus?: ActionResultStatus;
+  resultError?: string | null;
+  url?: string;
+  title?: string;
+  observation?: JsonObject;
+}
+
+export type AgentObservation = JsonObject;
+
+interface EventTraceFields {
+  runId?: string;
+  timestamp?: number;
+  trace_id?: string;
+  span_id?: string;
+  parent_id?: string;
+  operation?: string;
+  start_time?: number;
+  end_time?: number;
+  duration_ms?: number;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  usage?: TokenUsage | null;
+}
+
+export type AgentEvent = EventTraceFields & (
+  | { type: 'status'; status: string; message?: string }
+  | { type: 'run_meta'; startedAt: number; model?: string; agentModels?: string[]; task?: string }
+  | { type: 'step'; step: number; stage: 'observe'; observation: unknown }
+  | { type: 'step'; step: number; stage: 'action'; rationale?: string; action: AgentAction; usage?: TokenUsage | null }
+  | { type: 'step'; step: number; stage: 'result'; result: unknown; resultStatus?: ActionResultStatus; resultError?: string | null }
+  | { type: 'model_plan'; stage: 'start' | 'thinking' | 'success' | 'winner' | 'failed' | 'cancelled' | 'pending' | 'rate_limited' | 'consensus'; step?: number; model?: string; models?: string[]; action?: AgentAction; rationale?: string; reasoning?: string | null; usage?: TokenUsage | null; error?: string; delay?: number; cooldown_ms?: number; routing?: unknown; consensus?: unknown }
+  | { type: 'terminal_output'; step?: number; phase: 'start' | 'stdout' | 'stderr' | 'exit' | 'error' | 'timeout'; command?: string; cwd?: string; sequence?: number; chunk?: string; exitCode?: number | null; elapsedMs?: number; message?: string }
+  | { type: 'session_checkpoint'; step: number; message: string }
+  | { type: 'rollback'; targetStep: number; message: string }
+  | { type: 'notification'; level: 'info' | 'warning' | 'discovery'; step?: number; message: string }
+  | { type: 'approval_required' | 'question_required'; approvalId: string; step?: number; action: AgentAction; message?: string }
+  | { type: 'approval_result'; approvalId?: string; step?: number; decision: 'approve' | 'reject' | 'blocked'; action: AgentAction; message: string }
+  | { type: 'user_response'; approvalId: string; step?: number; question: string; response: string }
+  | { type: 'done'; answer: string; steps?: AgentStep[]; quality?: unknown; meta?: JsonObject }
+  | { type: 'error'; error: string; rollbackSuggestion?: unknown }
+);
+
+export type AgentEventWriter = (event: AgentEvent) => void;
+
+export type RunStatus =
+  | 'starting'
+  | 'running'
+  | 'waiting_approval'
+  | 'cancelling'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export type ActiveRunStatus = Extract<RunStatus, 'starting' | 'running' | 'waiting_approval' | 'cancelling'>;
+export type TerminalRunStatus = Extract<RunStatus, 'completed' | 'failed' | 'cancelled'>;
+
+export const ACTIVE_RUN_STATUSES: ReadonlySet<RunStatus> = new Set<RunStatus>([
+  'starting',
+  'running',
+  'waiting_approval',
+  'cancelling',
+]);
+
+export const RUN_STATUS_TRANSITIONS: Readonly<Record<RunStatus, ReadonlySet<RunStatus>>> = {
+  starting: new Set(['running', 'cancelling', 'failed']),
+  running: new Set(['waiting_approval', 'cancelling', 'completed', 'failed']),
+  waiting_approval: new Set(['running', 'cancelling', 'failed']),
+  cancelling: new Set(['cancelled', 'failed']),
+  completed: new Set(),
+  failed: new Set(),
+  cancelled: new Set(),
+};
+
+export interface RunMeta {
+  model?: string;
+  agentModels?: string[];
+  task?: string;
+  projectId?: string | null;
+  dataDir?: string;
+  projectRoot?: string | null;
+  [key: string]: unknown;
+}
+
+export interface WorkerControl {
+  cancel?: () => void;
+  rollback?: (targetStep: number) => void;
+}
+
+export interface RunRecord {
+  runId: string;
+  startedAt: number;
+  cancelAc: AbortController;
+  events: AgentEvent[];
+  status: RunStatus;
+  meta: RunMeta;
+  traceWrites?: Promise<unknown>[];
+  _reconnectWriters?: AgentEventWriter[] | null;
+  pendingRollback?: number | null;
+  rolledBack?: boolean;
+  workerControl?: WorkerControl | null;
+  cleanupTimer?: NodeJS.Timeout;
+}
+
+export interface AgentRunStore {
+  createRun(meta?: RunMeta, startedAt?: number, existingRunId?: string): RunRecord;
+  getRun(runId: string): RunRecord | null;
+  getActiveRun(): RunRecord | null;
+  getActiveRuns(): RunRecord[];
+  getRunningRuns(): RunRecord[];
+  addEvent(runId: string, event: AgentEvent): void;
+  transitionRun(runId: string, nextStatus: RunStatus): RunRecord | null;
+  cancelRun(runId: string): RunRecord | null;
+  closeRun(runId: string, outcome?: TerminalRunStatus): RunRecord | null;
+}
+
+export interface ApprovalPayload {
+  type: 'approval_required' | 'question_required';
+  runId: string;
+  step?: number;
+  action: AgentAction;
+  message?: string;
+}
+
+export interface PendingApproval extends ApprovalPayload {
+  approvalId: string;
+}
+
+export interface ApprovalStore {
+  request(payload: ApprovalPayload, requestedApprovalId?: string): { approvalId: string; promise: Promise<string> };
+  resolve(approvalId: string, decision: string): ApprovalPayload;
+  listPendingForRun(runId: string): PendingApproval[];
+  getPendingForRun(runId: string): PendingApproval | null;
+  rejectAll(): void;
+}
+
+export interface DomainRules {
+  needsBrowser(url: string): Promise<boolean>;
+  markBrowserDomain(url: string): Promise<void>;
+  detectBotResponse(content: unknown): Promise<boolean>;
+  getRules(): Promise<string[]>;
+  addDomain(domain: string): Promise<void>;
+  removeDomain(domain: string): Promise<void>;
+  resetToDefaults(): Promise<void>;
+}
+
+export interface AgentRuntimeState {
+  runId?: string;
+  onEvent?: AgentEventWriter;
+  headless?: boolean;
+  browserSession?: {
+    view?: { navigate(url: string): Promise<unknown>; [key: string]: unknown };
+    [key: string]: unknown;
+  } | null;
+  observeDesktop?: boolean;
+  model?: string;
+  agentModels?: string[];
+  strategy?: string;
+  systemPrompt?: string | null;
+  cancelSignal?: AbortSignal;
+  projectRoot?: string | null;
+  dataDir?: string | null;
+  [key: string]: unknown;
+}
+
+export interface RuntimeStepContext {
+  task: string;
+  step: number;
+  history: AgentStep[];
+}
+
+export interface RuntimeDecisionContext extends RuntimeStepContext {
+  observation: AgentObservation;
+  state: AgentRuntimeState;
+}
+
+export interface RunAgentRuntimeOptions {
+  task: string;
+  maxSteps?: number;
+  onEvent?: AgentEventWriter | null;
+  cancelSignal?: AbortSignal | null;
+  initialize: (context: { task: string; onEvent?: AgentEventWriter | null }) => AgentRuntimeState | Promise<AgentRuntimeState>;
+  observe: (state: AgentRuntimeState, context: RuntimeStepContext) => AgentObservation | Promise<AgentObservation>;
+  decide: (context: RuntimeDecisionContext) => AgentDecision | Promise<AgentDecision>;
+  authorize?: ((state: AgentRuntimeState, action: AgentAction, context: AgentExecutionContext) => AgentAuthorization | Promise<AgentAuthorization>) | null;
+  execute: (state: AgentRuntimeState, action: AgentAction, context: AgentExecutionContext) => unknown | Promise<unknown>;
+  cleanup?: ((state: AgentRuntimeState) => void | Promise<void>) | null;
+  shouldObserve?: ((lastAction: AgentAction) => boolean) | null;
+  initialStep?: number;
+  initialHistory?: AgentStep[];
+  onCheckpoint?: ((history: AgentStep[], step: number) => unknown | Promise<unknown>) | null;
+  saveSessionSnapshot?: ((data: unknown) => unknown | Promise<unknown>) | null;
+  sessionCheckpointDir?: string | null;
+  runRecord?: Pick<RunRecord, 'runId' | 'pendingRollback' | 'rolledBack'> | null;
+}
+
+export interface AgentExecutionContext {
+  task: string;
+  step: number;
+  history: AgentStep[];
+  observation: AgentObservation;
+  authorization?: AgentAuthorization;
+  rationale?: string;
+}
+
+export type AgentAuthorization =
+  | { status: 'approved'; response?: string }
+  | { status: 'rejected'; message: string; response?: string };
+
+export type ActionHandlerMap<State extends AgentRuntimeState = AgentRuntimeState> = {
+  [Tool in AgentTool]?: (
+    state: State,
+    action: ActionForTool<Tool>,
+    context: AgentExecutionContext,
+  ) => unknown | Promise<unknown>;
+};
+
+export interface DesktopAgentResult {
+  answer: string;
+  steps: AgentStep[];
+  quality?: ResultQuality;
+}
+
+export interface ResultQuality {
+  status: 'done' | 'done_unverified' | 'done_degraded';
+  requires_verified_sources: boolean;
+  official_source_steps: number[];
+  failure_steps: number[];
+  unverified: boolean;
+  browse_intent_without_observation: boolean;
+  degraded: boolean;
+  reasons: string[];
+}
+
+export interface DesktopAgentRunOptions {
+  task: string;
+  model: string;
+  models?: string[];
+  strategy?: string;
+  systemPrompt?: string | null;
+  headless?: boolean;
+  onEvent?: AgentEventWriter;
+  cancelSignal?: AbortSignal;
+  runId: string;
+  runRecord?: RunRecord | null;
+  startedAt?: number;
+  initialStep?: number;
+  initialHistory?: AgentStep[];
+  conversationHistory?: Array<{ role: string; content: string }>;
+  memory?: boolean;
+  projectRoot?: string | null;
+  dataDir?: string | null;
+  checkpointWriter?: {
+    saveCheckpoint(data: unknown): void | Promise<void>;
+    saveHealthySnapshot(data: unknown): void | Promise<void>;
+  } | null;
+}
+
+export interface DesktopAgentRunner {
+  (options: DesktopAgentRunOptions): Promise<DesktopAgentResult>;
+  domainRules?: DomainRules;
+}

--- a/agent/core/project-store.ts
+++ b/agent/core/project-store.ts
@@ -74,6 +74,38 @@ function normalizeProjectInput({ name, rootPath }: { name?: string; rootPath?: s
   return { name: trimmedName, rootPath: path.normalize(trimmedRoot) };
 }
 
+export class ProjectPathError extends Error {
+  status = 400;
+  code = 'PROJECT_ROOT_UNAVAILABLE';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProjectPathError';
+  }
+}
+
+/** 校验项目根存在、可访问且确实为目录，并返回消除 symlink/.. 后的 canonical 路径。 */
+export async function validateProjectRoot(rootPath: string): Promise<string> {
+  const normalized = path.normalize(rootPath);
+  let stats;
+  try {
+    stats = await fs.stat(normalized);
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') {
+      throw new ProjectPathError(`项目根目录不存在或已移动: ${normalized}`);
+    }
+    throw new ProjectPathError(`项目根目录无法访问: ${normalized} (${err?.message || err})`);
+  }
+  if (!stats.isDirectory()) {
+    throw new ProjectPathError(`项目根路径不是目录: ${normalized}`);
+  }
+  try {
+    return await fs.realpath(normalized);
+  } catch (err: any) {
+    throw new ProjectPathError(`项目根目录无法解析: ${normalized} (${err?.message || err})`);
+  }
+}
+
 export interface Project {
   projectId: string;
   name: string;
@@ -120,6 +152,7 @@ export function createProjectStore(memoryRoot: string) {
 
     async create({ name, rootPath }: { name?: string; rootPath?: string }) {
       const normalized = normalizeProjectInput({ name, rootPath });
+      normalized.rootPath = await validateProjectRoot(normalized.rootPath);
       const now = new Date().toISOString();
       const project: Project = { projectId: generateProjectId(), ...normalized, createdAt: now, updatedAt: now };
       registry.projects.push(project);
@@ -138,6 +171,7 @@ export function createProjectStore(memoryRoot: string) {
           name: patch.name ?? project.name,
           rootPath: patch.rootPath ?? project.rootPath,
         });
+        normalized.rootPath = await validateProjectRoot(normalized.rootPath);
         project.name = normalized.name;
         project.rootPath = normalized.rootPath;
       }
@@ -160,7 +194,9 @@ export function createProjectStore(memoryRoot: string) {
 
     /** 设置当前项目;传 null 回到「无项目」全局态 */
     async setActive(projectId: string | null) {
-      if (projectId !== null && !store.get(projectId)) throw new Error('项目不存在');
+      const project = projectId === null ? null : store.get(projectId);
+      if (projectId !== null && !project) throw new Error('项目不存在');
+      if (project) await validateProjectRoot(project.rootPath);
       registry.activeProjectId = projectId;
       await writeRegistry(memoryRoot, registry);
       return registry.activeProjectId;
@@ -195,4 +231,28 @@ export function resolveRunPaths(
     };
   }
   return { projectId: null, projectRoot: process.cwd(), dataDir: globalMemoryDir };
+}
+
+/**
+ * 执行 Agent 前使用的严格路径解析：显式项目不存在或根目录失效时直接报错，
+ * 避免静默回退到全局 cwd，或让 child_process 报误导性的 posix_spawn ENOENT。
+ */
+export async function resolveRunPathsForExecution(
+  projectStore: ProjectStore,
+  projectId: string | null | undefined,
+  globalMemoryDir: string,
+): Promise<{ projectId: string | null; projectRoot: string; dataDir: string }> {
+  if (!projectId) {
+    return { projectId: null, projectRoot: process.cwd(), dataDir: globalMemoryDir };
+  }
+  const project = projectStore.get(projectId);
+  if (!project) {
+    throw new ProjectPathError(`项目不存在或已删除: ${projectId}`);
+  }
+  const projectRoot = await validateProjectRoot(project.rootPath);
+  return {
+    projectId: project.projectId,
+    projectRoot,
+    dataDir: projectDataDir(globalMemoryDir, project.projectId),
+  };
 }

--- a/agent/core/providers/types.ts
+++ b/agent/core/providers/types.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Response } from 'express';
+import type { AgentAction, AgentObservation, AgentStep, JsonObject, TokenUsage } from '../contracts.ts';
 
 // 归一化后的模型信息。provider 是「展示名」（gemini / nvidia 等，
 // 由 baseURL 推断），前端徽标依赖它；与下面 LLMProvider.name 这个「内部路由标识」区分开。
@@ -40,31 +41,32 @@ export interface ModelInfo {
 // 由 runtime 的 decide 阶段透传，各 provider 自行决定如何构造 messages。
 export interface AgentPlanOpts {
   model: string;
+  modelConfig?: ModelInfo[];
   signal?: AbortSignal;
   systemPrompt?: string | null;
   task?: string;
   step?: number;
-  history?: any[];
-  observation?: any;
+  history?: AgentStep[];
+  observation?: AgentObservation;
   conversationHistory?: Array<{ role: string; content: string }>;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 // agent 决策的归一化返回，对齐现有 planner 的输出形状。
 export interface AgentPlanResult {
   rationale?: string;
-  action: any;
-  usage?: { prompt_tokens: number; completion_tokens: number } | null;
+  action: AgentAction;
+  usage?: TokenUsage | null;
   reasoning?: string | null;
 }
 
 export interface CompletionOpts {
   model: string;
-  messages: any[];
+  messages: JsonObject[];
   temperature: number;
   top_p: number;
   max_tokens: number;
-  chat_template_kwargs?: any;
+  chat_template_kwargs?: JsonObject;
   preserveReasoningContent?: boolean;
 }
 

--- a/agent/core/result-quality.ts
+++ b/agent/core/result-quality.ts
@@ -1,3 +1,5 @@
+import type { AgentStep, ResultQuality } from './contracts.ts';
+
 const HIGH_STAKES_TASK_PATTERNS = [
   /医保|社保|公积金|签证|移民|贷款|股票|基金|汇率|合规|法律|法规|政策|许可/,
 ];
@@ -108,7 +110,7 @@ function browseStepProducedContent(step: any) {
   return result.length >= 400;
 }
 
-export function assessResultQuality({ task, steps = [], answer = '' }: { task: string; steps?: any[]; answer?: string }) {
+export function assessResultQuality({ task, steps = [], answer = '' }: { task: string; steps?: AgentStep[]; answer?: string }): ResultQuality {
   const requiresVerifiedSources = taskRequiresVerifiedSources(task);
   const hasBrowseIntent = taskHasBrowseIntent(task);
   const failureSteps = steps.filter(step => {
@@ -128,7 +130,7 @@ export function assessResultQuality({ task, steps = [], answer = '' }: { task: s
   const answerText = textOf(answer);
   const answerAcknowledgesUnverified = /未能核验|无法核验|未完成核验|未找到官方|无法确认|请以.*为准/.test(answerText);
 
-  let status = 'done';
+  let status: ResultQuality['status'] = 'done';
   const reasons: string[] = [];
 
   if (requiresVerifiedSources && officialSourceSteps.length === 0) {

--- a/agent/core/router.ts
+++ b/agent/core/router.ts
@@ -12,8 +12,19 @@
  *   { browser: async (state, action) => ..., fs: async (state, action) => ..., ... }
  */
 
-export function createActionRouter(handlers, { defaultTool }: { defaultTool?: string } = {} as any) {
-  return async (state, action, context) => {
+import type {
+  ActionHandlerMap,
+  AgentAction,
+  AgentExecutionContext,
+  AgentRuntimeState,
+  AgentTool,
+} from './contracts.ts';
+
+export function createActionRouter<State extends AgentRuntimeState>(
+  handlers: ActionHandlerMap<State>,
+  { defaultTool }: { defaultTool?: AgentTool } = {},
+) {
+  return async (state: State, action: AgentAction, context: AgentExecutionContext) => {
     const toolName =
       typeof action?.tool === 'string' && action.tool.trim()
         ? action.tool.trim()
@@ -28,6 +39,6 @@ export function createActionRouter(handlers, { defaultTool }: { defaultTool?: st
       throw new Error(`未找到工具处理器: ${toolName}`);
     }
 
-    return handler(state, action, context);
+    return handler(state, action as never, context);
   };
 }

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -37,6 +37,12 @@ import {
 } from "./checkpoint.js";
 import { assessResultQuality } from "./result-quality.ts";
 import { runtimeConfig } from "./runtime-config.ts";
+import type {
+  AgentAction,
+  AgentStep,
+  ActionResultStatus,
+  RunAgentRuntimeOptions,
+} from './contracts.ts';
 
 function actionTargetUrl(action) {
   if (typeof action?.url === 'string' && action.url) return action.url;
@@ -44,7 +50,13 @@ function actionTargetUrl(action) {
   return null;
 }
 
-function compressHistory(history, maxSteps?) {
+function observationText(observation: unknown, key: 'url' | 'title'): string | undefined {
+  if (!observation || typeof observation !== 'object') return undefined;
+  const value = (observation as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function compressHistory(history: AgentStep[], maxSteps?: number) {
   // 历史截断预算每次从运行时配置读取，前台改完无需重启即生效
   const { maxHistorySteps, maxResultChars: MAX_RESULT_CHARS, maxParallelResultChars: MAX_PARALLEL_RESULT_CHARS } = runtimeConfig.get();
   if (maxSteps == null) maxSteps = maxHistorySteps;
@@ -118,7 +130,7 @@ function stableStringify(value) {
   return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
 }
 
-function actionLoopKey(action) {
+function actionLoopKey(action: AgentAction | undefined | null) {
   if (!action || typeof action !== 'object') return '';
   if (action.type === 'finish' || action.type === 'ask_user' || action.type === 'notify_user') return '';
   const tool = action.tool || 'core';
@@ -147,7 +159,7 @@ function resultFingerprint(result) {
   return String(result ?? '').replace(/\s+/g, ' ').trim().slice(0, 2000);
 }
 
-function normalizeResultStatus(status) {
+function normalizeResultStatus(status): ActionResultStatus | '' {
   const value = typeof status === 'string' ? status.trim().toLowerCase() : '';
   if (value === 'success' || value === 'failed' || value === 'rejected') return value;
   return '';
@@ -157,7 +169,11 @@ function historyEntryFailed(entry) {
   return normalizeResultStatus(entry?.resultStatus || entry?.status) === 'failed';
 }
 
-function normalizeActionResult(value) {
+function normalizeActionResult(value): {
+  result: unknown;
+  resultStatus: ActionResultStatus;
+  resultError: string | null;
+} {
   if (value && typeof value === 'object' && !Array.isArray(value)) {
     const isStructuredResult = Object.prototype.hasOwnProperty.call(value, 'resultStatus')
       || Object.prototype.hasOwnProperty.call(value, 'result')
@@ -168,7 +184,7 @@ function normalizeActionResult(value) {
     if (!isStructuredResult) {
       return { result: value, resultStatus: 'success', resultError: null };
     }
-    const resultStatus = normalizeResultStatus(value.resultStatus || value.status)
+    const resultStatus: ActionResultStatus = normalizeResultStatus(value.resultStatus || value.status)
       || (value.ok === false ? 'failed' : 'success');
     const resultError = value.resultError != null
       ? String(value.resultError)
@@ -188,7 +204,7 @@ function visionImageKey(action) {
   return isVisionImageAnalyze(action) ? String(action.image).trim() : '';
 }
 
-function detectRepeatedActionLoop(history, action) {
+function detectRepeatedActionLoop(history: AgentStep[], action: AgentAction) {
   const key = actionLoopKey(action);
   if (!key || !Array.isArray(history) || history.length === 0) return null;
 
@@ -215,7 +231,7 @@ function detectRepeatedActionLoop(history, action) {
   return { count, key, result: fingerprint || '', failed: false };
 }
 
-function detectRepeatedVisionLoop(history, action) {
+function detectRepeatedVisionLoop(history: AgentStep[], action: AgentAction) {
   const image = visionImageKey(action);
   if (!image || !Array.isArray(history) || history.length === 0) return null;
 
@@ -276,7 +292,7 @@ export async function runAgentRuntime({
   // v2: 会话检查点 & 手动回滚
   sessionCheckpointDir = null,
   runRecord = null,
-}) {
+}: RunAgentRuntimeOptions) {
   const history = initialHistory;
   let finalAnswer = "";
   const state = await initialize?.({ task, onEvent });
@@ -406,7 +422,7 @@ export async function runAgentRuntime({
         const result = authorization.message || "操作未获批准";
         const resultStatus = "rejected";
         const resultError = result;
-        const url = actionTargetUrl(decision.action) || observation?.url;
+        const url = actionTargetUrl(decision.action) || observationText(observation, 'url');
         history.push({
           step,
           rationale: decision.rationale,
@@ -415,7 +431,7 @@ export async function runAgentRuntime({
           resultStatus,
           resultError,
           url,
-          title: observation?.title,
+          title: observationText(observation, 'title'),
         });
 
         onEvent?.({
@@ -440,7 +456,7 @@ export async function runAgentRuntime({
 
       // ---- 执行 ----
       let result;
-      let resultStatus = "success";
+      let resultStatus: 'success' | 'failed' | 'rejected' = "success";
       let resultError = null;
       try {
         const rawResult = await execute(state, decision.action, {
@@ -469,8 +485,8 @@ export async function runAgentRuntime({
         result,
         resultStatus,
         resultError,
-        url: actionTargetUrl(decision.action) || observation?.url,
-        title: observation?.title,
+        url: actionTargetUrl(decision.action) || observationText(observation, 'url'),
+        title: observationText(observation, 'title'),
       });
 
       if (decision.action.type !== "finish") {

--- a/agent/core/schemas.ts
+++ b/agent/core/schemas.ts
@@ -21,12 +21,17 @@
 
 import { cleanText } from './utils.ts';
 import { inferTool } from './action-types.ts';
+import type { AgentAction, AgentDecision, JsonObject } from './contracts.ts';
 
-function normalizePath(value, fallback = '.') {
+function isRecord(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizePath(value: unknown, fallback = '.') {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
-function sanitizeUrl(rawUrl) {
+function sanitizeUrl(rawUrl: unknown) {
   if (typeof rawUrl !== 'string' || !rawUrl.trim()) {
     throw new Error('navigate 缺少 url');
   }
@@ -45,14 +50,13 @@ function sanitizeUrl(rawUrl) {
   }
 }
 
-function normalizeBrowserAction(type, action) {
+function normalizeBrowserAction(type: string, action: JsonObject): AgentAction {
   if (type === 'open' || type === 'goto') {
     type = 'navigate';
   }
 
   if (type === 'get_page_content') {
-    type = 'get_page_content';
-    return { tool: 'browser', type };
+    return { tool: 'browser', type: 'get_page_content' };
   }
 
   if (type === 'navigate') {
@@ -123,7 +127,7 @@ function normalizeBrowserAction(type, action) {
   throw new Error(`不支持的浏览器动作: ${type}`);
 }
 
-function normalizeSearchAction(type, action) {
+function normalizeSearchAction(type: string, action: JsonObject): AgentAction {
   if (type === 'web_search') {
     const query = typeof action.query === 'string' ? action.query.trim() : '';
     if (!query) throw new Error('web_search 缺少 query');
@@ -139,7 +143,7 @@ function normalizeSearchAction(type, action) {
   throw new Error(`不支持的搜索动作: ${type}`);
 }
 
-function normalizeCodegraphAction(type, action) {
+function normalizeCodegraphAction(type: string, action: JsonObject): AgentAction {
   if (type === 'codegraph_query') {
     const query = typeof action.query === 'string' ? action.query.trim() : '';
     if (!query) throw new Error('codegraph_query 缺少 query');
@@ -148,7 +152,7 @@ function normalizeCodegraphAction(type, action) {
   throw new Error(`不支持的代码图谱动作: ${type}`);
 }
 
-function normalizeVisionAction(type, action) {
+function normalizeVisionAction(type: string, action: JsonObject): AgentAction {
   if (type === 'image_analyze') {
     const image = typeof action.image === 'string' ? action.image.trim() : '';
     const question = typeof action.question === 'string' ? action.question.trim() : '';
@@ -164,7 +168,7 @@ function normalizeVisionAction(type, action) {
   throw new Error(`不支持的视觉动作: ${type}`);
 }
 
-function normalizeFsAction(type, action) {
+function normalizeFsAction(type: string, action: JsonObject): AgentAction {
   if (type === 'list_dir') {
     return {
       tool: 'fs',
@@ -214,7 +218,7 @@ function normalizeFsAction(type, action) {
   throw new Error(`不支持的文件动作: ${type}`);
 }
 
-function normalizeTerminalAction(type, action) {
+function normalizeTerminalAction(type: string, action: JsonObject): AgentAction {
   if (type === 'run_safe' || type === 'run_confirmed' || type === 'run_review') {
     return {
       tool: 'terminal',
@@ -232,7 +236,7 @@ function normalizeTerminalAction(type, action) {
   throw new Error(`不支持的终端动作: ${type}`);
 }
 
-function normalizeMacOsAction(type, action) {
+function normalizeMacOsAction(type: string, action: JsonObject): AgentAction {
   if (type === 'open_app' || type === 'activate_app') {
     return {
       tool: 'macos',
@@ -284,7 +288,7 @@ function normalizeMacOsAction(type, action) {
   throw new Error(`不支持的 macOS 动作: ${type}`);
 }
 
-function normalizeIdeAction(type, action) {
+function normalizeIdeAction(type: string, action: JsonObject): AgentAction {
   if (type === 'ide_list_tools' || type === 'list_tools') {
     return {
       tool: 'ide',
@@ -294,7 +298,7 @@ function normalizeIdeAction(type, action) {
   }
 
   if (type === 'ide_call_tool' || type === 'call_tool') {
-    const args = action.arguments && typeof action.arguments === 'object' && !Array.isArray(action.arguments)
+    const args = isRecord(action.arguments)
       ? action.arguments
       : {};
     return {
@@ -309,7 +313,7 @@ function normalizeIdeAction(type, action) {
   throw new Error(`不支持的 IDE 动作: ${type}`);
 }
 
-function normalizeChromeAction(type, action) {
+function normalizeChromeAction(type: string, action: JsonObject): AgentAction {
   if (type === 'chrome_list_tools' || type === 'chrome_list') {
     return {
       tool: 'chrome',
@@ -319,7 +323,7 @@ function normalizeChromeAction(type, action) {
   }
 
   if (type === 'chrome_call_tool' || type === 'chrome_call') {
-    const args = action.arguments && typeof action.arguments === 'object' && !Array.isArray(action.arguments)
+    const args = isRecord(action.arguments)
       ? action.arguments
       : {};
     return {
@@ -334,7 +338,7 @@ function normalizeChromeAction(type, action) {
   throw new Error(`不支持的 Chrome 动作: ${type}`);
 }
 
-function normalizeSpawnAction(type, action) {
+function normalizeSpawnAction(type: string, action: JsonObject): AgentAction {
   if (type === 'spawn') {
     const tasks = Array.isArray(action.tasks)
       ? action.tasks
@@ -354,7 +358,7 @@ function normalizeSpawnAction(type, action) {
   throw new Error(`不支持的 spawn 动作: ${type}`);
 }
 
-function normalizeCoreAction(type, action) {
+function normalizeCoreAction(type: string, action: JsonObject): AgentAction {
   if (type === 'finish' || type === 'answer' || type === 'final' || type === 'final_answer' || type === 'done') {
     const answer = typeof action.answer === 'string'
       ? action.answer.trim()
@@ -377,21 +381,24 @@ function normalizeCoreAction(type, action) {
     };
   }
   if (type === 'notify_user') {
+    const level = typeof action.level === 'string' && ['info', 'warning', 'discovery'].includes(action.level)
+      ? action.level as 'info' | 'warning' | 'discovery'
+      : 'info';
     return {
       tool: 'core',
       type,
       message: typeof action.message === 'string' ? action.message.trim() : '',
-      level: ['info', 'warning', 'discovery'].includes(action.level) ? action.level : 'info',
+      level,
     };
   }
   throw new Error(`不支持的核心动作: ${type}`);
 }
 
-export function normalizeDesktopAgentDecision(payload) {
-  const action = payload?.action;
-  if (!action || typeof action !== 'object') {
+export function normalizeDesktopAgentDecision(payload: unknown): AgentDecision {
+  if (!isRecord(payload) || !isRecord(payload.action)) {
     throw new Error('模型未返回 action');
   }
+  const action = payload.action;
 
   const type = String(action.type || '').trim();
   if (!type) {
@@ -405,7 +412,7 @@ export function normalizeDesktopAgentDecision(payload) {
   // fetch 已合并到 browser（统一走 WebView）
   const tool = rawTool === 'fetch' ? 'browser' : rawTool;
 
-  let normalizedAction;
+  let normalizedAction: AgentAction;
   if (tool === 'browser') {
     normalizedAction = normalizeBrowserAction(type, action);
   } else if (tool === 'fs') {

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -47,6 +47,30 @@ import { createDesktopPlanner, DEFAULT_MODEL_TIMEOUT_MS } from './planner.ts';
 import { saveCheckpoint } from '../core/checkpoint.ts';
 import { log } from '../../helpers/logger.ts';
 import { runtimeConfig } from '../core/runtime-config.ts';
+import type { ProviderRegistry } from '../core/providers/registry.ts';
+import type { ModelInfo } from '../core/providers/types.ts';
+import type {
+  AgentRunStore,
+  ApprovalStore,
+  DesktopAgentRunOptions,
+  DesktopAgentRunner,
+} from '../core/contracts.ts';
+
+interface DesktopAgentRunnerConfig {
+  registry: ProviderRegistry;
+  openai_client: unknown;
+  modelConfig: ModelInfo[];
+  maxSteps?: number;
+  defaultHeadless?: boolean;
+  observeDesktop?: boolean;
+  runStore?: AgentRunStore | null;
+  approvalStore: Pick<ApprovalStore, 'request'>;
+  checkpointDir?: string;
+  visionModel: string;
+  modelTimeoutMs?: number;
+  staggerDelayMs?: number;
+  batchSize?: number;
+}
 
 export function createDesktopAgentRunner({
   registry,
@@ -55,14 +79,14 @@ export function createDesktopAgentRunner({
   maxSteps = 8,
   defaultHeadless = false,
   observeDesktop = false,
-  runStore: _runStore,
+  runStore,
   approvalStore,
   checkpointDir,
   visionModel,
   modelTimeoutMs = DEFAULT_MODEL_TIMEOUT_MS,
   staggerDelayMs = 0,
   batchSize = 1,
-}) {
+}: DesktopAgentRunnerConfig): DesktopAgentRunner {
   const domainRules = createDomainRules(checkpointDir);
   const { ensureBrowserSession } = createSharedBrowserSessionManager();
 
@@ -281,7 +305,8 @@ export function createDesktopAgentRunner({
     projectRoot = null,
     dataDir = null,
     checkpointWriter = null,
-  }) {
+  }: DesktopAgentRunOptions) {
+    agentModels = agentModels || [model];
     const { maxSteps, modelTimeoutMs, staggerDelayMs, batchSize, observeDesktop, autoModelRouting } = liveConfig();
     const blacklistedModels = new Set();
     const plan = createDesktopPlanner({ registry, modelConfig, blacklistedModels, modelTimeoutMs, staggerDelayMs, batchSize, autoModelRouting });
@@ -290,6 +315,7 @@ export function createDesktopAgentRunner({
       runId,
       approvalStore,
       onEvent,
+      runStore,
     });
 
     // 本次 run 的落盘目录：命中项目用项目目录，否则回退工厂注入的全局 checkpointDir。
@@ -364,6 +390,7 @@ export function createDesktopAgentRunner({
     });
   }
 
-  runDesktopAgent.domainRules = domainRules;
-  return runDesktopAgent;
+  const runner = runDesktopAgent as DesktopAgentRunner;
+  runner.domainRules = domainRules;
+  return runner;
 }

--- a/agent/policy/approvals.ts
+++ b/agent/policy/approvals.ts
@@ -1,7 +1,15 @@
 import { classifyAgentAction } from './classify.ts';
+import type {
+  AgentAction,
+  AgentAuthorization,
+  AgentEventWriter,
+  AgentExecutionContext,
+  AgentRunStore,
+  ApprovalStore,
+} from '../core/contracts.ts';
 
 export function createReadOnlyAuthorizer() {
-  return async (_state, action, _context) => {
+  return async (_state: unknown, action: AgentAction, _context: AgentExecutionContext): Promise<AgentAuthorization> => {
     const policy = classifyAgentAction(action);
 
     if (policy.level === 'safe') {
@@ -20,8 +28,14 @@ export function createAgentAuthorizer({
   runId,
   approvalStore,
   onEvent,
+  runStore,
+}: {
+  runId: string;
+  approvalStore: Pick<ApprovalStore, 'request'>;
+  onEvent?: AgentEventWriter;
+  runStore?: AgentRunStore | null;
 }) {
-  return async (_state, action, context) => {
+  return async (_state: unknown, action: AgentAction, context: AgentExecutionContext): Promise<AgentAuthorization> => {
     const policy = classifyAgentAction(action);
 
     if (policy.level === 'safe') {
@@ -66,7 +80,17 @@ export function createAgentAuthorizer({
       message,
     });
 
-    const decision = await promise;
+    if (runStore?.getRun(runId)?.status === 'running') {
+      runStore.transitionRun(runId, 'waiting_approval');
+    }
+    let decision: string;
+    try {
+      decision = await promise;
+    } finally {
+      if (runStore?.getRun(runId)?.status === 'waiting_approval') {
+        runStore.transitionRun(runId, 'running');
+      }
+    }
 
     if (isQuestion) {
       const response = typeof decision === 'string' && decision !== 'approve' && decision !== 'reject'

--- a/agent/worker/runner.ts
+++ b/agent/worker/runner.ts
@@ -100,6 +100,7 @@ export function createSandboxedWorkerAgentRunner({
   checkpointDir,
   modelConfig,
   approvalStore,
+  runStore,
   visionModel,
   sandbox = true,
   sandboxFile = path.join(REPO_ROOT, 'sandbox.sb'),
@@ -109,6 +110,7 @@ export function createSandboxedWorkerAgentRunner({
   checkpointDir: string;
   modelConfig: any[];
   approvalStore: any;
+  runStore?: any;
   visionModel: string;
   sandbox?: boolean;
   sandboxFile?: string;
@@ -179,11 +181,17 @@ export function createSandboxedWorkerAgentRunner({
       }
       if (message.type === 'approval_request') {
         try {
+          if (opts.runRecord && runStore?.getRun(runId)?.status === 'running') {
+            runStore.transitionRun(runId, 'waiting_approval');
+          }
           const { approvalId, promise } = approvalStore.request({
             ...(message.payload || {}),
             runId,
           }, message.approvalId);
           promise.then((decision: string) => {
+            if (runStore?.getRun(runId)?.status === 'waiting_approval') {
+              runStore.transitionRun(runId, 'running');
+            }
             writeWorkerMessage(child, { type: 'approval_response', approvalId, decision });
           });
         } catch (err: any) {

--- a/helpers/run-agent.ts
+++ b/helpers/run-agent.ts
@@ -13,6 +13,7 @@ import { shutdownChromeMcp, closeAllChromePagesQuiet } from '../agent/tools/chro
 import { resetChromeSnapshotState } from '../agent/tools/chrome/execute.ts';
 import { appendTraceEvent } from './trace-store.ts';
 import { log } from './logger.ts';
+import type { AgentEvent, AgentRunStore, TerminalRunStatus } from '../agent/core/contracts.ts';
 
 function spanPart(value: any) {
   return String(value ?? '')
@@ -61,15 +62,15 @@ function buildOperation(payload: any) {
   return payload?.type || 'event';
 }
 
-export function createBaseEventSender(runId: string, agentRunStore: any, memoryDir?: string) {
+export function createBaseEventSender(runId: string, agentRunStore: AgentRunStore, memoryDir?: string) {
   const stageTimes = new Map<string, number>();
   const modelTimes = new Map<string, number>();
 
-  return (payload: any) => {
+  return (payload: AgentEvent): AgentEvent => {
     const timestamp = Number.isFinite(payload?.timestamp) ? payload.timestamp : Date.now();
     const spanId = buildSpanId(payload);
     const parentId = buildParentId(payload);
-    const event: any = {
+    const event = {
       ...payload,
       runId: payload?.runId || runId,
       timestamp,
@@ -77,7 +78,7 @@ export function createBaseEventSender(runId: string, agentRunStore: any, memoryD
       span_id: spanId,
       operation: buildOperation(payload),
       ...(parentId ? { parent_id: parentId } : {}),
-    };
+    } as AgentEvent;
 
     if (event.usage) {
       event.input_tokens = event.input_tokens ?? event.usage.prompt_tokens ?? null;
@@ -142,7 +143,12 @@ export async function loadMemoryForPrompt(memoryDir: string) {
   }
 }
 
-export async function cleanupAgentRun(checkpointDir: string | undefined, runId: string, agentRunStore: any, { removeSnapshots = false }: { removeSnapshots?: boolean } = {}) {
+export async function cleanupAgentRun(
+  checkpointDir: string | undefined,
+  runId: string,
+  agentRunStore: AgentRunStore,
+  { removeSnapshots = false, finalStatus }: { removeSnapshots?: boolean; finalStatus?: TerminalRunStatus } = {},
+) {
   if (checkpointDir) {
     // step-level checkpoint 只用于崩溃恢复，任务完成后可删除
     await removeCheckpoint(checkpointDir, runId).catch(() => {});
@@ -151,7 +157,7 @@ export async function cleanupAgentRun(checkpointDir: string | undefined, runId: 
       await removeSessionCheckpoints(checkpointDir, runId).catch(() => {});
     }
   }
-  agentRunStore.closeRun(runId);
+  agentRunStore.closeRun(runId, finalStatus);
   resetChromeSnapshotState();
   // run 结束（或异常）默认关闭本次 run 期间打开的 Chrome tab，避免长期跑下来 tab 堆积；
   // 设 CHROME_MCP_KEEP_TABS=true 跳过（适合调试或想保留页面看结果的场景）。

--- a/helpers/run-store.ts
+++ b/helpers/run-store.ts
@@ -12,10 +12,21 @@
  * 生命周期：
  *   createRun (running)
  *     → addEvent × N（每个 SSE 事件追加到 events 数组）
- *     → cancelRun（可选，用户中途取消）
- *     → closeRun (done)
+ *     → cancelRun（可选，running → cancelling）
+ *     → closeRun（completed / failed / cancelled）
  *     → 5 分钟后自动从内存中删除（给 SSE 重连留窗口）
  */
+
+import {
+  ACTIVE_RUN_STATUSES,
+  RUN_STATUS_TRANSITIONS,
+  type AgentEvent,
+  type AgentRunStore,
+  type RunMeta,
+  type RunRecord,
+  type RunStatus,
+  type TerminalRunStatus,
+} from '../agent/core/contracts.ts';
 
 function createRunId() {
   return `run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
@@ -24,12 +35,22 @@ function createRunId() {
 /** 运行结束后保留在内存中的时长，超时自动清理 */
 const RUN_TTL_MS = 5 * 60 * 1000;
 
-export function createAgentRunStore() {
-  /** @type {Map<string, RunRecord>} runId → 运行记录 */
-  const runs = new Map();
+export function createAgentRunStore(): AgentRunStore {
+  const runs = new Map<string, RunRecord>();
 
-  function getRun(runId) {
+  function getRun(runId: string): RunRecord | null {
     return runs.get(runId) || null;
+  }
+
+  function transitionRun(runId: string, nextStatus: RunStatus): RunRecord | null {
+    const run = getRun(runId);
+    if (!run || run.status === nextStatus) return run;
+    const allowed = RUN_STATUS_TRANSITIONS[run.status];
+    if (!allowed.has(nextStatus)) {
+      throw new Error(`非法 Run 状态迁移: ${run.status} -> ${nextStatus} (${runId})`);
+    }
+    run.status = nextStatus;
+    return run;
   }
 
   return {
@@ -37,14 +58,16 @@ export function createAgentRunStore() {
      * 创建新的运行记录
      * 调用时机：POST /api/agent 收到任务后立即创建
      */
-    createRun(meta = {}, startedAt = Date.now(), existingRunId) {
+    createRun(meta: RunMeta = {}, startedAt = Date.now(), existingRunId?: string) {
       const runId = existingRunId || createRunId();
+      const existing = runs.get(runId);
+      if (existing?.cleanupTimer) clearTimeout(existing.cleanupTimer);
       const record = {
         runId,
         startedAt,
         cancelAc: new AbortController(),
         events: [],
-        status: 'running',
+        status: 'running' as const,
         meta,
       };
       runs.set(runId, record);
@@ -54,12 +77,12 @@ export function createAgentRunStore() {
     getRun,
 
     /**
-     * 获取当前正在运行的 Agent（最多一个）
+     * 获取当前占用运行锁的 Agent（包括 waiting_approval / cancelling）
      * 调用时机：GET /api/agent/active 前端刷新后检测是否有进行中的任务
      */
     getActiveRun() {
       for (const run of runs.values()) {
-        if (run.status === 'running' && !run.cancelAc.signal.aborted) {
+        if (ACTIVE_RUN_STATUSES.has(run.status)) {
           return run;
         }
       }
@@ -67,18 +90,18 @@ export function createAgentRunStore() {
     },
 
     getActiveRuns() {
-      return Array.from(runs.values()).filter(run => run.status === 'running' && !run.cancelAc.signal.aborted);
+      return Array.from(runs.values()).filter(run => ACTIVE_RUN_STATUSES.has(run.status));
     },
 
     getRunningRuns() {
-      return Array.from(runs.values()).filter(run => run.status === 'running');
+      return Array.from(runs.values()).filter(run => ACTIVE_RUN_STATUSES.has(run.status));
     },
 
     /**
      * 追加 SSE 事件到运行记录
      * 调用时机：每次 sendEvent 都会同时 addEvent，用于 SSE 重连时回放
      */
-    addEvent(runId, event) {
+    addEvent(runId: string, event: AgentEvent) {
       const run = getRun(runId);
       if (run) {
         run.events.push(event);
@@ -90,24 +113,33 @@ export function createAgentRunStore() {
      * 调用时机：POST /api/agent/cancel 用户主动取消任务
      * runtime 循环中通过 isCancelled() 检测并抛出异常退出
      */
-    cancelRun(runId) {
+    transitionRun,
+
+    cancelRun(runId: string) {
       const run = getRun(runId);
-      if (!run) return;
+      if (!run || !ACTIVE_RUN_STATUSES.has(run.status)) return run;
+      transitionRun(runId, 'cancelling');
       run.cancelAc.abort();
+      return run;
     },
 
     /**
      * 关闭运行（完成或出错后调用）
      * 调用时机：POST /api/agent 的 finally 块
-     * 清理重连写入器，标记 status='done'，
+     * 清理重连写入器，迁移到终态，
      * 然后启动 5 分钟倒计时自动删除该记录
      */
-    closeRun(runId) {
+    closeRun(runId: string, outcome?: TerminalRunStatus) {
       const run = getRun(runId);
-      if (!run) return;
+      if (!run) return null;
+      if (!ACTIVE_RUN_STATUSES.has(run.status)) return run;
       run._reconnectWriters = null;
-      run.status = 'done';
-      setTimeout(() => runs.delete(runId), RUN_TTL_MS);
+      const terminalStatus = outcome || (run.status === 'cancelling' ? 'cancelled' : 'completed');
+      transitionRun(runId, terminalStatus);
+      run.cleanupTimer = setTimeout(() => {
+        if (runs.get(runId) === run) runs.delete(runId);
+      }, RUN_TTL_MS);
+      return run;
     },
   };
 }

--- a/routes/agent-checkpoints.ts
+++ b/routes/agent-checkpoints.ts
@@ -12,7 +12,7 @@ export function createAgentCheckpointRouter({ checkpointDir, agentRunStore, memo
     if (!checkpointDir) {
       return res.json({ checkpoints: [] });
     }
-    const queryRunId = req.query.runId;
+    const queryRunId = typeof req.query.runId === 'string' ? req.query.runId : null;
     const activeRun = agentRunStore.getActiveRun();
     const runId = queryRunId || activeRun?.runId;
     if (!runId) {

--- a/routes/agent-run-control.ts
+++ b/routes/agent-run-control.ts
@@ -4,14 +4,13 @@ import { removeCheckpoint, removeSessionCheckpoints } from '../agent/core/checkp
 import { readTraceEvents } from '../helpers/trace-store.ts';
 import { log } from '../helpers/logger.ts';
 import { tReq } from '../helpers/i18n.ts';
+import { ACTIVE_RUN_STATUSES, type AgentEvent, type ApprovalStore } from '../agent/core/contracts.ts';
 
-function pendingApprovalState(approvalStore: any, runId: string) {
-  const pending = typeof approvalStore.listPendingForRun === 'function'
-    ? approvalStore.listPendingForRun(runId)
-    : [];
+function pendingApprovalState(approvalStore: ApprovalStore, runId: string) {
+  const pending = approvalStore.listPendingForRun(runId);
   return {
-    pendingApproval: pending.find((item: any) => item.type === 'approval_required') || null,
-    pendingQuestion: pending.find((item: any) => item.type === 'question_required') || null,
+    pendingApproval: pending.find(item => item.type === 'approval_required') || null,
+    pendingQuestion: pending.find(item => item.type === 'question_required') || null,
     pendingEvents: pending,
   };
 }
@@ -104,8 +103,8 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
     }
 
     let writer = null;
-    if (run.status === 'running' && !run.cancelAc.signal.aborted) {
-      writer = (payload: any) => {
+    if (ACTIVE_RUN_STATUSES.has(run.status)) {
+      writer = (payload: AgentEvent) => {
         if (!res.writableEnded) {
           res.write(`data: ${JSON.stringify(payload)}\n\n`);
         }
@@ -115,7 +114,7 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
 
       req.on('close', () => {
         if (run._reconnectWriters) {
-          run._reconnectWriters = run._reconnectWriters.filter((reconnectWriter: any) => reconnectWriter !== writer);
+          run._reconnectWriters = run._reconnectWriters.filter(reconnectWriter => reconnectWriter !== writer);
         }
       });
     }
@@ -126,7 +125,7 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
       res.write(`data: ${JSON.stringify(event)}\n\n`);
     }
 
-    if (run.status !== 'running' || run.cancelAc.signal.aborted) {
+    if (!ACTIVE_RUN_STATUSES.has(run.status)) {
       res.end();
     }
     return;

--- a/routes/agent-run-execution.ts
+++ b/routes/agent-run-execution.ts
@@ -1,6 +1,19 @@
 import { loadLatestHealthySnapshot } from '../agent/core/checkpoint.ts';
 import { cleanupAgentRun } from '../helpers/run-agent.ts';
 import { log } from '../helpers/logger.ts';
+import type {
+  AgentRunStore,
+  AgentStep,
+  DesktopAgentResult,
+  DesktopAgentRunner,
+  RunRecord,
+  TerminalRunStatus,
+} from '../agent/core/contracts.ts';
+import type { AgentRunSession } from './agent-run-session.ts';
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
 
 async function buildRollbackSuggestion({
   checkpointDir,
@@ -57,7 +70,7 @@ export async function executeAgentRun({
   projectRoot,
   dataDir,
 }: {
-  runDesktopAgent: any;
+  runDesktopAgent: DesktopAgentRunner;
   task: string;
   model: string;
   models: string[];
@@ -65,21 +78,22 @@ export async function executeAgentRun({
   systemPrompt: string;
   headless: boolean;
   runId: string;
-  runRecord: any;
-  session: any;
+  runRecord: RunRecord;
+  session: AgentRunSession;
   cancelSignal: AbortSignal;
-  conversationHistory: any;
+  conversationHistory: Array<{ role: string; content: string }> | unknown;
   useMemory: boolean;
-  checkpointInitialStep: any;
-  checkpointInitialHistory: any;
+  checkpointInitialStep?: number;
+  checkpointInitialHistory?: AgentStep[];
   checkpointDir: string;
-  agentRunStore: any;
+  agentRunStore: AgentRunStore;
   projectRoot?: string;
   dataDir?: string;
 }) {
   let finalAnswer: string | null = null;
-  let agentError: any = null;
-  let agentResult = null;
+  let agentError: Error | null = null;
+  let agentResult: DesktopAgentResult | null = null;
+  let finalStatus: TerminalRunStatus = 'completed';
 
   try {
     agentResult = await runDesktopAgent({
@@ -118,9 +132,11 @@ export async function executeAgentRun({
         quality: agentResult.quality,
       },
     });
-  } catch (err: any) {
+  } catch (value: unknown) {
+    const err = asError(value);
     agentError = err;
-    log.error('Desktop agent error:', err?.message || err);
+    finalStatus = err.message === 'Agent 已取消' ? 'cancelled' : 'failed';
+    log.error('Desktop agent error:', err.message);
     const { completedStepCount, observedStepCount } = session.getTrackingState();
     const rollbackSuggestion = await buildRollbackSuggestion({
       checkpointDir,
@@ -135,7 +151,7 @@ export async function executeAgentRun({
       rollbackSuggestion,
     });
   } finally {
-    await cleanupAgentRun(checkpointDir, runId, agentRunStore);
+    await cleanupAgentRun(checkpointDir, runId, agentRunStore, { finalStatus });
   }
 
   return { agentResult, finalAnswer, agentError };

--- a/routes/agent-run-session.ts
+++ b/routes/agent-run-session.ts
@@ -3,6 +3,22 @@ import { formatLogTime, buildAgentMetrics, buildSseWriter, logAgentEvent } from 
 import { createBaseEventSender } from '../helpers/run-agent.ts';
 import { log } from '../helpers/logger.ts';
 import { tReq } from '../helpers/i18n.ts';
+import type { Request, Response } from 'express';
+import type { AgentEvent, AgentRunStore, ApprovalStore } from '../agent/core/contracts.ts';
+
+export interface AgentRunTrackingState {
+  completedStepCount: number;
+  observedStepCount: number;
+  modelsUsed: string[];
+  modelUsage: Record<string, number>;
+  stepModels: Record<number, string>;
+}
+
+export interface AgentRunSession {
+  sendEvent(payload: AgentEvent): void;
+  getTrackingState(): AgentRunTrackingState;
+  close(args: { finalAnswer: string | null; agentError: Error | null; approvalStore: ApprovalStore }): void;
+}
 
 export function createAgentRunSession({
   req,
@@ -15,19 +31,19 @@ export function createAgentRunSession({
   agentRunStore,
   memoryDir,
 }: {
-  req: any;
-  res: any;
+  req: Request;
+  res: Response;
   model: string;
   agentHeadless: boolean;
   normalizedTask: string;
   runId: string;
   startedAt: number;
-  agentRunStore: any;
+  agentRunStore: AgentRunStore;
   memoryDir?: string;
 }) {
   let completedStepCount = 0;
   let observedStepCount = 0;
-  const modelsUsed = new Set();
+  const modelsUsed = new Set<string>();
   const modelUsageCounts = new Map<string, number>();
   const stepModels: Record<number, string> = {};
   let sseClosed = false;
@@ -57,7 +73,7 @@ export function createAgentRunSession({
 
   const rawSendEvent = buildSseWriter(res);
   const baseSendEvent = createBaseEventSender(runId, agentRunStore, memoryDir);
-  const sendEvent = (payload: any) => {
+  const sendEvent = (payload: AgentEvent) => {
     if (payload.type === 'step') {
       observedStepCount = Math.max(observedStepCount, payload.step || 0);
       if (payload.stage === 'result') {
@@ -88,7 +104,7 @@ export function createAgentRunSession({
   });
   log.debug(`[SSE] stream started, writableEnded=${res.writableEnded} writableFinished=${res.writableFinished}`);
 
-  function getTrackingState() {
+  function getTrackingState(): AgentRunTrackingState {
     return {
       completedStepCount,
       observedStepCount,
@@ -98,7 +114,7 @@ export function createAgentRunSession({
     };
   }
 
-  function close({ finalAnswer, agentError, approvalStore }: { finalAnswer: string | null; agentError: any; approvalStore: any }) {
+  function close({ finalAnswer, agentError, approvalStore }: { finalAnswer: string | null; agentError: Error | null; approvalStore: ApprovalStore }) {
     const status = agentError
       ? agentError.message === 'Agent 已取消'
         ? 'cancelled'
@@ -145,5 +161,5 @@ export function createAgentRunSession({
     sseClosed = true;
   }
 
-  return { sendEvent, getTrackingState, close };
+  return { sendEvent, getTrackingState, close } satisfies AgentRunSession;
 }

--- a/routes/agent-run-start.ts
+++ b/routes/agent-run-start.ts
@@ -8,7 +8,7 @@ import { createAgentRunSession } from './agent-run-session.ts';
 import { parseAgentRunRequest, resolveCheckpointSeed } from './agent-run-request.ts';
 import { executeAgentRun } from './agent-run-execution.ts';
 import { removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
-import { resolveRunPaths } from '../agent/core/project-store.ts';
+import { resolveRunPathsForExecution } from '../agent/core/project-store.ts';
 
 export function createAgentRunStartRouter({
   runDesktopAgent,
@@ -39,7 +39,7 @@ export function createAgentRunStartRouter({
       }
 
       // 解析本次 run 的落盘目录与文件工具根：命中项目用项目目录，否则回退全局（无项目态）。
-      const { projectId: resolvedProjectId, projectRoot, dataDir } = resolveRunPaths(projectStore, projectId, memoryDir);
+      const { projectId: resolvedProjectId, projectRoot, dataDir } = await resolveRunPathsForExecution(projectStore, projectId, memoryDir);
       runCheckpointDir = dataDir;
 
       const { checkpointInitialStep, checkpointInitialHistory } = await resolveCheckpointSeed(runCheckpointDir, fromCheckpoint);
@@ -147,7 +147,8 @@ export function createAgentRunStartRouter({
         return;
       }
       if (!res.headersSent) {
-        return res.status(500).json({ error: message });
+        const status = Number(err?.status) || 500;
+        return res.status(status).json({ error: message, ...(err?.code ? { code: err.code } : {}) });
       }
       try { res.end(); } catch {}
     }

--- a/routes/agent-types.ts
+++ b/routes/agent-types.ts
@@ -1,15 +1,22 @@
 import type { ProviderRegistry } from '../agent/core/providers/registry.ts';
+import type { ModelInfo } from '../agent/core/providers/types.ts';
 import type { RuntimeConfigStore } from '../agent/core/runtime-config.ts';
 import type { ProjectStore } from '../agent/core/project-store.ts';
+import type {
+  AgentRunStore,
+  ApprovalStore,
+  DesktopAgentRunner,
+  DomainRules,
+} from '../agent/core/contracts.ts';
 
 export interface AgentRouterContext {
-  runDesktopAgent: any;
-  agentRunStore: any;
-  approvalStore: any;
+  runDesktopAgent: DesktopAgentRunner;
+  agentRunStore: AgentRunStore;
+  approvalStore: ApprovalStore;
   memoryDir: string;
   checkpointDir: string;
-  domainRules: any;
-  modelConfig: any[];
+  domainRules?: DomainRules;
+  modelConfig: ModelInfo[];
   registry: ProviderRegistry;
   runtimeConfig: RuntimeConfigStore;
   projectStore: ProjectStore;

--- a/server.ts
+++ b/server.ts
@@ -112,6 +112,7 @@ const runDesktopAgent = AGENT_SANDBOXED_WORKERS
       checkpointDir: CHECKPOINT_DIR,
       modelConfig,
       approvalStore,
+      runStore: agentRunStore,
       visionModel: VISION_MODEL,
       sandbox: AGENT_WORKER_SANDBOX,
     }) as any

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -54,7 +54,7 @@ beforeEach(async () => {
     memoryDir: tmpDir,
     checkpointDir: tmpDir,
     domainRules: null,
-    modelConfig: [{ id: 'test-model', provider: 'test' }],
+    modelConfig: [{ id: 'test-model', label: 'test-model', provider: 'test' }],
     registry: mockRegistry,
     runtimeConfig,
     projectStore,

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -32,6 +32,7 @@ let tmpDir;
 let app;
 let agentRunStore;
 let approvalStore;
+let projectStore;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-api-test-'));
@@ -44,7 +45,7 @@ beforeEach(async () => {
   agentRunStore = createAgentRunStore();
   approvalStore = createApprovalStore();
   // 空注册表 → resolveRunPaths 回退到 tmpDir/process.cwd()，与无项目态一致。
-  const projectStore = createProjectStore(tmpDir);
+  projectStore = createProjectStore(tmpDir);
   await projectStore.init();
 
   const router = createAgentRouter({
@@ -172,6 +173,21 @@ describe('POST /api/agent', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('模型');
+  });
+
+  it('returns a clear validation error when the selected project directory was moved', async () => {
+    const projectRoot = path.join(tmpDir, 'movable-project');
+    await fs.mkdir(projectRoot);
+    const project = await projectStore.create({ name: 'movable', rootPath: projectRoot });
+    await fs.rm(projectRoot, { recursive: true, force: true });
+
+    const res = await request(app)
+      .post('/api/agent')
+      .send({ task: 'inspect project', model: 'test-model', memory: false, projectId: project.projectId });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('PROJECT_ROOT_UNAVAILABLE');
+    expect(res.body.error).toContain('项目根目录不存在或已移动');
   });
 
   it('returns JSON errors for startup failures before the SSE stream opens', async () => {

--- a/test/approval-store.test.ts
+++ b/test/approval-store.test.ts
@@ -4,7 +4,12 @@ import { createApprovalStore } from '../agent/core/approval-store.ts';
 describe('approval store', () => {
   it('can register a caller-provided approval id for worker bridges', async () => {
     const store = createApprovalStore();
-    const { approvalId, promise } = store.request({ step: 1 }, 'worker_approval_1');
+    const { approvalId, promise } = store.request({
+      type: 'approval_required',
+      runId: 'run_worker_1',
+      step: 1,
+      action: { tool: 'terminal', type: 'run_confirmed', command: 'npm test', cwd: '', timeoutMs: 12000 },
+    }, 'worker_approval_1');
 
     expect(approvalId).toBe('worker_approval_1');
     store.resolve('worker_approval_1', 'approve');
@@ -13,9 +18,14 @@ describe('approval store', () => {
 
   it('rejects duplicate caller-provided approval ids', () => {
     const store = createApprovalStore();
-    store.request({}, 'worker_approval_dup');
+    const payload = {
+      type: 'approval_required' as const,
+      runId: 'run_worker_dup',
+      action: { tool: 'terminal' as const, type: 'run_confirmed' as const, command: 'npm test', cwd: '', timeoutMs: 12000 },
+    };
+    store.request(payload, 'worker_approval_dup');
 
-    expect(() => store.request({}, 'worker_approval_dup')).toThrow('审批已存在');
+    expect(() => store.request(payload, 'worker_approval_dup')).toThrow('审批已存在');
   });
 
   it('lists pending approvals for an active run', () => {
@@ -24,14 +34,14 @@ describe('approval store', () => {
       type: 'approval_required',
       runId: 'run_abc_123',
       step: 2,
-      action: { tool: 'terminal', type: 'run', command: 'npm test' },
+      action: { tool: 'terminal', type: 'run_confirmed', command: 'npm test', cwd: '', timeoutMs: 12000 },
       message: '需要确认',
     }, 'approval_pending_1');
     store.request({
       type: 'approval_required',
       runId: 'run_other_456',
       step: 1,
-      action: { tool: 'fs', type: 'write_file' },
+      action: { tool: 'fs', type: 'write_file', path: 'out.txt', content: 'x', append: false },
       message: 'other',
     }, 'approval_pending_2');
 
@@ -41,7 +51,7 @@ describe('approval store', () => {
         runId: 'run_abc_123',
         approvalId: 'approval_pending_1',
         step: 2,
-        action: { tool: 'terminal', type: 'run', command: 'npm test' },
+        action: { tool: 'terminal', type: 'run_confirmed', command: 'npm test', cwd: '', timeoutMs: 12000 },
         message: '需要确认',
       },
     ]);

--- a/test/chrome-tools.test.ts
+++ b/test/chrome-tools.test.ts
@@ -83,6 +83,7 @@ describe('Chrome MCP action normalization', () => {
     });
 
     expect(result.action.type).toBe('chrome_call_tool');
+    if (result.action.type !== 'chrome_call_tool') throw new Error('expected chrome_call_tool');
     expect(result.action.toolName).toBe('click');
   });
 });

--- a/test/project-store.test.ts
+++ b/test/project-store.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createProjectStore,
+  resolveRunPathsForExecution,
+} from '../agent/core/project-store.ts';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-project-store-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('project root validation', () => {
+  it('stores the canonical directory path', async () => {
+    const memoryDir = path.join(tmpDir, 'data');
+    const actualRoot = path.join(tmpDir, 'actual-project');
+    const linkedRoot = path.join(tmpDir, 'linked-project');
+    await fs.mkdir(actualRoot);
+    await fs.symlink(actualRoot, linkedRoot);
+    const store = createProjectStore(memoryDir);
+    await store.init();
+
+    const project = await store.create({ name: 'linked', rootPath: linkedRoot });
+
+    expect(project.rootPath).toBe(await fs.realpath(actualRoot));
+  });
+
+  it('rejects missing paths and regular files', async () => {
+    const store = createProjectStore(path.join(tmpDir, 'data'));
+    await store.init();
+    const missing = path.join(tmpDir, 'missing');
+    const file = path.join(tmpDir, 'file.txt');
+    await fs.writeFile(file, 'not a directory');
+
+    await expect(store.create({ name: 'missing', rootPath: missing }))
+      .rejects.toThrow('项目根目录不存在或已移动');
+    await expect(store.create({ name: 'file', rootPath: file }))
+      .rejects.toThrow('项目根路径不是目录');
+  });
+
+  it('rejects execution after a registered project directory is removed', async () => {
+    const memoryDir = path.join(tmpDir, 'data');
+    const root = path.join(tmpDir, 'project');
+    await fs.mkdir(root);
+    const store = createProjectStore(memoryDir);
+    await store.init();
+    const project = await store.create({ name: 'project', rootPath: root });
+    await fs.rm(root, { recursive: true, force: true });
+
+    await expect(resolveRunPathsForExecution(store, project.projectId, memoryDir))
+      .rejects.toThrow('项目根目录不存在或已移动');
+    await expect(store.update(project.projectId, { name: 'renamed' }))
+      .rejects.toThrow('项目根目录不存在或已移动');
+    await expect(store.setActive(project.projectId))
+      .rejects.toThrow('项目根目录不存在或已移动');
+  });
+});

--- a/test/result-quality.test.ts
+++ b/test/result-quality.test.ts
@@ -8,11 +8,13 @@ describe('result quality assessment', () => {
       steps: [
         {
           step: 1,
-          action: { tool: 'browser', type: 'http_fetch', url: 'https://example.com' },
+          rationale: 'fetch',
+          action: { tool: 'browser', type: 'http_fetch', url: 'https://example.com', extractLinks: false },
           result: '您的请求已中断 Web应用防护服务检测您当前访问存在Web安全风险',
         },
         {
           step: 2,
+          rationale: 'read',
           action: { tool: 'browser', type: 'get_page_content' },
           result: '百度安全验证 请完成下方验证后继续操作 拖动左侧滑块使图片为正',
         },
@@ -30,13 +32,15 @@ describe('result quality assessment', () => {
       steps: [
         {
           step: 1,
-          action: { tool: 'fs', type: 'search_files' },
+          rationale: 'search',
+          action: { tool: 'fs', type: 'search_files', query: 'error', path: '.', include: '*', maxResults: 20 },
           result: '未找到明显问题',
           resultStatus: 'success',
         },
         {
           step: 2,
-          action: { tool: 'terminal', type: 'run_safe' },
+          rationale: 'run',
+          action: { tool: 'terminal', type: 'run_safe', command: 'pwd', cwd: '', timeoutMs: 8000 },
           result: 'command exited without details',
           resultStatus: 'failed',
           resultError: 'exit code 1',
@@ -55,11 +59,13 @@ describe('result quality assessment', () => {
       steps: [
         {
           step: 1,
+          rationale: 'navigate',
           action: {
             tool: 'chrome',
             type: 'chrome_call_tool',
             toolName: 'navigate_page',
             arguments: { url: 'https://www.gov.cn/zhengce/example.html' },
+            refreshTools: false,
           },
           result: '这里是政策正文，包含足够多的可用内容用于判断来源有效。这里继续补充政策适用范围、办理条件、材料要求、办理流程、办理时限、责任部门和注意事项，确保内容长度超过最低可用阈值。',
         },

--- a/test/run-store.test.ts
+++ b/test/run-store.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createAgentRunStore } from '../helpers/run-store.ts';
 
 describe('agent run store', () => {
-  it('lists only active non-cancelled runs', () => {
+  it('keeps cancelling runs active until cleanup finishes', () => {
     const store = createAgentRunStore();
     const runA = store.createRun({}, 1, 'run_a');
     const runB = store.createRun({}, 2, 'run_b');
@@ -11,8 +11,35 @@ describe('agent run store', () => {
     store.cancelRun(runB.runId);
     store.closeRun(runC.runId);
 
-    expect(store.getActiveRuns().map((run: any) => run.runId)).toEqual([runA.runId]);
+    expect(runB.status).toBe('cancelling');
+    expect(store.getActiveRuns().map(run => run.runId)).toEqual([runA.runId, runB.runId]);
     expect(store.getActiveRun()?.runId).toBe(runA.runId);
-    expect(store.getRunningRuns().map((run: any) => run.runId)).toEqual([runA.runId, runB.runId]);
+    expect(store.getRunningRuns().map(run => run.runId)).toEqual([runA.runId, runB.runId]);
+
+    store.closeRun(runB.runId);
+    expect(runB.status).toBe('cancelled');
+    expect(store.getActiveRuns().map(run => run.runId)).toEqual([runA.runId]);
+  });
+
+  it('supports explicit approval waiting transitions', () => {
+    const store = createAgentRunStore();
+    const run = store.createRun({}, 1, 'run_waiting');
+
+    store.transitionRun(run.runId, 'waiting_approval');
+    expect(run.status).toBe('waiting_approval');
+    expect(store.getActiveRun()).toBe(run);
+
+    store.transitionRun(run.runId, 'running');
+    store.closeRun(run.runId, 'completed');
+    expect(run.status).toBe('completed');
+    expect(store.getActiveRun()).toBeNull();
+  });
+
+  it('rejects invalid state transitions', () => {
+    const store = createAgentRunStore();
+    const run = store.createRun({}, 1, 'run_invalid');
+    store.closeRun(run.runId, 'completed');
+
+    expect(() => store.transitionRun(run.runId, 'running')).toThrow('非法 Run 状态迁移');
   });
 });

--- a/test/session-checkpoint.test.ts
+++ b/test/session-checkpoint.test.ts
@@ -9,6 +9,8 @@ import {
   KEEP_HEALTHY,
 } from '../agent/core/checkpoint.ts';
 import { runAgentRuntime } from '../agent/core/runtime.ts';
+import { normalizeDesktopAgentDecision } from '../agent/core/schemas.ts';
+import type { AgentStep } from '../agent/core/contracts.ts';
 
 let tmpDir;
 
@@ -20,11 +22,11 @@ afterEach(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
-function makeHistory(steps) {
+function makeHistory(steps: number[]): AgentStep[] {
   return steps.map(s => ({
     step: s,
     rationale: `step ${s} rationale`,
-    action: { type: 'click', elementId: `el-${s}` },
+    action: { tool: 'browser', type: 'click', elementId: `el-${s}` },
     result: `step ${s} result`,
   }));
 }
@@ -132,6 +134,11 @@ describe('listSessionCheckpoints', () => {
 // ─── runtime integration tests ───
 
 function noop() {}
+const initialize = () => ({});
+const observe = () => ({});
+const approve = () => ({ status: 'approved' as const });
+const decision = (action: Record<string, unknown>, rationale = '') =>
+  normalizeDesktopAgentDecision({ action, rationale });
 const events = () => {
   const log = [];
   return { log, onEvent: e => log.push(e) };
@@ -145,15 +152,12 @@ describe('runtime: session checkpoint integration', () => {
       maxSteps: 2,
       onEvent: noop,
       cancelSignal,
-      initialize: noop,
+      initialize,
       observe: () => ({ url: 'https://previous.example/', title: 'Previous' }),
       decide: ({ step }) => step === 1
-        ? {
-            action: { tool: 'browser', type: 'http_fetch', url: 'https://target.example/page' },
-            rationale: 'fetch target',
-          }
-        : { action: { type: 'finish', answer: 'done' }, rationale: 'done' },
-      authorize: noop,
+        ? decision({ tool: 'browser', type: 'http_fetch', url: 'https://target.example/page' }, 'fetch target')
+        : decision({ type: 'finish', answer: 'done' }, 'done'),
+      authorize: approve,
       execute: () => 'target content',
       cleanup: noop,
     });
@@ -170,12 +174,12 @@ describe('runtime: session checkpoint integration', () => {
       maxSteps: 2,
       onEvent,
       cancelSignal,
-      initialize: noop,
-      observe: noop,
+      initialize,
+      observe,
       decide: ({ step }) => step === 1
-        ? { action: { tool: 'terminal', type: 'run_safe', command: 'bad' }, rationale: 'run' }
-        : { action: { type: 'finish', answer: 'done' }, rationale: 'finish' },
-      authorize: noop,
+        ? decision({ tool: 'terminal', type: 'run_safe', command: 'bad' }, 'run')
+        : decision({ type: 'finish', answer: 'done' }, 'finish'),
+      authorize: approve,
       execute: (_state, action) => {
         if (action.type === 'finish') return action.answer;
         throw new Error('exit code 1');
@@ -204,13 +208,10 @@ describe('runtime: session checkpoint integration', () => {
       maxSteps: 6,
       onEvent,
       cancelSignal,
-      initialize: noop,
-      observe: noop,
-      decide: () => ({
-        action: { tool: 'fs', type: 'read_file', path: 'word/document.xml', maxBytes: 12000 },
-        rationale: 'read template',
-      }),
-      authorize: () => ({ status: 'approved' }),
+      initialize,
+      observe,
+      decide: () => decision({ tool: 'fs', type: 'read_file', path: 'word/document.xml', maxBytes: 12000 }, 'read template'),
+      authorize: approve,
       execute: () => {
         executeCalls += 1;
         return 'same file content';
@@ -234,13 +235,10 @@ describe('runtime: session checkpoint integration', () => {
       maxSteps: 4,
       onEvent,
       cancelSignal,
-      initialize: noop,
-      observe: noop,
-      decide: () => ({
-        action: { tool: 'search', type: 'web_search', query: '2026年7月3日 A股收盘行情' },
-        rationale: 'search',
-      }),
-      authorize: () => ({ status: 'approved' }),
+      initialize,
+      observe,
+      decide: () => decision({ tool: 'search', type: 'web_search', query: '2026年7月3日 A股收盘行情' }, 'search'),
+      authorize: approve,
       execute: () => {
         executeCalls += 1;
         return {
@@ -272,16 +270,16 @@ describe('runtime: session checkpoint integration', () => {
       cancelSignal,
       sessionCheckpointDir: tmpDir,
       runRecord,
-      initialize: noop,
-      observe: noop,
+      initialize,
+      observe,
       decide: () => {
         stepCount++;
         if (stepCount >= 7) {
-          return { action: { type: 'finish', answer: 'all done' }, rationale: 'enough' };
+          return decision({ type: 'finish', answer: 'all done' }, 'enough');
         }
-        return { action: { type: 'click', elementId: 'btn' }, rationale: 'go' };
+        return decision({ type: 'click', elementId: 'btn' }, 'go');
       },
-      authorize: noop,
+      authorize: approve,
       execute: () => 'executed',
       cleanup: noop,
     });
@@ -313,13 +311,13 @@ describe('runtime: session checkpoint integration', () => {
       initialize: () => ({
         runId,
         onEvent: noop,
-        browserSession: { view: { circular: true } },
+        browserSession: { view: { navigate: async () => {}, circular: true } },
         observeDesktop: true,
         keep: 'ok',
       }),
-      observe: noop,
-      decide: () => ({ action: { type: 'finish', answer: 'done' }, rationale: 'ok' }),
-      authorize: noop,
+      observe,
+      decide: () => decision({ type: 'finish', answer: 'done' }, 'ok'),
+      authorize: approve,
       execute: () => 'done',
       cleanup: noop,
     });
@@ -344,16 +342,16 @@ describe('runtime: session checkpoint integration', () => {
       cancelSignal,
       sessionCheckpointDir: tmpDir,
       runRecord: { runId, pendingRollback: null },
-      initialize: noop,
-      observe: noop,
+      initialize,
+      observe,
       decide: () => {
         stepCount++;
         if (stepCount >= 7) {
-          return { action: { type: 'finish', answer: 'done' }, rationale: 'enough' };
+          return decision({ type: 'finish', answer: 'done' }, 'enough');
         }
-        return { action: { type: 'click', elementId: 'btn' }, rationale: 'go' };
+        return decision({ type: 'click', elementId: 'btn' }, 'go');
       },
-      authorize: noop,
+      authorize: approve,
       execute: () => 'executed',
       cleanup: noop,
     });
@@ -384,16 +382,16 @@ describe('runtime: session checkpoint integration', () => {
       runRecord: runRecord2,
       initialStep: 1,
       initialHistory: makeHistory([1, 2, 3, 4]),
-      initialize: noop,
-      observe: noop,
+      initialize,
+      observe,
       decide: () => {
         stepCount++;
         if (stepCount >= 3) {
-          return { action: { type: 'finish', answer: 'rolled back' }, rationale: 'done' };
+          return decision({ type: 'finish', answer: 'rolled back' }, 'done');
         }
-        return { action: { type: 'click', elementId: 'btn' }, rationale: 'retry' };
+        return decision({ type: 'click', elementId: 'btn' }, 'retry');
       },
-      authorize: noop,
+      authorize: approve,
       execute: () => 'executed',
       cleanup: noop,
     });
@@ -419,10 +417,10 @@ describe('runtime: session checkpoint integration', () => {
       cancelSignal,
       sessionCheckpointDir: tmpDir,
       runRecord,
-      initialize: noop,
-      observe: noop,
-      decide: () => ({ action: { type: 'finish', answer: 'done' }, rationale: 'ok' }),
-      authorize: noop,
+      initialize,
+      observe,
+      decide: () => decision({ type: 'finish', answer: 'done' }, 'ok'),
+      authorize: approve,
       execute: noop,
       cleanup: noop,
     });

--- a/test/spawn-tool.test.ts
+++ b/test/spawn-tool.test.ts
@@ -46,6 +46,7 @@ describe('Spawn action normalization', () => {
       },
     });
 
+    if (result.action.type !== 'spawn') throw new Error('expected spawn action');
     expect(result.action.tasks).toEqual(['task1', 'task2', 'task3']);
   });
 
@@ -57,6 +58,7 @@ describe('Spawn action normalization', () => {
       },
     });
 
+    if (result.action.type !== 'spawn') throw new Error('expected spawn action');
     expect(result.action.tasks).toHaveLength(5);
     expect(result.action.tasks).toEqual(['t1', 't2', 't3', 't4', 't5']);
   });


### PR DESCRIPTION
## Summary
- add typed discriminated unions for agent actions, events, decisions, steps, approvals, runners, and run records
- introduce an explicit run lifecycle state machine, including approval waiting and cancellation states
- keep cancelling runs active until cleanup completes and protect reused run IDs from stale cleanup timers
- validate project roots during create, update, activation, and agent startup
- return a clear PROJECT_ROOT_UNAVAILABLE error before spawning workers when a project directory was moved or deleted
- add and update backend TODO items and regression coverage

## Verification
- npm run typecheck
- npm run lint
- npm test (37 files, 205 tests)
- git diff --check