### PR TITLE
fix: harden backend P0 security boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,12 @@ NVIDIA_API_KEY=nvapi-...
 
 # ─── Server ───────────────────────────────────────────────
 PORT=3001
-# HOST=0.0.0.0
+# 默认只监听本机。对外监听（0.0.0.0 / :: / 局域网 IP）时必须配置 SAGENT_API_TOKEN。
+# HOST=127.0.0.1
+# 建议使用 `openssl rand -hex 24` 生成；至少 16 个字符。
+SAGENT_API_TOKEN=
+# 逗号分隔的额外 Web Origin；同源请求和本机开发 Origin 会自动允许。
+# SAGENT_CORS_ORIGINS=https://sagent.example.com
 
 # ─── Models ───────────────────────────────────────────────
 # 模型列表在启动时从供应商接口（/v1/models）自动拉取，无需手动配置。

--- a/BACKEND_TODO.md
+++ b/BACKEND_TODO.md
@@ -4,9 +4,9 @@
 
 ## P0 — 安全边界
 
-- [ ] 重构 `terminal.run_safe`：改为无 shell 的命令 + 参数白名单，移除可写/可执行子命令。
-- [ ] 为局域网 API 增加认证、严格 CORS 和安全的默认监听地址。
-- [ ] 审批接口校验 `approvalId` 与 `runId` 的归属关系。
+- [x] 重构 `terminal.run_safe`：改为无 shell 的命令 + 参数白名单，移除可写/可执行子命令。
+- [x] 为局域网 API 增加认证、严格 CORS 和安全的默认监听地址。
+- [x] 审批接口校验 `approvalId` 与 `runId` 的归属关系。
 
 ## P1 — 核心正确性
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -45,7 +45,9 @@ npm run sandbox
 | 变量 | 说明 | 默认值 / 备注 |
 | --- | --- | --- |
 | `PORT` | 后端监听端口。开发模式下前端 Vite 仍是 `5173`，并代理到后端。 | `3001`；Docker 镜像内为 `5173` |
-| `HOST` | 后端监听地址。 | `0.0.0.0` |
+| `HOST` | 后端监听地址。非回环地址必须同时配置 `SAGENT_API_TOKEN`。 | `127.0.0.1`；Docker 中显式为 `0.0.0.0` |
+| `SAGENT_API_TOKEN` | `/api`、`/v1` 和 `/screenshots` 的访问令牌。可用 Bearer 或 `X-Sagent-Token` 传递。 | 本机回环监听时可为空；对外监听时至少 16 个字符 |
+| `SAGENT_CORS_ORIGINS` | 额外允许的 Web Origin，逗号分隔。无 Origin 的 CLI、精确同源和本机开发 Origin 自动允许。 | 空 |
 | `MEMORY_DIR` | 本地数据目录，保存记忆、trace、checkpoint、截图、上传文件、运行时配置。 | `data`；Docker 中为 `/app/data` |
 | `HOST_PORT` | `docker compose` 映射到宿主机的端口。 | `5173` |
 | `LOG_LEVEL` | 日志等级。 | `info`，可选 `debug` / `info` / `warn` / `error` |
@@ -204,8 +206,12 @@ bridge 自身也支持这些变量：
 
 ```bash
 cp .env.example .env
+openssl rand -hex 24
+# 把输出填入 .env 的 SAGENT_API_TOKEN=
 docker compose up --build
 ```
+
+容器内服务监听 `0.0.0.0`，因此 `SAGENT_API_TOKEN` 是必填项。浏览器首次访问受保护接口时会提示输入该 token，并在本地浏览器保存。
 
 修改宿主机端口：
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Docker builds the frontend and serves the UI/API from one Bun process. It is use
 
 ```bash
 cp .env.example .env
+openssl rand -hex 24
+# Paste the output into SAGENT_API_TOKEN= in .env.
 docker compose up --build
 ```
 
@@ -75,11 +77,20 @@ Dangerous operations such as deleting files, installing packages, or executing t
 
 ## Multi-Device View
 
-Devices on the same LAN can open `http://<Mac-IP>:5173` to watch the active Agent run in real time.
+The default dev server only listens on `127.0.0.1`. To share it on the LAN, generate a token in `.env`, then explicitly expose Vite:
+
+```bash
+openssl rand -hex 24
+# Paste the output into SAGENT_API_TOKEN= in .env.
+VITE_HOST=0.0.0.0 npm run sandbox
+```
+
+Devices on the same LAN can then open `http://<Mac-IP>:5173`. The first protected request prompts for the token. For a separately hosted frontend, list its exact origin in `SAGENT_CORS_ORIGINS`.
 
 - While an Agent run is active, secondary devices show the execution flow and receive the final result when it completes.
 - Chat history is local to each browser/device.
 - Only one Agent run can execute at a time; additional requests receive a 409 response.
+- API, OpenAI-compatible `/v1`, and screenshot routes require authentication whenever `SAGENT_API_TOKEN` is configured. Non-loopback backend listeners refuse to start without one.
 
 ## Core Workflows
 

--- a/agent/core/approval-store.ts
+++ b/agent/core/approval-store.ts
@@ -25,6 +25,28 @@ interface ApprovalRecord {
   resolve: (decision: string) => void;
 }
 
+export class ApprovalNotFoundError extends Error {
+  readonly code = 'APPROVAL_NOT_FOUND';
+
+  constructor(readonly approvalId: string) {
+    super(`审批不存在: ${approvalId}`);
+    this.name = 'ApprovalNotFoundError';
+  }
+}
+
+export class ApprovalRunMismatchError extends Error {
+  readonly code = 'APPROVAL_RUN_MISMATCH';
+
+  constructor(
+    readonly approvalId: string,
+    readonly expectedRunId: string,
+    readonly actualRunId: string,
+  ) {
+    super(`审批与运行不匹配: ${approvalId}`);
+    this.name = 'ApprovalRunMismatchError';
+  }
+}
+
 function serializeApproval(approval: ApprovalRecord) {
   return {
     ...approval.payload,
@@ -75,10 +97,13 @@ export function createApprovalStore(): ApprovalStore {
      * @param {'approve'|'reject'|string} decision
      * @returns {Object} 审批时传入的 payload
      */
-    resolve(approvalId: string, decision: string) {
+    resolve(approvalId: string, decision: string, expectedRunId: string) {
       const approval = pending.get(approvalId);
       if (!approval) {
-        throw new Error(`审批不存在: ${approvalId}`);
+        throw new ApprovalNotFoundError(approvalId);
+      }
+      if (approval.payload.runId !== expectedRunId) {
+        throw new ApprovalRunMismatchError(approvalId, expectedRunId, approval.payload.runId);
       }
       pending.delete(approvalId);
       approval.resolve(decision);

--- a/agent/core/contracts.ts
+++ b/agent/core/contracts.ts
@@ -220,7 +220,7 @@ export interface PendingApproval extends ApprovalPayload {
 
 export interface ApprovalStore {
   request(payload: ApprovalPayload, requestedApprovalId?: string): { approvalId: string; promise: Promise<string> };
-  resolve(approvalId: string, decision: string): ApprovalPayload;
+  resolve(approvalId: string, decision: string, expectedRunId: string): ApprovalPayload;
   listPendingForRun(runId: string): PendingApproval[];
   getPendingForRun(runId: string): PendingApproval | null;
   rejectAll(): void;

--- a/agent/tools/terminal/run.ts
+++ b/agent/tools/terminal/run.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
-import { SAFE_COMMANDS, getFirstToken } from './safe-policy';
+import { parseSafeCommand } from './safe-policy';
 
 type TerminalOutputEvent = {
   phase: 'start' | 'stdout' | 'stderr' | 'exit' | 'error' | 'timeout';
@@ -26,29 +26,6 @@ function resolveCwd(value, base = process.cwd()) {
   return path.isAbsolute(value) ? value : path.resolve(base, value);
 }
 
-function assertSafeCommand(command) {
-  const firstToken = getFirstToken(command);
-  if (!SAFE_COMMANDS.has(firstToken)) {
-    throw new Error(`run_safe 不允许执行该命令: ${firstToken || command}`);
-  }
-
-  // Block dangerous shell operators: pipe, semicolon, backticks, command substitution,
-  // background &, logical &&/||, process substitution, heredoc
-  if (
-    /[|;]/.test(command) ||
-    /`/.test(command) ||
-    /\$\(/.test(command) ||
-    /\$\{/.test(command) ||
-    /[^&]&[^&]/.test(command) ||
-    /\s&(\s|$)/.test(command) ||
-    /&&|\|\|/.test(command) ||
-    /[<>]\(/.test(command) ||
-    /<<\s*\w/.test(command)
-  ) {
-    throw new Error(`run_safe 不允许使用危险操作符: ${command}`);
-  }
-}
-
 function emitTerminalEvent(onOutput: TerminalActionOptions['onOutput'], event: TerminalOutputEvent) {
   if (typeof onOutput !== 'function') return;
   try {
@@ -58,7 +35,7 @@ function emitTerminalEvent(onOutput: TerminalActionOptions['onOutput'], event: T
   }
 }
 
-async function runShellCommand(command, { cwd, timeoutMs, onOutput }) {
+async function runProcess({ file, args, env = process.env, command, cwd, timeoutMs, onOutput }) {
   return new Promise((resolve, reject) => {
     const startedAt = Date.now();
     let sequence = 0;
@@ -77,8 +54,9 @@ async function runShellCommand(command, { cwd, timeoutMs, onOutput }) {
       timestamp: startedAt,
     });
 
-    const child = spawn('zsh', ['-lc', command], {
+    const child = spawn(file, args, {
       cwd,
+      env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -172,12 +150,19 @@ export async function executeTerminalAction(action, opts: TerminalActionOptions 
   }
 
   if (action.type === 'run_safe') {
-    assertSafeCommand(command);
-    return runShellCommand(command, { cwd, timeoutMs, onOutput: opts.onOutput });
+    const parsed = parseSafeCommand(command);
+    return runProcess({ ...parsed, command, cwd, timeoutMs, onOutput: opts.onOutput });
   }
 
   if (action.type === 'run_confirmed' || action.type === 'run_review') {
-    return runShellCommand(command, { cwd, timeoutMs: Math.max(timeoutMs, 12000), onOutput: opts.onOutput });
+    return runProcess({
+      file: '/bin/zsh',
+      args: ['-lc', command],
+      command,
+      cwd,
+      timeoutMs: Math.max(timeoutMs, 12000),
+      onOutput: opts.onOutput,
+    });
   }
 
   throw new Error(`不支持的终端动作: ${action.type}`);

--- a/agent/tools/terminal/safe-policy.ts
+++ b/agent/tools/terminal/safe-policy.ts
@@ -1,8 +1,17 @@
-// run_safe 终端命令策略：只读 / 低破坏命令的白名单，以及允许在命令前剥离的环境变量前缀。
-// 修改前请确认条目对应的命令在 macOS 上没有副作用、不会加载额外二进制或脚本。
+/**
+ * run_safe 安全策略。
+ *
+ * run_safe 只允许执行一个无 shell 的只读进程。这里同时负责命令行分词和参数校验；
+ * 未通过的命令会在 policy 层升级为 run_confirmed，由用户审批后才进入 zsh。
+ */
 
-export const SAFE_COMMANDS = new Set([
-  // 文件查看 / 搜索（只读）
+export interface ParsedSafeCommand {
+  file: string;
+  args: string[];
+  env?: NodeJS.ProcessEnv;
+}
+
+const SIMPLE_READ_ONLY_COMMANDS = new Set([
   'pwd',
   'ls',
   'cat',
@@ -10,40 +19,14 @@ export const SAFE_COMMANDS = new Set([
   'tail',
   'wc',
   'stat',
-  'date',
-  'echo',
-  'rg',
-  'find',
   'which',
-  'git',
   'grep',
-  'diff',
-  'sort',
-  'uniq',
-  'awk',
-  'sed',
   'cut',
   'tr',
-  'xargs',
-  'tee',
   'tree',
   'du',
   'df',
   'jq',
-  // 文件操作（低破坏性）
-  'mkdir',
-  'touch',
-  'cp',
-  'mv',
-  'ln',
-  'tar',
-  'gzip',
-  'gunzip',
-  'zip',
-  'unzip',
-  // 系统信息（只读）
-  'env',
-  'printenv',
   'id',
   'whoami',
   'hostname',
@@ -51,62 +34,232 @@ export const SAFE_COMMANDS = new Set([
   'ps',
   'pgrep',
   'pidof',
-  // 网络 / 系统观测（只读）
   'lsof',
   'netstat',
   'ss',
-  'memory_pressure',
   'vm_stat',
   'system_profiler',
-  'plutil',
 ]);
 
-// 允许在命令前出现并被剥离的环境变量前缀。
-// 这些变量都不会影响 shell 二进制查找或加载（不像 PATH / DYLD_* / LD_* / IFS / BASH_ENV / ENV / ZDOTDIR）。
-export const SAFE_ENV_PREFIXES = new Set([
-  'GIT_CONFIG_GLOBAL',   // 指定 .gitconfig 路径，常见 =/dev/null
-  'GIT_CONFIG_NOSYSTEM', // =1 时让 git 忽略 /etc/gitconfig
-  'HOME',                // 用户主目录，影响 ~ 展开
-  'LANG',                // 默认 locale
-  'LC_ALL',              // 强制覆盖所有 locale 类别
-  'LC_CTYPE',            // 字符分类 locale
-  'TZ',                  // 时区
+export const SAFE_COMMANDS = new Set([
+  ...SIMPLE_READ_ONLY_COMMANDS,
+  'date',
+  'diff',
+  'rg',
+  'git',
 ]);
 
-// 取命令首词，跳过 SAFE_ENV_PREFIXES 列出的环境变量前缀（如 GIT_CONFIG_GLOBAL=...）。
-export function getFirstToken(command) {
-  const tokens = String(command || '').trim().split(/\s+/);
-  for (const token of tokens) {
-    const m = token.match(/^([A-Za-z_][A-Za-z0-9_]*)=/);
-    if (m && SAFE_ENV_PREFIXES.has(m[1])) {
+const SHELL_META = new Set(['|', ';', '&', '>', '<', '`']);
+const GIT_READ_ONLY_SUBCOMMANDS = new Set([
+  'status',
+  'diff',
+  'log',
+  'show',
+  'rev-parse',
+  'ls-files',
+  'ls-tree',
+  'grep',
+]);
+
+function tokenize(command: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: 'single' | 'double' | null = null;
+  let escaping = false;
+  let tokenStarted = false;
+
+  const push = () => {
+    if (tokenStarted) tokens.push(current);
+    current = '';
+    tokenStarted = false;
+  };
+
+  for (let i = 0; i < command.length; i += 1) {
+    const char = command[i];
+    if (escaping) {
+      current += char;
+      escaping = false;
+      tokenStarted = true;
       continue;
     }
-    return token;
+    if (char === '\\' && quote !== 'single') {
+      escaping = true;
+      continue;
+    }
+    if (quote === 'single') {
+      if (char === "'") quote = null;
+      else {
+        current += char;
+        tokenStarted = true;
+      }
+      continue;
+    }
+    if (quote === 'double') {
+      if (char === '"') quote = null;
+      else if (char === '$' || char === '`') throw new Error('run_safe 不允许 shell 展开');
+      else {
+        current += char;
+        tokenStarted = true;
+      }
+      continue;
+    }
+    if (char === "'") {
+      quote = 'single';
+      tokenStarted = true;
+      continue;
+    }
+    if (char === '"') {
+      quote = 'double';
+      tokenStarted = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      push();
+      continue;
+    }
+    if (SHELL_META.has(char) || char === '$') {
+      throw new Error(`run_safe 不允许 shell 操作符: ${char}`);
+    }
+    current += char;
+    tokenStarted = true;
   }
-  return '';
+
+  if (escaping || quote) throw new Error('run_safe 命令引号或转义不完整');
+  push();
+  return tokens;
 }
 
-// 命令是否可以走 run_safe 路径（首词在白名单且没有危险 shell 操作符）。
-// classify 阶段用它判断是否需要把 run_safe 升级到 run_confirmed 走审批。
-export function canRunSafe(command) {
-  const cmd = String(command || '');
-  const firstToken = getFirstToken(cmd);
-  if (!SAFE_COMMANDS.has(firstToken)) {
-    return false;
+function hasOption(args: string[], ...options: string[]) {
+  return args.some(arg => options.some(option => arg === option || arg.startsWith(`${option}=`)));
+}
+
+function validateDate(args: string[]) {
+  // macOS date 的数字位置参数（包括 HHMM 这种短格式）会修改系统时间。
+  // -j 明确禁止设置时间；没有 -j 时只允许纯查询/格式化参数。
+  if (args.includes('-j')) {
+    return !args.some(arg => arg === '--set' || arg.startsWith('--set='));
   }
-  // 与 run.ts 内的危险操作符黑名单保持一致
-  if (
-    /[|;]/.test(cmd) ||
-    /`/.test(cmd) ||
-    /\$\(/.test(cmd) ||
-    /\$\{/.test(cmd) ||
-    /[^&]&[^&]/.test(cmd) ||
-    /\s&(\s|$)/.test(cmd) ||
-    /&&|\|\|/.test(cmd) ||
-    /[<>]\(/.test(cmd) ||
-    /<<\s*\w/.test(cmd)
-  ) {
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg.startsWith('+') || arg === '-u' || arg === '-R' || arg === '-I' || arg.startsWith('-I')) {
+      continue;
+    }
+    if (arg === '-r' || arg === '-v') {
+      index += 1;
+      if (index >= args.length) return false;
+      continue;
+    }
     return false;
   }
   return true;
+}
+
+function validateDiff(args: string[]) {
+  return !hasOption(args, '--output', '-o');
+}
+
+function validateRipgrep(args: string[]) {
+  return !hasOption(args, '--pre', '--pre-glob', '--hostname-bin');
+}
+
+function validateGit(args: string[]) {
+  if (args.length === 0) return false;
+  // 禁止 git -c / --config-env 在只读命令中注入外部 diff、pager 或过滤器。
+  if (args[0].startsWith('-') || hasOption(args, '-c', '--config-env', '--exec-path')) return false;
+  const subcommand = args[0];
+  if (!GIT_READ_ONLY_SUBCOMMANDS.has(subcommand)) return false;
+  if (hasOption(
+    args,
+    '--output',
+    '-o',
+    '--ext-diff',
+    '--textconv',
+    '--exec',
+    '--paginate',
+    '--open-files-in-pager',
+  )) return false;
+  return true;
+}
+
+function validateSimpleCommand(file: string, args: string[]) {
+  // tree -o/--output 写文件，其余简单命令只保留只读参数面。
+  if (file === 'tree' && args.some(arg => arg === '--output' || arg.startsWith('--output=') || arg.startsWith('-o'))) return false;
+  // macOS/BSD hostname 的位置参数会直接修改系统 hostname。
+  if (file === 'hostname' && !args.every(arg => ['-f', '-s', '-d'].includes(arg))) return false;
+  return true;
+}
+
+function validateArgs(file: string, args: string[]) {
+  if (args.some(arg => arg.includes('\0') || arg.includes('\n') || arg.includes('\r'))) return false;
+  if (SIMPLE_READ_ONLY_COMMANDS.has(file)) return validateSimpleCommand(file, args);
+  if (file === 'date') return validateDate(args);
+  if (file === 'diff') return validateDiff(args);
+  if (file === 'rg') return validateRipgrep(args);
+  if (file === 'git') return validateGit(args);
+  return false;
+}
+
+export function parseSafeCommand(command: string): ParsedSafeCommand {
+  const tokens = tokenize(String(command || '').trim());
+  if (tokens.length === 0) throw new Error('run_safe 命令为空');
+  const [file, ...args] = tokens;
+  if (file.includes('/') || !SAFE_COMMANDS.has(file)) {
+    throw new Error(`run_safe 不允许执行该命令: ${file}`);
+  }
+  if (!validateArgs(file, args)) {
+    throw new Error(`run_safe 不允许该命令参数: ${command}`);
+  }
+  if (file !== 'git') return { file, args };
+
+  const [subcommand, ...subcommandArgs] = args;
+  const hardenedArgs = [
+    '-c', 'core.fsmonitor=false',
+    '-c', 'core.pager=cat',
+    '-c', `pager.${subcommand}=false`,
+    subcommand,
+  ];
+  if (['diff', 'log', 'show'].includes(subcommand)) {
+    hardenedArgs.push('--no-ext-diff', '--no-textconv');
+  }
+  hardenedArgs.push(...subcommandArgs);
+
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key === 'GIT_CONFIG_PARAMETERS' || key.startsWith('GIT_CONFIG_KEY_') || key.startsWith('GIT_CONFIG_VALUE_')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_CONFIG_COUNT;
+
+  return {
+    file,
+    args: hardenedArgs,
+    env: {
+      ...env,
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_EXTERNAL_DIFF: '',
+      GIT_OPTIONAL_LOCKS: '0',
+      GIT_PAGER: 'cat',
+      PAGER: 'cat',
+    },
+  };
+}
+
+export function getFirstToken(command: string) {
+  try {
+    return tokenize(String(command || '').trim())[0] || '';
+  } catch {
+    return '';
+  }
+}
+
+export function canRunSafe(command: string) {
+  try {
+    parseSafeCommand(command);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -29,12 +29,15 @@ async function focusOrOpenWindow() {
 }
 
 async function postApprovalDecision(data, decision) {
-  const { runId, approvalId } = data || {};
+  const { runId, approvalId, apiToken } = data || {};
   if (!runId || !approvalId) return;
   try {
     await fetch('/api/agent/approvals', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(apiToken ? { 'X-Sagent-Token': apiToken } : {}),
+      },
       body: JSON.stringify({ runId, approvalId, decision }),
     });
   } catch {

--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -1,0 +1,39 @@
+const STORAGE_KEY = 'sagent_api_token';
+let promptPromise = null;
+let promptAttempted = false;
+
+export function getApiToken() {
+  if (typeof window === 'undefined') return '';
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function setApiToken(token) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (token) window.localStorage.setItem(STORAGE_KEY, token);
+    else window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // 隐私模式或禁用 storage 时，当前请求仍可使用输入的 token。
+  }
+}
+
+export async function promptForApiToken() {
+  if (typeof window === 'undefined' || typeof window.prompt !== 'function') return '';
+  if (!promptPromise && promptAttempted) return '';
+  if (!promptPromise) {
+    promptAttempted = true;
+    promptPromise = Promise.resolve().then(() => {
+      const token = window.prompt('Sagent API 需要认证，请输入 SAGENT_API_TOKEN：', getApiToken());
+      const normalized = String(token || '').trim();
+      if (normalized) setApiToken(normalized);
+      return normalized;
+    }).finally(() => {
+      promptPromise = null;
+    });
+  }
+  return promptPromise;
+}

--- a/client/src/api/http.js
+++ b/client/src/api/http.js
@@ -1,13 +1,31 @@
 import { getLocale } from '../i18n/locale.js';
+import { getApiToken, promptForApiToken } from './auth.js';
 
 // 统一 fetch 封装：给所有 API 请求带上 X-Lang，让后端按用户在前台选择的语言
 // 返回错误/状态/建议等面向用户的文案。
 // 用自定义头 X-Lang 而非 Accept-Language——后者是 fetch 规范里的禁止改写头，
 // 浏览器会忽略前端对它的设置；后端把 X-Lang 作为首选、Accept-Language 兜底。
-export function apiFetch(url, options = {}) {
+function withApiHeaders(options, token) {
   const headers = new Headers(options.headers || {});
   if (!headers.has('X-Lang')) {
     headers.set('X-Lang', getLocale());
   }
-  return fetch(url, { ...options, headers });
+  if (token && !headers.has('Authorization') && !headers.has('X-Sagent-Token')) {
+    headers.set('X-Sagent-Token', token);
+  }
+  return { ...options, headers };
+}
+
+export async function apiFetch(url, options = {}) {
+  const initialToken = getApiToken();
+  const response = await fetch(url, withApiHeaders(options, initialToken));
+  if (response.status !== 401) return response;
+
+  const storedToken = getApiToken();
+  const token = storedToken && storedToken !== initialToken
+    ? storedToken
+    : await promptForApiToken();
+  if (!token) return response;
+  await response.body?.cancel().catch(() => {});
+  return fetch(url, withApiHeaders(options, token));
 }

--- a/client/src/notifications.js
+++ b/client/src/notifications.js
@@ -1,6 +1,7 @@
 // 浏览器审批通知工具：注册 ServiceWorker、请求权限、弹通知。
 // 决策按钮的点击 → SW 直接 POST /api/agent/approvals（见 public/sw.js）。
 import { tStatic } from './i18n/locale.js';
+import { getApiToken } from './api/auth.js';
 
 let swRegistrationPromise = null;
 
@@ -117,7 +118,7 @@ export async function showAgentNotification({ runId, approvalId, message, kind =
       renotify: true,
       requireInteraction,
       actions,
-      data: { runId, approvalId, kind },
+      data: { runId, approvalId, kind, apiToken: getApiToken() },
     });
     console.info('[Notifications] 已弹出通知', { kind, approvalId: approvalId || null, runId });
     return true;

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -8,12 +8,12 @@ export default defineConfig({
     target: ['safari15', 'chrome80', 'firefox80'],
   },
   server: {
-    host: '0.0.0.0',
+    host: process.env.VITE_HOST || '127.0.0.1',
     port: 5173,
     proxy: {
-      '/api': 'http://localhost:3001',
-      '/v1': 'http://localhost:3001',
-      '/screenshots': 'http://localhost:3001',
+      '/api': { target: 'http://localhost:3001', changeOrigin: false },
+      '/v1': { target: 'http://localhost:3001', changeOrigin: false },
+      '/screenshots': { target: 'http://localhost:3001', changeOrigin: false },
     },
   },
 })

--- a/helpers/security.ts
+++ b/helpers/security.ts
@@ -1,0 +1,175 @@
+import crypto from 'node:crypto';
+import net from 'node:net';
+import type { CorsOptions } from 'cors';
+import type { NextFunction, Request, Response } from 'express';
+
+const MIN_API_TOKEN_LENGTH = 16;
+const SESSION_COOKIE = 'sagent_session';
+
+export interface ServerSecurityConfig {
+  host: string;
+  apiToken: string;
+  allowedOrigins: Set<string>;
+}
+
+function normalizeOrigin(value: string) {
+  const parsed = new URL(value);
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error(`不支持的 CORS Origin: ${value}`);
+  }
+  return parsed.origin;
+}
+
+function hostnameOnly(value: string) {
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed.startsWith('[')) return trimmed.slice(1, trimmed.indexOf(']'));
+  if (net.isIP(trimmed)) return trimmed;
+  return trimmed.split(':')[0];
+}
+
+export function isLoopbackHost(value: string) {
+  const host = hostnameOnly(value);
+  return host === 'localhost'
+    || host === '::1'
+    || host === '0:0:0:0:0:0:0:1'
+    || host.startsWith('127.')
+    || host.startsWith('::ffff:127.');
+}
+
+export function loadServerSecurityConfig(env: NodeJS.ProcessEnv = process.env): ServerSecurityConfig {
+  const host = String(env.HOST || '127.0.0.1').trim() || '127.0.0.1';
+  const apiToken = String(env.SAGENT_API_TOKEN || '').trim();
+  if (apiToken && apiToken.length < MIN_API_TOKEN_LENGTH) {
+    throw new Error(`SAGENT_API_TOKEN 至少需要 ${MIN_API_TOKEN_LENGTH} 个字符`);
+  }
+  if (!isLoopbackHost(host) && !apiToken) {
+    throw new Error(`HOST=${host} 会对外监听，必须配置 SAGENT_API_TOKEN（至少 ${MIN_API_TOKEN_LENGTH} 个字符）`);
+  }
+
+  const allowedOrigins = new Set<string>();
+  for (const value of String(env.SAGENT_CORS_ORIGINS || '').split(',')) {
+    const origin = value.trim();
+    if (origin) allowedOrigins.add(normalizeOrigin(origin));
+  }
+  return { host, apiToken, allowedOrigins };
+}
+
+function requestOrigin(req: Request) {
+  const protocol = req.protocol;
+  const host = req.get('host');
+  return host ? `${protocol}://${host}` : '';
+}
+
+export function isAllowedRequestOrigin(req: Request, origin: string, config: ServerSecurityConfig) {
+  let normalized: string;
+  try {
+    normalized = normalizeOrigin(origin);
+  } catch {
+    return false;
+  }
+  if (config.allowedOrigins.has(normalized)) return true;
+  try {
+    if (normalized === normalizeOrigin(requestOrigin(req))) return true;
+  } catch {
+    return false;
+  }
+
+  try {
+    const originUrl = new URL(normalized);
+    const requestUrl = new URL(requestOrigin(req));
+    return isLoopbackHost(originUrl.hostname) && isLoopbackHost(requestUrl.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function createOriginGuard(config: ServerSecurityConfig) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const origin = req.get('origin');
+    if (!origin || isAllowedRequestOrigin(req, origin, config)) return next();
+    return res.status(403).json({ error: 'Origin 不被允许', code: 'ORIGIN_FORBIDDEN' });
+  };
+}
+
+export function createCorsOptions(config: ServerSecurityConfig): CorsOptions {
+  void config;
+  return {
+    origin(origin, callback) {
+      // 实际拒绝由 origin guard 完成；这里仅控制响应头。
+      callback(null, origin || false);
+    },
+    credentials: true,
+    methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Authorization', 'Content-Type', 'X-Lang', 'X-Sagent-Token'],
+    maxAge: 600,
+  };
+}
+
+function isProtectedPath(pathname: string) {
+  return pathname === '/api'
+    || pathname.startsWith('/api/')
+    || pathname === '/v1'
+    || pathname.startsWith('/v1/')
+    || pathname === '/screenshots'
+    || pathname.startsWith('/screenshots/');
+}
+
+function safeEqual(actual: string, expected: string) {
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  return actualBuffer.length === expectedBuffer.length
+    && crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+function sessionValue(apiToken: string) {
+  return crypto.createHmac('sha256', apiToken).update('sagent-session-v1').digest('base64url');
+}
+
+function cookieValue(req: Request, name: string) {
+  const cookies = String(req.headers.cookie || '').split(';');
+  for (const cookie of cookies) {
+    const separator = cookie.indexOf('=');
+    if (separator === -1) continue;
+    if (cookie.slice(0, separator).trim() === name) {
+      return cookie.slice(separator + 1).trim();
+    }
+  }
+  return '';
+}
+
+function requestTokens(req: Request) {
+  const tokens: string[] = [];
+  const authorization = req.get('authorization') || '';
+  const bearer = authorization.match(/^Bearer\s+(.+)$/i);
+  if (bearer) tokens.push(bearer[1].trim());
+  const customHeader = req.get('x-sagent-token');
+  if (customHeader) tokens.push(customHeader.trim());
+  return tokens;
+}
+
+export function createApiAuth(config: ServerSecurityConfig) {
+  const expectedSession = config.apiToken ? sessionValue(config.apiToken) : '';
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!config.apiToken || req.method === 'OPTIONS' || !isProtectedPath(req.path)) return next();
+
+    const validHeader = requestTokens(req).some(token => safeEqual(token, config.apiToken));
+    const validCookie = safeEqual(cookieValue(req, SESSION_COOKIE), expectedSession);
+    if (!validHeader && !validCookie) {
+      res.setHeader('Cache-Control', 'no-store');
+      return res.status(401).json({ error: '需要有效的 Sagent API Token', code: 'AUTH_REQUIRED' });
+    }
+
+    if (validHeader) {
+      const forwardedProto = String(req.headers['x-forwarded-proto'] || '').split(',')[0].trim();
+      const secure = req.secure || forwardedProto === 'https' || String(req.get('origin') || '').startsWith('https://');
+      res.cookie(SESSION_COOKIE, expectedSession, {
+        httpOnly: true,
+        sameSite: 'strict',
+        secure,
+        path: '/',
+      });
+    }
+    return next();
+  };
+}

--- a/routes/agent-approval.ts
+++ b/routes/agent-approval.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
 import { tReq } from '../helpers/i18n.ts';
+import { ApprovalNotFoundError, ApprovalRunMismatchError } from '../agent/core/approval-store.ts';
 import type { AgentRouterContext } from './agent-types.ts';
 
 export function createAgentApprovalRouter({ approvalStore }: AgentRouterContext) {
   const router = Router();
 
-  router.post('/api/agent/approvals', (req, res) => {
+  router.post('/api/agent/approvals', (req, res, next) => {
     const { runId, approvalId, decision } = req.body ?? {};
 
     if (typeof runId !== 'string' || !runId) {
@@ -21,15 +22,19 @@ export function createAgentApprovalRouter({ approvalStore }: AgentRouterContext)
     }
 
     try {
-      approvalStore.resolve(approvalId, decision);
+      approvalStore.resolve(approvalId, decision, runId);
       return res.json({ ok: true });
-    } catch {
+    } catch (err) {
+      if (err instanceof ApprovalRunMismatchError) {
+        return res.status(409).json({ error: err.message, code: err.code });
+      }
+      if (!(err instanceof ApprovalNotFoundError)) return next(err);
       // Approval may have been cleared by rejectAll() after run ended
       return res.json({ ok: true, stale: true });
     }
   });
 
-  router.post('/api/agent/question', (req, res) => {
+  router.post('/api/agent/question', (req, res, next) => {
     const { runId, approvalId, response } = req.body ?? {};
 
     if (typeof runId !== 'string' || !runId) {
@@ -45,9 +50,13 @@ export function createAgentApprovalRouter({ approvalStore }: AgentRouterContext)
     }
 
     try {
-      approvalStore.resolve(approvalId, response.trim());
+      approvalStore.resolve(approvalId, response.trim(), runId);
       return res.json({ ok: true });
-    } catch {
+    } catch (err) {
+      if (err instanceof ApprovalRunMismatchError) {
+        return res.status(409).json({ error: err.message, code: err.code });
+      }
+      if (!(err instanceof ApprovalNotFoundError)) return next(err);
       return res.json({ ok: true, stale: true });
     }
   });

--- a/server.ts
+++ b/server.ts
@@ -55,9 +55,13 @@ import { createBaseEventSender, loadMemoryForPrompt, cleanupAgentRun } from './h
 import { padEndW, truncateW } from './agent/core/utils.ts';
 import { log } from './helpers/logger.ts';
 import { runtimeConfig } from './agent/core/runtime-config.ts';
+import { createApiAuth, createCorsOptions, createOriginGuard, loadServerSecurityConfig } from './helpers/security.ts';
 
+const securityConfig = loadServerSecurityConfig();
 const app = express();
-app.use(cors());
+app.use(createOriginGuard(securityConfig));
+app.use(cors(createCorsOptions(securityConfig)));
+app.use(createApiAuth(securityConfig));
 app.use(express.json({ limit: '25mb' }));
 
 const { openai_client, gemini_client } = createClients();
@@ -137,7 +141,7 @@ if (fs.existsSync(path.join(CLIENT_DIST_DIR, 'index.html'))) {
 }
 
 const PORT = process.env.PORT || 3001;
-const HOST = process.env.HOST || '0.0.0.0';
+const HOST = securityConfig.host;
 const SIGNAL_EXIT_CODES: Record<string, number> = { SIGINT: 130, SIGTERM: 143 };
 
 function envMs(name: string, fallback: number) {

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -165,6 +165,40 @@ describe('GET /api/agent/active', () => {
   });
 });
 
+describe('approval ownership', () => {
+  it('rejects approval decisions submitted with another run id', async () => {
+    approvalStore.request({
+      type: 'approval_required',
+      runId: 'run_owner',
+      action: { tool: 'terminal', type: 'run_confirmed', command: 'npm test', cwd: '', timeoutMs: 12000 },
+    }, 'approval_owner_1');
+
+    const res = await request(app)
+      .post('/api/agent/approvals')
+      .send({ runId: 'run_other', approvalId: 'approval_owner_1', decision: 'approve' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('APPROVAL_RUN_MISMATCH');
+    expect(approvalStore.getPendingForRun('run_owner')?.approvalId).toBe('approval_owner_1');
+    approvalStore.rejectAll();
+  });
+
+  it('rejects question responses submitted with another run id', async () => {
+    approvalStore.request({
+      type: 'question_required',
+      runId: 'run_question_owner',
+      action: { tool: 'ask_user', type: 'question', question: 'Continue?' },
+    }, 'question_owner_1');
+
+    const res = await request(app)
+      .post('/api/agent/question')
+      .send({ runId: 'run_other', approvalId: 'question_owner_1', response: 'yes' });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('APPROVAL_RUN_MISMATCH');
+    expect(approvalStore.getPendingForRun('run_question_owner')?.approvalId).toBe('question_owner_1');
+    approvalStore.rejectAll();
+  });
+});
+
 describe('POST /api/agent', () => {
   it('requires an explicit model selection', async () => {
     const res = await request(app)

--- a/test/approval-store.test.ts
+++ b/test/approval-store.test.ts
@@ -12,7 +12,7 @@ describe('approval store', () => {
     }, 'worker_approval_1');
 
     expect(approvalId).toBe('worker_approval_1');
-    store.resolve('worker_approval_1', 'approve');
+    store.resolve('worker_approval_1', 'approve', 'run_worker_1');
     await expect(promise).resolves.toBe('approve');
   });
 
@@ -56,5 +56,22 @@ describe('approval store', () => {
       },
     ]);
     expect(store.getPendingForRun('run_abc_123')?.approvalId).toBe('approval_pending_1');
+  });
+
+  it('does not resolve an approval through a different run id', async () => {
+    const store = createApprovalStore();
+    const { promise } = store.request({
+      type: 'approval_required',
+      runId: 'run_owner',
+      action: { tool: 'terminal', type: 'run_confirmed', command: 'npm test', cwd: '', timeoutMs: 12000 },
+    }, 'approval_owned');
+
+    expect(() => store.resolve('approval_owned', 'approve', 'run_attacker')).toThrowError(
+      expect.objectContaining({ code: 'APPROVAL_RUN_MISMATCH' }),
+    );
+    expect(store.getPendingForRun('run_owner')?.approvalId).toBe('approval_owned');
+
+    store.resolve('approval_owned', 'reject', 'run_owner');
+    await expect(promise).resolves.toBe('reject');
   });
 });

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -1,0 +1,100 @@
+import cors from 'cors';
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import {
+  createApiAuth,
+  createCorsOptions,
+  createOriginGuard,
+  loadServerSecurityConfig,
+} from '../helpers/security.ts';
+
+function createApp(env: NodeJS.ProcessEnv) {
+  const config = loadServerSecurityConfig(env);
+  const app = express();
+  app.use(createOriginGuard(config));
+  app.use(cors(createCorsOptions(config)));
+  app.use(createApiAuth(config));
+  app.use(express.json());
+  app.get('/api/ping', (_req, res) => res.json({ ok: true }));
+  app.get('/screenshots/example.png', (_req, res) => res.type('png').send('image'));
+  app.get('/', (_req, res) => res.send('public'));
+  return app;
+}
+
+describe('server security', () => {
+  it('defaults to loopback without requiring a token', async () => {
+    const config = loadServerSecurityConfig({});
+    expect(config.host).toBe('127.0.0.1');
+    const res = await request(createApp({})).get('/api/ping');
+    expect(res.status).toBe(200);
+  });
+
+  it('refuses an external listen address without a strong token', () => {
+    expect(() => loadServerSecurityConfig({ HOST: '0.0.0.0' })).toThrow('必须配置 SAGENT_API_TOKEN');
+    expect(() => loadServerSecurityConfig({ HOST: '0.0.0.0', SAGENT_API_TOKEN: 'short' })).toThrow('至少需要 16 个字符');
+  });
+
+  it('protects API routes and establishes an HttpOnly session cookie', async () => {
+    const app = createApp({ HOST: '0.0.0.0', SAGENT_API_TOKEN: '0123456789abcdef' });
+    expect((await request(app).get('/api/ping')).status).toBe(401);
+
+    const authenticated = await request(app)
+      .get('/api/ping')
+      .set('Authorization', 'Bearer 0123456789abcdef');
+    expect(authenticated.status).toBe(200);
+    expect(authenticated.headers['set-cookie']?.[0]).toContain('sagent_session=');
+    expect(authenticated.headers['set-cookie']?.[0]).toContain('HttpOnly');
+    expect(authenticated.headers['set-cookie']?.[0]).toContain('SameSite=Strict');
+
+    const cookie = authenticated.headers['set-cookie'][0].split(';')[0];
+    const screenshot = await request(app).get('/screenshots/example.png').set('Cookie', cookie);
+    expect(screenshot.status).toBe(200);
+  });
+
+  it('leaves the static UI public when API auth is enabled', async () => {
+    const app = createApp({ HOST: '0.0.0.0', SAGENT_API_TOKEN: '0123456789abcdef' });
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('public');
+  });
+
+  it('actively rejects disallowed origins before route handlers run', async () => {
+    const app = createApp({ HOST: '127.0.0.1' });
+    const denied = await request(app)
+      .post('/api/ping')
+      .set('Origin', 'https://evil.example');
+    expect(denied.status).toBe(403);
+    expect(denied.body.code).toBe('ORIGIN_FORBIDDEN');
+
+    const spoofedProxyHost = await request(app)
+      .get('/api/ping')
+      .set('Host', '127.0.0.1:3001')
+      .set('X-Forwarded-Host', 'evil.example')
+      .set('Origin', 'http://evil.example');
+    expect(spoofedProxyHost.status).toBe(403);
+
+    const sameOrigin = await request(app)
+      .get('/api/ping')
+      .set('Host', '127.0.0.1:3001')
+      .set('Origin', 'http://localhost:5173');
+    expect(sameOrigin.status).toBe(200);
+    expect(sameOrigin.headers['access-control-allow-origin']).toBe('http://localhost:5173');
+  });
+
+  it('allows explicitly configured cross-origin clients and unauthenticated preflight', async () => {
+    const app = createApp({
+      HOST: '0.0.0.0',
+      SAGENT_API_TOKEN: '0123456789abcdef',
+      SAGENT_CORS_ORIGINS: 'https://ui.example',
+    });
+    const preflight = await request(app)
+      .options('/api/ping')
+      .set('Origin', 'https://ui.example')
+      .set('Access-Control-Request-Method', 'GET')
+      .set('Access-Control-Request-Headers', 'X-Sagent-Token');
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers['access-control-allow-origin']).toBe('https://ui.example');
+    expect(preflight.headers['access-control-allow-headers']).toContain('X-Sagent-Token');
+  });
+});

--- a/test/terminal-safe-policy.test.ts
+++ b/test/terminal-safe-policy.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { classifyAgentAction } from '../agent/policy/classify.ts';
+import { canRunSafe, parseSafeCommand } from '../agent/tools/terminal/safe-policy.ts';
+import { executeTerminalAction } from '../agent/tools/terminal/run.ts';
+
+describe('terminal run_safe policy', () => {
+  it.each([
+    'pwd',
+    'ls -la',
+    'rg -n "foo bar" src',
+    'git status',
+    'git diff',
+    'date +%Y-%m-%d',
+  ])('allows a read-only command: %s', command => {
+    expect(canRunSafe(command)).toBe(true);
+  });
+
+  it.each([
+    'git reset --hard',
+    'git clean -fd',
+    'git grep --open-files-in-pager=sh pattern',
+    'mkdir output',
+    'echo x > file',
+    'sed -i backup file',
+    'find . -exec sh {} ;',
+    'rg --pre sh pattern',
+    'sort -o output input',
+    'tree -o output.txt',
+    'env',
+    'hostname changed.example',
+    'memory_pressure',
+    'date 1234',
+    '/bin/pwd',
+  ])('rejects a writable or executable command: %s', command => {
+    expect(canRunSafe(command)).toBe(false);
+  });
+
+  it('parses quoted arguments without invoking a shell', () => {
+    expect(parseSafeCommand('rg -n "foo bar" \'src files\'')).toEqual({
+      file: 'rg',
+      args: ['-n', 'foo bar', 'src files'],
+    });
+  });
+
+  it('preserves explicit empty argv values', () => {
+    expect(parseSafeCommand("rg '' README.md")).toEqual({
+      file: 'rg',
+      args: ['', 'README.md'],
+    });
+  });
+
+  it('hardens git against configured external processes', () => {
+    const parsed = parseSafeCommand('git diff -- README.md');
+    expect(parsed.file).toBe('git');
+    expect(parsed.args).toEqual(expect.arrayContaining([
+      '-c',
+      'core.fsmonitor=false',
+      'diff',
+      '--no-ext-diff',
+      '--no-textconv',
+      '--',
+      'README.md',
+    ]));
+    expect(parsed.env).toMatchObject({
+      GIT_CONFIG_NOSYSTEM: '1',
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_PAGER: 'cat',
+    });
+  });
+
+  it('upgrades an unsafe run_safe action to approval', () => {
+    const action: any = {
+      tool: 'terminal' as const,
+      type: 'run_safe' as const,
+      command: 'mkdir output',
+      cwd: '',
+      timeoutMs: 8000,
+    };
+    const decision = classifyAgentAction(action);
+    expect(decision.level).toBe('confirm');
+    expect(action.type).toBe('run_confirmed');
+  });
+
+  it('executes quoted argv directly without shell expansion', async () => {
+    const result = await executeTerminalAction({
+      tool: 'terminal',
+      type: 'run_safe',
+      command: 'ls "BACKEND_TODO.md"',
+      cwd: '',
+      timeoutMs: 2000,
+    });
+    expect(result).toContain('exit_code: 0');
+    expect(result).toContain('command: ls "BACKEND_TODO.md"');
+  });
+});


### PR DESCRIPTION
## Summary
- add typed agent core contracts and explicit run states
- validate project roots before starting agent runs
- execute run_safe commands without a shell using strict command/argument policy
- require API token for non-loopback listeners, enforce strict Origin/CORS checks, and default to loopback
- bind approval IDs to their owning run IDs

## Verification
- npm run typecheck
- npm run lint
- npm test (39 files, 240 tests)
- npm run build:client
- git diff --check