### PR TITLE
fix: support keyboard deletion in model selector

### DIFF
--- a/client/src/components/ModelSelector.jsx
+++ b/client/src/components/ModelSelector.jsx
@@ -682,6 +682,19 @@ function ModelPickerDropdown({
                       ref={inputRef}
                       type="text"
                       value={query}
+                      onKeyDown={e => {
+                        if (
+                          multiple
+                          && clearable
+                          && !disabled
+                          && query.length === 0
+                          && selectedModelIds.length > 0
+                          && (e.key === 'Backspace' || e.key === 'Delete')
+                        ) {
+                          e.preventDefault();
+                          setSelectedModelIds(selectedModelIds.slice(0, -1));
+                        }
+                      }}
                       onChange={e => {
                         setQuery(e.target.value);
                         setExpandedEncyclopediaModels([]);


### PR DESCRIPTION
## Summary
- remove the last selected model when Backspace or Delete is pressed in an empty model search input
- preserve normal text editing while the search input contains text
- respect disabled and non-clearable selector states

## Validation
- git diff --check
- lint/build not run because frontend dependencies are not installed in this worktree (eslint and vite unavailable)