### PR TITLE
docs: align architecture with config store

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,114 @@
+# Architecture
+
+This document describes the repository-wide architecture. For React-specific details, see [client/ARCHITECTURE.md](client/ARCHITECTURE.md). Configuration formats and migration rules are documented in [CONFIGURATION.md](CONFIGURATION.md).
+
+## System overview
+
+```text
+React/Vite client
+  ├─ chat, projects, settings and approvals
+  └─ fetch + SSE
+          │
+          ▼
+Express API in server.ts
+  ├─ authentication, CORS and origin guard
+  ├─ model and OpenAI-compatible routes
+  ├─ Agent run lifecycle and streaming
+  └─ project/configuration APIs
+          │
+          ▼
+Agent runtime
+  ├─ provider registry and model metadata
+  ├─ race/vote planner
+  ├─ policy and approval boundary
+  ├─ tools: files, terminal, browser, vision, macOS and MCP
+  └─ direct runner or short-lived worker process
+          │
+          ▼
+data directory
+  ├─ config.json
+  ├─ projects, memory and uploads
+  ├─ traces and checkpoints
+  └─ local caches and smoke reports
+```
+
+## Startup flow
+
+1. `server.ts` loads deployment variables from `.env`.
+2. Provider clients are created and their model lists are fetched. Startup fails if no provider can supply a usable model list.
+3. `configStore` loads `data/config.json`, migrates legacy `runtime-config.json` when present, and computes effective Agent settings.
+4. The project, run, approval and persistence stores are initialized.
+5. The server selects the direct runner or sandboxed worker runner. Explicit startup environment variables override stored `execution` values, so `npm run sandbox` always enables workers.
+6. API routes and the production client bundle are mounted.
+7. If recovery is enabled, incomplete checkpoints are inspected and resumed.
+
+## Configuration architecture
+
+Configuration is intentionally split by lifecycle:
+
+| Source | Owns | Reload behavior |
+| --- | --- | --- |
+| `.env` | provider secrets, server binding, authentication, logging and executable overrides | process restart |
+| `agent/core/config-schema.ts` | Agent field types, defaults, ranges and profiles | code release |
+| `data/config.json` | Agent overrides, MCP servers, tools and execution preferences | Agent values apply to the next run |
+| per-run API payload | selected models, strategy and task-specific options | current run |
+
+`agent/core/config-store.ts` is the stateful boundary around the structured document. It validates and normalizes input, performs atomic persistence, exposes source metadata to Settings, and provides synchronous effective values to hot runtime paths.
+
+Agent tuning resolves as:
+
+```text
+schema defaults < compatibility environment defaults < data/config.json < per-run values
+```
+
+Startup-only execution flags are different: an explicitly supplied environment variable overrides the stored execution preference. This keeps commands and deployment manifests deterministic.
+
+## Agent run lifecycle
+
+The client starts a run through the Agent API and consumes an SSE stream. The backend reserves the single active-run slot, creates a run record, then invokes the selected runner.
+
+Each step follows this loop:
+
+```text
+observe → build bounded prompt → ask one or more models → select decision
+        → classify policy → request approval when needed → execute tool
+        → persist trace/checkpoint → continue or finish
+```
+
+The planner supports:
+
+- `race`: accept the first valid decision and cancel remaining model calls.
+- `vote`: wait for model decisions and aggregate the best action.
+
+Agent values such as step limits, timeouts, output budgets and context limits are read from `configStore` at run time. Startup choices such as direct versus worker execution are fixed for the server process.
+
+## Runner boundary
+
+`npm run dev` runs the Agent in the backend process. `npm run sandbox` sets `AGENT_SANDBOXED_WORKERS=true`, causing each run to execute in a short-lived worker. On macOS, the worker can additionally be constrained by `sandbox.sb`.
+
+The backend remains responsible for shared run state, approvals and SSE delivery. Worker messages bridge tool requests, trace events, approval decisions and cancellation back to the main process.
+
+## Tools and policy
+
+Tools are registered by the Agent runtime and normalized into structured actions. Policy classification occurs before side effects. Read-only operations may proceed directly; terminal execution, file mutation, package installation and other sensitive actions require explicit approval.
+
+Chrome and JetBrains integrations are configured under `mcpServers` in `data/config.json`. Their concrete clients translate the generic SSE or stdio configuration into MCP `tools/list` and `tools/call` operations. Prompt details are loaded lazily so disabled integrations do not consume prompt context.
+
+## Persistence and recovery
+
+Project data is isolated below the configured data directory. Traces are append-only run diagnostics; checkpoints contain resumable execution state. A completed or cancelled run removes its checkpoint, while an interrupted run can be restored after restart when recovery is enabled.
+
+Writes that must survive shutdown are tracked through the persistence queue. Server shutdown first stops accepting work, cancels or drains active runs, flushes queued persistence and LLM logs, then exits.
+
+## Frontend boundaries
+
+The React client keeps browser-local chat presentation state while the backend owns Agent execution state. On refresh, the client queries the active run and reconnects to its SSE stream. When a mobile browser resumes after being backgrounded, it fetches the persisted trace to recover terminal events that may have been missed.
+
+Settings reads schema, effective values and source metadata from `/api/config`. Agent/profile changes are persisted through the config API; Chrome and JetBrains cards save and test MCP connections through dedicated endpoints.
+
+## Extension points
+
+- Add a provider under `agent/core/providers/` and register it in the provider registry.
+- Add an Agent action/tool under `agent/tools/`, then update policy classification and tests.
+- Add a structured configuration field to `config-schema.ts`; consumers should read it through `configStore` rather than reading tuning environment variables directly.
+- Add an API route under `routes/` and keep `server.ts` focused on composition and process lifecycle.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -114,6 +114,8 @@ The Settings UI creates a versioned document at `data/config.json`:
 
 Values not present in the file use the canonical defaults defined by the backend schema.
 
+The schema lives in `agent/core/config-schema.ts`; loading, migration, source tracking and atomic persistence are handled by `agent/core/config-store.ts`.
+
 ## Profiles
 
 | Profile | Intended use |
@@ -136,6 +138,8 @@ built-in schema defaults
   < data/config.json
   < per-run request values
 ```
+
+The `execution` section is startup-only. Explicit startup environment values override stored execution preferences so commands and deployment manifests remain deterministic. In particular, `npm run sandbox` sets `AGENT_SANDBOXED_WORKERS=true` and always selects the worker runner for that server process.
 
 Provider keys and server deployment variables remain environment-only.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 > Chinese documentation: [README_ZH.md](README_ZH.md)
 >
 > Environment variables and runtime settings: [CONFIGURATION.md](CONFIGURATION.md)
+>
+> System design: [ARCHITECTURE.md](ARCHITECTURE.md)
 
 ## Overview
 
@@ -48,6 +50,8 @@ npm run sandbox
 Edit `.env` before starting if you have not added an API key yet. Open http://localhost:5173 when the dev server is ready.
 
 `npm run sandbox` starts the UI/API server normally and runs each Agent task in a short-lived macOS sandboxed worker. Use `npm run dev` only when you intentionally want the non-sandboxed development mode.
+
+After startup, use Settings to choose an Agent profile, edit basic or advanced runtime limits, and manage Chrome/JetBrains MCP connections. These values are stored locally in `data/config.json`; secrets remain in `.env`.
 
 ## Docker
 
@@ -135,3 +139,5 @@ client/     React/Vite frontend
 scripts/    Smoke tests, stop script, Chrome MCP bridge
 test/       Vitest and integration tests
 ```
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the backend, Agent, worker, configuration and persistence flows, and [client/ARCHITECTURE.md](client/ARCHITECTURE.md) for the React client.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -9,6 +9,8 @@
 > 英文版：[README.md](README.md)
 >
 > 环境变量和运行时配置：[CONFIGURATION.md](CONFIGURATION.md)
+>
+> 系统架构：[ARCHITECTURE.md](ARCHITECTURE.md)
 
 ## 项目简介
 
@@ -49,6 +51,8 @@ npm run sandbox
 
 `npm run sandbox` 会正常启动 UI/API server，并让每次 Agent 任务在 macOS 沙盒 worker 中执行。只有明确需要无沙盒调试时，才使用 `npm run dev`。
 
+启动后可在设置页选择 Agent Profile、调整基础/高级运行参数，并管理 Chrome 与 JetBrains MCP 连接。这些值保存在本地 `data/config.json`，密钥仍保留在 `.env`。
+
 ## Docker 运行
 
 Docker 会构建前端，并用一个 Bun 进程提供 UI/API 服务。它适合分发 server/UI 包；依赖桌面、系统 WebView 或宿主浏览器控制的 Agent 能力，仍建议在 macOS 上原生运行。
@@ -75,11 +79,20 @@ Agent 等待审批时，sagent 会显示页面内审批面板，并发送浏览�
 
 ## 多设备查看
 
-局域网内其他设备可以打开 `http://<Mac-IP>:5173` 实时查看当前 Agent 运行。
+开发服务默认只监听 `127.0.0.1`。需要在局域网访问时，先在 `.env` 设置至少 16 位的 `SAGENT_API_TOKEN`，再显式暴露 Vite：
+
+```bash
+openssl rand -hex 24
+# 把输出填入 .env 的 SAGENT_API_TOKEN=
+VITE_HOST=0.0.0.0 npm run sandbox
+```
+
+局域网设备随后可打开 `http://<Mac-IP>:5173`，首次受保护请求会要求输入 Token。独立部署前端时，还需通过 `SAGENT_CORS_ORIGINS` 配置精确来源。
 
 - Agent 运行中，其他设备展示执行流程，并在完成后收到最终结果。
 - 聊天历史保存在各自浏览器里，不跨设备共享。
 - 同一时间只能运行一个 Agent，新的任务请求会收到 409。
+- 配置 Token 后，API、OpenAI 兼容 `/v1` 和截图接口都需要认证；后端监听非 loopback 地址时，没有合规 Token 将拒绝启动。
 
 ## 核心工作流
 
@@ -124,3 +137,5 @@ client/     React/Vite 前端
 scripts/    冒烟测试、停止脚本、Chrome MCP bridge
 test/       Vitest 和集成测试
 ```
+
+后端、Agent、worker、配置和持久化流程见 [ARCHITECTURE.md](ARCHITECTURE.md)，React 前端细节见 [client/ARCHITECTURE.md](client/ARCHITECTURE.md)。

--- a/agent/core/config-store.ts
+++ b/agent/core/config-store.ts
@@ -1,5 +1,5 @@
 /**
- * Runtime Config — 集中的运行时配置层（单一数据源 + 落盘）
+ * Config Store — 集中的结构化配置仓库（单一数据源 + 落盘）
  *
  * 把原先散落在 server.ts / runtime.ts / memory.ts 里、启动时从 process.env
  * 冻结的 Agent 行为参数收敛到这里。消费点改为每次读 get()，因此前台改完
@@ -184,7 +184,7 @@ export function normalizeConfigDocument(value: any): SagentConfigDocument {
   } as SagentConfigDocument;
 }
 
-export const runtimeConfig = {
+export const configStore = {
   /** 启动时调用一次：设定落盘目录并加载 json 覆盖。 */
   async init(persistDir: string): Promise<RuntimeConfig> {
     envState = configDefaultsFromEnv();
@@ -249,12 +249,18 @@ export const runtimeConfig = {
     return JSON.parse(JSON.stringify(document.tools || {}));
   },
 
-  execution() {
+  execution(env: Record<string, string | undefined> = process.env) {
     const stored = document.execution || {};
+    const envBool = (name: string, fallback: boolean) => {
+      const raw = env[name];
+      if (raw == null || String(raw).trim() === '') return fallback;
+      return ['1', 'true', 'yes', 'on'].includes(String(raw).trim().toLowerCase());
+    };
     return {
-      resume: stored.resume ?? process.env.AGENT_RESUME !== 'false',
-      sandboxedWorkers: stored.sandboxedWorkers ?? process.env.AGENT_SANDBOXED_WORKERS === 'true',
-      workerSandbox: stored.workerSandbox ?? process.env.AGENT_WORKER_SANDBOX !== 'false',
+      resume: envBool('AGENT_RESUME', stored.resume ?? true),
+      // execution 是启动期部署选择；显式环境变量优先，确保 npm run sandbox 语义稳定。
+      sandboxedWorkers: envBool('AGENT_SANDBOXED_WORKERS', stored.sandboxedWorkers ?? false),
+      workerSandbox: envBool('AGENT_WORKER_SANDBOX', stored.workerSandbox ?? true),
     };
   },
 
@@ -311,4 +317,4 @@ export const runtimeConfig = {
   },
 };
 
-export type RuntimeConfigStore = typeof runtimeConfig;
+export type ConfigStore = typeof configStore;

--- a/agent/core/memory.ts
+++ b/agent/core/memory.ts
@@ -37,7 +37,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { cleanText } from './utils.ts';
-import { runtimeConfig } from './runtime-config.ts';
+import { configStore } from './config-store.ts';
 
 const MEMORY_FILE = 'agent-memory.json';
 const MAX_CHARS = 3000;
@@ -256,7 +256,7 @@ export function extractProjectKnowledge(memory, { task: _task, result }) {
 }
 
 export async function compactConversationMemory(memory, { maxEntries, summarizeFn }: { maxEntries?: number; summarizeFn?: (text: string) => Promise<string> } = {}) {
-  if (maxEntries == null) maxEntries = runtimeConfig.get().memoryMaxEntries;
+  if (maxEntries == null) maxEntries = configStore.get().memoryMaxEntries;
   const conv = memory.conversation;
   if (conv.length <= maxEntries) {
     return;

--- a/agent/core/planner.ts
+++ b/agent/core/planner.ts
@@ -19,7 +19,7 @@ import {
   buildChatCompletionRequest,
   createChatCompletionWithTemplateFallback,
 } from './openai-compatible-request.ts';
-import { runtimeConfig } from './runtime-config.ts';
+import { configStore } from './config-store.ts';
 
 // 每一步只需产出一个结构化动作；过大的输出预算会放大推理延迟和供应商超时风险。
 const DEFAULT_AGENT_MAX_TOKENS = 4_096;
@@ -119,7 +119,7 @@ export function createJsonPlanner({
   return async ({ model, signal = null, ...context }) => {
     let messages = buildMessages(context);
     const configuredMaxTokens = Number(context.maxOutputTokens)
-      || runtimeConfig.get().maxOutputTokens
+      || configStore.get().maxOutputTokens
       || maxTokens;
     let requestMaxTokens = resolveAgentMaxTokens({
       model,

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -1,6 +1,6 @@
 import { buildIdePromptLines, isIdeMcpEnabled } from '../tools/ide/mcp-client.ts';
 import { buildChromePromptLines, isChromeMcpEnabled } from '../tools/chrome/mcp-client.ts';
-import { runtimeConfig } from './runtime-config.ts';
+import { configStore } from './config-store.ts';
 
 type PromptCapabilityContext = {
   task?: string;
@@ -131,7 +131,7 @@ function promptResultText(value: any) {
 
 export function compactAgentHistory(history: any[], maxEntries?: number, maxResultChars?: number) {
   if (!Array.isArray(history) || history.length === 0) return [];
-  const config = runtimeConfig.get();
+  const config = configStore.get();
   const entryLimit = maxEntries ?? config.maxHistorySteps;
   const resultLimit = maxResultChars ?? config.maxResultChars;
   return history.slice(-entryLimit).map(entry => {

--- a/agent/core/providers/gemini.ts
+++ b/agent/core/providers/gemini.ts
@@ -22,7 +22,7 @@ import { initSse, writeSse, writeSseDone } from '../../../helpers/streaming.ts';
 import { retryAsync } from '../../../helpers/retry.ts';
 import { buildSummaryPrompt } from './summary-prompt.ts';
 import { extractModelMetadata } from './model-metadata.ts';
-import { runtimeConfig } from '../runtime-config.ts';
+import { configStore } from '../config-store.ts';
 import type {
   LLMProvider,
   ModelInfo,
@@ -133,7 +133,7 @@ export function createGeminiProvider(client: GoogleGenAI): LLMProvider {
       const maxOutputTokens = resolveAgentMaxTokens({
         model,
         modelConfig,
-        requestedMaxTokens: runtimeConfig.get().maxOutputTokens,
+        requestedMaxTokens: configStore.get().maxOutputTokens,
         promptPayload: { systemInstruction: system, contents, tools, toolConfig },
       });
 

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -36,7 +36,7 @@ import {
   HEALTH_CHECKPOINT_INTERVAL,
 } from "./checkpoint.js";
 import { assessResultQuality } from "./result-quality.ts";
-import { runtimeConfig } from "./runtime-config.ts";
+import { configStore } from "./config-store.ts";
 import type {
   AgentAction,
   AgentStep,
@@ -58,7 +58,7 @@ function observationText(observation: unknown, key: 'url' | 'title'): string | u
 
 function compressHistory(history: AgentStep[], maxSteps?: number) {
   // 历史截断预算每次从运行时配置读取，前台改完无需重启即生效
-  const { maxHistorySteps, maxResultChars: MAX_RESULT_CHARS, maxParallelResultChars: MAX_PARALLEL_RESULT_CHARS } = runtimeConfig.get();
+  const { maxHistorySteps, maxResultChars: MAX_RESULT_CHARS, maxParallelResultChars: MAX_PARALLEL_RESULT_CHARS } = configStore.get();
   if (maxSteps == null) maxSteps = maxHistorySteps;
   // Progressive truncation: recent steps keep more context, old steps get shorter results
   const truncateEntry = (h, remaining) => {

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -46,7 +46,7 @@ import { observeDesktopAgent } from './observer.ts';
 import { createDesktopPlanner, DEFAULT_MODEL_TIMEOUT_MS } from './planner.ts';
 import { saveCheckpoint, saveHealthySnapshot } from '../core/checkpoint.ts';
 import { log } from '../../helpers/logger.ts';
-import { runtimeConfig } from '../core/runtime-config.ts';
+import { configStore } from '../core/config-store.ts';
 import type { ProviderRegistry } from '../core/providers/registry.ts';
 import type { ModelInfo } from '../core/providers/types.ts';
 import type {
@@ -91,9 +91,9 @@ export function createDesktopAgentRunner({
   const { ensureBrowserSession } = createSharedBrowserSessionManager();
 
   // Agent 行为参数每次 run 实时读取（前台改完无需重启即生效）；
-  // 构造参数（maxSteps 等）保留为兜底，运行时优先用 runtimeConfig。
+  // 构造参数（maxSteps 等）保留为兜底，运行时优先用 configStore。
   function liveConfig() {
-    const c = runtimeConfig.get();
+    const c = configStore.get();
     return {
       maxSteps: c.maxSteps,
       modelTimeoutMs: c.modelTimeoutSec * 1000,

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { log } from '../../../helpers/logger.ts';
-import { runtimeConfig } from '../../core/runtime-config.ts';
+import { configStore } from '../../core/config-store.ts';
 
 const DEFAULT_PROTOCOL_VERSIONS = ['2025-03-26', '2024-11-05'];
 const DEFAULT_SSE_HOST = '127.0.0.1';
@@ -165,7 +165,7 @@ function clientKey(config) {
 }
 
 export function isChromeMcpEnabled(env = process.env) {
-  const configured = runtimeConfig.mcpServers().chrome;
+  const configured = configStore.mcpServers().chrome;
   if (configured) return configured.enabled;
   // 显式开关优先；只要配置了任一连接参数，也视为用户想启用 Chrome MCP。
   if (envFlag(env.CHROME_MCP_ENABLED)) {
@@ -229,7 +229,7 @@ export function buildChromePromptLines(env = process.env) {
 }
 
 export function loadChromeMcpConfig(env = process.env) {
-  const configured = runtimeConfig.mcpServers().chrome;
+  const configured = configStore.mcpServers().chrome;
   if (configured) {
     const transport = configured.transport;
     return {

--- a/agent/tools/ide/mcp-client.ts
+++ b/agent/tools/ide/mcp-client.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import { log } from '../../../helpers/logger.ts';
-import { runtimeConfig } from '../../core/runtime-config.ts';
+import { configStore } from '../../core/config-store.ts';
 
 const DEFAULT_PROTOCOL_VERSIONS = ['2025-03-26', '2024-11-05'];
 const DEFAULT_SSE_HOST = '127.0.0.1';
@@ -154,7 +154,7 @@ function toolKey(config) {
 }
 
 export function isIdeMcpEnabled(env = process.env) {
-  const configured = runtimeConfig.mcpServers().jetbrains;
+  const configured = configStore.mcpServers().jetbrains;
   if (configured) return configured.enabled;
   if (envFlag(env.IDE_MCP_ENABLED)) {
     return true;
@@ -181,7 +181,7 @@ export function buildIdePromptLines(env = process.env) {
 }
 
 export function loadIdeMcpConfig(env = process.env) {
-  const configured = runtimeConfig.mcpServers().jetbrains;
+  const configured = configStore.mcpServers().jetbrains;
   if (configured) {
     const transport = configured.transport;
     const projectPath = toAbsolutePath(configured.projectPath || '.', process.cwd());

--- a/agent/tools/macos/observe.ts
+++ b/agent/tools/macos/observe.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { execFile } from 'node:child_process';
 import { getMacOSCapabilityReport } from './permissions.ts';
 import { invokeMacOSHelper, resolveMacOSBackend } from './helper-client.ts';
-import { runtimeConfig } from '../../core/runtime-config.ts';
+import { configStore } from '../../core/config-store.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCREENSHOT_DIR = path.resolve(__dirname, '../../../data/screenshots');
@@ -34,7 +34,7 @@ async function captureScreenshot(runId, signal?: AbortSignal) {
   const filePath = path.join(dirPath, `screen-${Date.now()}.png`);
   try {
     await execFileText('screencapture', ['-x', '-t', 'png', filePath], signal);
-    const redaction = runtimeConfig.tools().screenshots?.redaction || process.env.AGENT_SCREENSHOT_REDACTION || 'pixelate';
+    const redaction = configStore.tools().screenshots?.redaction || process.env.AGENT_SCREENSHOT_REDACTION || 'pixelate';
     if (redaction !== 'none') {
       try {
         await execFileText('sips', ['-z', '48', '72', filePath], signal);

--- a/agent/worker/agent-worker.ts
+++ b/agent/worker/agent-worker.ts
@@ -106,18 +106,18 @@ async function main() {
   const { createProviderRegistry } = await import('../core/providers/registry.ts');
   const { createDesktopAgentRunner } = await import('../desktop/agent.ts');
   const { initLlmLogger, flushLlmLogs } = await import('../core/llm-logger.ts');
-  const { runtimeConfig } = await import('../core/runtime-config.ts');
+  const { configStore } = await import('../core/config-store.ts');
   const { DEFAULT_VISION_MODEL } = await import('../tools/vision/execute.ts');
   flushLlmLogsBeforeExit = flushLlmLogs;
 
   const memoryDir = payload.memoryDir || process.env.MEMORY_DIR || 'data';
-  await runtimeConfig.init(memoryDir);
+  await configStore.init(memoryDir);
   initLlmLogger(memoryDir);
 
   const { openai_client, gemini_client } = createClients();
   const registry = createProviderRegistry({ openai_client, gemini_client });
   const modelConfig = Array.isArray(payload.modelConfig) ? payload.modelConfig : [];
-  const cfg = runtimeConfig.get();
+  const cfg = configStore.get();
   const runDesktopAgent = createDesktopAgentRunner({
     registry,
     openai_client,

--- a/client/ARCHITECTURE.md
+++ b/client/ARCHITECTURE.md
@@ -95,34 +95,32 @@ client/src/
 
 ```
 ┌───────────────────────────────────────────────────────────────┐
-│ 1-51    import：组件、hook、工具函数                            │
-│ 53-99   辅助函数：附件拼接、模型 ID 清洗、trace 模型提取          │
+│ import：组件、hook、API 和工具函数                               │
+│ 辅助函数：附件拼接、模型 ID 清洗、trace 模型提取                  │
 ├───────────────────────────────────────────────────────────────┤
-│ 101     function App()  ← 应用根组件                           │
+│ function App()  ← 应用根组件                                   │
 │                                                               │
-│ 101-226 ① 状态声明区                                           │
-│ 228-258 ② 启动初始化：拉后端模型列表                            │
-│ 262-266 ③ 同步浏览器地址栏颜色（useThemeColorSync）             │
-│ 268-470 ④ Agent SSE 重连 effect（最复杂的一块）                 │
-│ 479-555 ⑤ 可见性兜底（手机后台漏事件的补救）                    │
-│ 557-633 ⑥ 零碎 effects：聚焦/滚动/建议/textarea 自适应高度      │
-│ 635-641 ⑦ 卸载清理                                            │
+│ ① 状态与持久化 hook                                            │
+│ ② 启动初始化：拉取后端模型、项目和推荐任务                       │
+│ ③ 顶层 effects：主题、Agent SSE 重连、可见性兜底                 │
+│ ④ 交互 effects：聚焦、滚动、快捷键和 textarea 高度               │
+│ ⑤ 卸载清理                                                     │
 │                                                               │
-│ 643-739 ⑧ 业务 handler / hook：session / project / agent /附件 │
-│ 741-786 ⑨ handleSubmit / handleKeyDown                        │
-│ 788-847 ⑩ 派生数据 + 工具栏 slot 变量                          │
+│ ⑥ 业务 handler / hook：session、project、agent、附件            │
+│ ⑦ 提交、停止、审批、回滚和快捷键                                │
+│ ⑧ 派生数据 + 工具栏 slot 变量                                   │
 │                                                               │
-│ 849-1015 ⑪ return (...)：实际渲染的 JSX                       │
+│ ⑨ return (...)：实际渲染的 JSX                                │
 └───────────────────────────────────────────────────────────────┘
 ```
 
-`App` 这个函数会被 React **反复调用**——任何 state 变了就调一次。①-⑩ 区每次渲染都重跑（`useEffect` 内部按依赖触发），⑪ 是当次渲染要画的东西。
+`App` 这个函数会被 React **反复调用**——任何 state 变了就调一次。上面的分区描述职责，不绑定具体行号；重构后应保持职责边界，而不是维持某个行号范围。
 
 ---
 
 ## 3. 区域详解
 
-### ① 状态声明（101-226）
+### ① 状态声明
 
 | 状态 | 来源 | 用途 |
 |---|---|---|
@@ -142,18 +140,18 @@ client/src/
 - `useState` 的值用 `set*` 改，会重渲染。
 - `useRef` 的值用 `.current` 读写，**不会**重渲染。
 
-### ② 拉后端模型列表（228-258）
+### ② 拉后端模型列表
 
 挂载时 `apiFetch('/api/models')`：
 1. 更新 `availableModels`；
 2. 顺手扫一遍历史会话，清除已经下线的 `model/modelsUsed` 引用，不自动替换成首个可用模型；
 3. 设 `modelsLoaded = true`，让"清理用户多选模型"effect 才敢动手。Agent 运行前仍要求用户在模型选择器里手动选择至少一个模型。
 
-### ③ `useThemeColorSync`（262-266）
+### ③ `useThemeColorSync`
 
 把 `<meta name="theme-color">` 改成当前主背景色，让手机浏览器顶部地址栏跟着变色。逻辑全在 hook 里。
 
-### ④ Agent SSE 重连 effect（268-470）⭐
+### ④ Agent SSE 重连 effect ⭐
 
 **场景**：用户开了 Agent 任务，**刷新了页面**。后端还在跑，UI 必须接回来。
 
@@ -181,13 +179,13 @@ client/src/
 - `updateActiveSession` 不能依赖闭包里的 `activeSession`，因为回调可能在很久之后触发；它每次从最新 `chatState` 里拿 `activeSessionId`。
 - SSE 重连时同一批事件可能被回放两次，所以追加前按 `type / step / stage / model` 去重。
 
-### ⑤ 可见性兜底（479-555）
+### ⑤ 可见性兜底
 
 **场景**：手机切到后台时浏览器会冻结 JS、节流网络，SSE reader 可能漏掉 `done` / `error`。
 
 **做法**：监听 `visibilitychange`，切回前台时如果 UI 还以为 agent 在跑，就调 `fetchAgentTrace(rid)` 拉持久化的 trace。如果里面已经有终止事件（`done` / `error`），就把答案灌回去、收掉 running 状态、关掉所有挂起弹窗——避免"任务已结束但 UI 一直转圈"。
 
-### ⑥ 零碎 effects（557-633）
+### ⑥ 零碎 effects
 
 - **挂载聚焦**：进页面自动 focus 输入框。
 - **会话切换同步 trace**：切到另一个会话时，把那个会话的 agentTrace 拉出来（去重后写入），并把"上次 agent 任务原文"记到 ref 里供 rollback 重试用。
@@ -196,13 +194,13 @@ client/src/
 - **建议数据刷新**：从后端拉取推荐任务；提交任务后刷新"最近使用"。
 - **textarea 自适应高度**：根据 `input` 长度计算，最高 144px。
 
-### ⑦ 卸载清理（635-641）
+### ⑦ 卸载清理
 
 组件卸载（页面关闭、导航）时：
 - 中止 Agent 的网络流；
 - 拒绝挂起的审批 Promise（避免悬挂的 `await`）。
 
-### ⑧ 业务 handler / hook（643-739，843-847）
+### ⑧ 业务 handler / hook
 
 | Hook | 返回 | 干嘛 |
 |---|---|---|
@@ -214,14 +212,14 @@ client/src/
 
 **为什么抽 hook**：把"一坨相关的状态+函数"打包，避免 App.jsx 里全是 200 行的内联函数。
 
-### ⑨ 提交 + 快捷键（741-786）
+### ⑨ 提交 + 快捷键
 
 ```js
 handleSubmit  // 按发送：校验输入/附件/模型 → 拼任务文本 → 调 sendAgentTask
 handleKeyDown // 桌面按 Cmd/Ctrl+Enter 发送；手机不拦截（要换行）
 ```
 
-### ⑩ 派生数据 + slot 变量（788-847）
+### ⑩ 派生数据 + slot 变量
 
 派生数据：
 ```js
@@ -247,7 +245,7 @@ React 里可以把一段 JSX 表达式**赋给变量**，之后多处插入。`m
 
 业内叫 **slot pattern** / **render prop**——把 JSX 当数据传。
 
-### ⑪ 最后的 return JSX（849-1015）
+### ⑪ 最后的 return JSX
 
 骨架：
 
@@ -357,7 +355,7 @@ App.jsx 主要做三件事：
 | `components/NotificationBanner.jsx` | 桌面通知权限提示 banner |
 | `components/ScreenshotImages.jsx` | Agent trace 中嵌入的截图 |
 | `components/dialogs/ResetDialog.jsx` | 清空会话确认弹窗 |
-| `components/dialogs/SettingsDialog.jsx` | 设置弹窗（记忆开关等） |
+| `components/dialogs/SettingsDialog.jsx` | 外观、Agent Profiles、基础/高级参数、记忆、MCP 连接和 API Key 状态 |
 | `components/dialogs/ApprovalDialog.jsx` | Agent 操作审批弹窗 |
 | `components/dialogs/QuestionDialog.jsx` | Agent 反向提问弹窗 |
 | `components/dialogs/ProjectDialog.jsx` | 项目创建/编辑弹窗 |

--- a/helpers/config-deprecations.ts
+++ b/helpers/config-deprecations.ts
@@ -1,5 +1,5 @@
 import { AGENT_CONFIG_KEYS, AGENT_CONFIG_SCHEMA } from '../agent/core/config-schema.ts';
-import type { RuntimeConfigStore } from '../agent/core/runtime-config.ts';
+import type { ConfigStore } from '../agent/core/config-store.ts';
 import { log } from './logger.ts';
 
 const REMOVED_VARIABLES = ['MODELS', 'AGENT_MULTI_MODELS', 'AGENT_HEADLESS'];
@@ -7,7 +7,7 @@ const LEGACY_CHROME_PREFIX = 'CHROME_MCP_';
 const LEGACY_IDE_PREFIX = 'IDE_MCP_';
 
 export function warnLegacyConfiguration(
-  runtimeConfig: RuntimeConfigStore,
+  configStore: ConfigStore,
   env: Record<string, string | undefined> = process.env,
 ) {
   const removed = REMOVED_VARIABLES.filter(key => env[key] != null && String(env[key]).trim() !== '');
@@ -22,7 +22,7 @@ export function warnLegacyConfiguration(
     log.warn(`[Config] Agent 调优环境变量仅作为兼容默认值，请迁移到 data/config.json 或设置页: ${tuning.join(', ')}`);
   }
 
-  const stored = runtimeConfig.mcpServers();
+  const stored = configStore.mcpServers();
   const chromeLegacy = Object.keys(env).filter(key => key.startsWith(LEGACY_CHROME_PREFIX) && env[key]);
   const ideLegacy = Object.keys(env).filter(key => key.startsWith(LEGACY_IDE_PREFIX) && env[key]);
   if (!stored.chrome && chromeLegacy.length > 0) {

--- a/routes/agent-config.ts
+++ b/routes/agent-config.ts
@@ -57,8 +57,8 @@ async function testMcpConnection(name: string) {
   throw new Error(`暂不支持测试 MCP server: ${name}`);
 }
 
-function effectiveMcpServers(runtimeConfig: AgentRouterContext['runtimeConfig']) {
-  const stored = runtimeConfig.mcpServers();
+function effectiveMcpServers(configStore: AgentRouterContext['configStore']) {
+  const stored = configStore.mcpServers();
   const sources: Record<string, 'user' | 'env' | 'default'> = {};
   const servers: Record<string, any> = { ...stored };
   for (const name of Object.keys(stored)) sources[name] = 'user';
@@ -95,17 +95,17 @@ function effectiveMcpServers(runtimeConfig: AgentRouterContext['runtimeConfig'])
   return { servers, sources };
 }
 
-export function createAgentConfigRouter({ runtimeConfig }: AgentRouterContext) {
+export function createAgentConfigRouter({ configStore }: AgentRouterContext) {
   const router = Router();
-  const configPayload = (agent = runtimeConfig.get()) => {
-    const mcp = effectiveMcpServers(runtimeConfig);
+  const configPayload = (agent = configStore.get()) => {
+    const mcp = effectiveMcpServers(configStore);
     return {
       agent,
-      defaults: runtimeConfig.defaults(),
-      sources: runtimeConfig.sources(),
-      schema: runtimeConfig.schema(),
-      profiles: runtimeConfig.profiles(),
-      profile: runtimeConfig.document().profile || 'custom',
+      defaults: configStore.defaults(),
+      sources: configStore.sources(),
+      schema: configStore.schema(),
+      profiles: configStore.profiles(),
+      profile: configStore.document().profile || 'custom',
       mcpServers: mcp.servers,
       mcpSources: mcp.sources,
     };
@@ -119,7 +119,7 @@ export function createAgentConfigRouter({ runtimeConfig }: AgentRouterContext) {
   // 更新 Agent 行为参数；校验失败返回 400 + 原因，成功后落盘并下次任务即生效。
   router.post('/api/config', async (req, res) => {
     try {
-      const agent = await runtimeConfig.update(req.body ?? {});
+      const agent = await configStore.update(req.body ?? {});
       res.json(configPayload(agent));
     } catch (err: any) {
       res.status(400).json({ error: err?.message || tReq(req, 'config.validationFailed') });
@@ -128,13 +128,13 @@ export function createAgentConfigRouter({ runtimeConfig }: AgentRouterContext) {
 
   // 清空前台覆盖，回到 .env 默认值。
   router.post('/api/config/reset', async (_req, res) => {
-    const agent = await runtimeConfig.reset();
+    const agent = await configStore.reset();
     res.json(configPayload(agent));
   });
 
   router.post('/api/config/profile', async (req, res) => {
     try {
-      const agent = await runtimeConfig.applyProfile(req.body?.profile);
+      const agent = await configStore.applyProfile(req.body?.profile);
       res.json(configPayload(agent));
     } catch (err: any) {
       res.status(400).json({ error: err?.message || tReq(req, 'config.validationFailed') });
@@ -143,7 +143,7 @@ export function createAgentConfigRouter({ runtimeConfig }: AgentRouterContext) {
 
   router.put('/api/config/mcp/:name', async (req, res) => {
     try {
-      const mcpServers = await runtimeConfig.updateMcpServer(req.params.name, req.body);
+      const mcpServers = await configStore.updateMcpServer(req.params.name, req.body);
       res.json({ mcpServers });
     } catch (err: any) {
       res.status(400).json({ error: err?.message || tReq(req, 'config.validationFailed') });
@@ -152,7 +152,7 @@ export function createAgentConfigRouter({ runtimeConfig }: AgentRouterContext) {
 
   router.delete('/api/config/mcp/:name', async (req, res) => {
     try {
-      const mcpServers = await runtimeConfig.updateMcpServer(req.params.name, null);
+      const mcpServers = await configStore.updateMcpServer(req.params.name, null);
       res.json({ mcpServers });
     } catch (err: any) {
       res.status(400).json({ error: err?.message || tReq(req, 'config.validationFailed') });

--- a/routes/agent-types.ts
+++ b/routes/agent-types.ts
@@ -1,6 +1,6 @@
 import type { ProviderRegistry } from '../agent/core/providers/registry.ts';
 import type { ModelInfo } from '../agent/core/providers/types.ts';
-import type { RuntimeConfigStore } from '../agent/core/runtime-config.ts';
+import type { ConfigStore } from '../agent/core/config-store.ts';
 import type { ProjectStore } from '../agent/core/project-store.ts';
 import type {
   AgentRunStore,
@@ -18,6 +18,6 @@ export interface AgentRouterContext {
   domainRules?: DomainRules;
   modelConfig: ModelInfo[];
   registry: ProviderRegistry;
-  runtimeConfig: RuntimeConfigStore;
+  configStore: ConfigStore;
   projectStore: ProjectStore;
 }

--- a/server.ts
+++ b/server.ts
@@ -42,7 +42,7 @@ import { createBaseEventSender, loadMemoryForPrompt, cleanupAgentRun } from './h
 import { readTraceEvents } from './helpers/trace-store.ts';
 import { padEndW, truncateW } from './agent/core/utils.ts';
 import { log } from './helpers/logger.ts';
-import { runtimeConfig } from './agent/core/runtime-config.ts';
+import { configStore } from './agent/core/config-store.ts';
 import { createApiAuth, createCorsOptions, createOriginGuard, loadServerSecurityConfig } from './helpers/security.ts';
 import { flushAllPersistenceTasks } from './helpers/persistence-queue.ts';
 import { persistRecoveredAgentRunMemory } from './routes/agent-run-memory-persist.ts';
@@ -70,11 +70,11 @@ const CHECKPOINT_DIR = MEMORY_DIR;
 
 initLlmLogger(MEMORY_DIR);
 initWebViewDataStore(MEMORY_DIR);
-// 运行时配置层：读取版本化 data/config.json，并兼容迁移旧 runtime-config.json。
+// 配置仓库：读取版本化 data/config.json，并兼容迁移旧 runtime-config.json。
 // 必须在 createDesktopAgentRunner 之前 init，且供 runtime.ts/memory.ts 热读取。
-await runtimeConfig.init(MEMORY_DIR);
-warnLegacyConfiguration(runtimeConfig);
-const executionConfig = runtimeConfig.execution();
+await configStore.init(MEMORY_DIR);
+warnLegacyConfiguration(configStore);
+const executionConfig = configStore.execution();
 const AGENT_RESUME = executionConfig.resume;
 
 // 项目注册表：每个项目隔离记忆/trace/checkpoint/uploads 与文件工具根。
@@ -82,12 +82,12 @@ const AGENT_RESUME = executionConfig.resume;
 const projectStore = createProjectStore(MEMORY_DIR);
 await projectStore.init();
 
-const VISION_MODEL = (runtimeConfig.tools().vision?.model || process.env.VISION_MODEL || DEFAULT_VISION_MODEL).trim();
+const VISION_MODEL = (configStore.tools().vision?.model || process.env.VISION_MODEL || DEFAULT_VISION_MODEL).trim();
 const AGENT_SANDBOXED_WORKERS = executionConfig.sandboxedWorkers;
 const AGENT_WORKER_SANDBOX = executionConfig.workerSandbox;
 const agentRunStore = createAgentRunStore();
 const approvalStore = createApprovalStore();
-const initialAgentConfig = runtimeConfig.get();
+const initialAgentConfig = configStore.get();
 const directRunDesktopAgent = createDesktopAgentRunner({
   registry,
   openai_client,
@@ -119,7 +119,7 @@ runDesktopAgent.domainRules = directRunDesktopAgent.domainRules;
 const SCREENSHOT_DIR = path.join(MEMORY_DIR, 'screenshots');
 app.use('/screenshots', express.static(SCREENSHOT_DIR));
 
-app.use(createAgentRouter({ runDesktopAgent, agentRunStore, approvalStore, memoryDir: MEMORY_DIR, checkpointDir: CHECKPOINT_DIR, domainRules: runDesktopAgent.domainRules, modelConfig, registry, runtimeConfig, projectStore }));
+app.use(createAgentRouter({ runDesktopAgent, agentRunStore, approvalStore, memoryDir: MEMORY_DIR, checkpointDir: CHECKPOINT_DIR, domainRules: runDesktopAgent.domainRules, modelConfig, registry, configStore, projectStore }));
 app.use(createCompletionsRouter({ registry, modelConfig }));
 app.use(createSuggestionsRouter({ store: createSuggestionStore(path.join(__dirname, 'data')) }));
 
@@ -228,7 +228,7 @@ async function collectAllCheckpoints() {
 }
 
 const httpServer = app.listen(Number(PORT), HOST, async () => {
-  const cfg = runtimeConfig.get();
+  const cfg = configStore.get();
   const ideConfig = loadIdeMcpConfig();
   const chromeConfig = loadChromeMcpConfig();
   const W = 56;

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -39,7 +39,7 @@ beforeEach(async () => {
   const { createAgentRouter } = await import('../routes/agent.js');
   const { createAgentRunStore } = await import('../helpers/run-store.js');
   const { createApprovalStore } = await import('../agent/core/approval-store.js');
-  const { runtimeConfig } = await import('../agent/core/runtime-config.js');
+  const { configStore } = await import('../agent/core/config-store.js');
   const { createProjectStore } = await import('../agent/core/project-store.js');
 
   agentRunStore = createAgentRunStore();
@@ -57,7 +57,7 @@ beforeEach(async () => {
     domainRules: null,
     modelConfig: [{ id: 'test-model', label: 'test-model', provider: 'test' }],
     registry: mockRegistry,
-    runtimeConfig,
+    configStore,
     projectStore,
   });
 
@@ -237,7 +237,7 @@ describe('POST /api/agent', () => {
       domainRules: null,
       modelConfig: [{ id: 'test-model', provider: 'test' }],
       registry: mockRegistry,
-      runtimeConfig: {},
+      configStore: {},
       projectStore: {
         get() {
           throw new Error('project lookup failed');

--- a/test/config-store.test.ts
+++ b/test/config-store.test.ts
@@ -2,37 +2,37 @@ import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { runtimeConfig } from '../agent/core/runtime-config.ts';
+import { configStore } from '../agent/core/config-store.ts';
 
 describe('structured configuration store', () => {
   it('migrates legacy runtime-config.json to versioned config.json', async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-config-migrate-'));
     await writeFile(path.join(dir, 'runtime-config.json'), JSON.stringify({ maxSteps: 33 }));
 
-    await runtimeConfig.init(dir);
+    await configStore.init(dir);
 
-    expect(runtimeConfig.get().maxSteps).toBe(33);
-    expect(runtimeConfig.sources().maxSteps).toBe('user');
+    expect(configStore.get().maxSteps).toBe(33);
+    expect(configStore.sources().maxSteps).toBe('user');
     const saved = JSON.parse(await readFile(path.join(dir, 'config.json'), 'utf8'));
     expect(saved).toMatchObject({ version: 1, agent: { maxSteps: 33 }, mcpServers: {} });
   });
 
   it('persists generic SSE and stdio MCP server entries', async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-config-mcp-'));
-    await runtimeConfig.init(dir);
+    await configStore.init(dir);
 
-    await runtimeConfig.updateMcpServer('chrome', {
+    await configStore.updateMcpServer('chrome', {
       enabled: true,
       transport: { type: 'sse', url: 'http://127.0.0.1:3099/sse' },
       promptMode: 'lazy',
     });
-    await runtimeConfig.updateMcpServer('jetbrains', {
+    await configStore.updateMcpServer('jetbrains', {
       enabled: true,
       transport: { type: 'stdio', command: 'npx', args: ['-y', '@jetbrains/mcp-proxy'] },
       projectPath: '.',
     });
 
-    expect(runtimeConfig.mcpServers()).toMatchObject({
+    expect(configStore.mcpServers()).toMatchObject({
       chrome: { enabled: true, transport: { type: 'sse' } },
       jetbrains: { enabled: true, transport: { type: 'stdio' } },
     });
@@ -43,22 +43,46 @@ describe('structured configuration store', () => {
 
   it('resets a profile durably while preserving other config sections', async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-config-reset-'));
-    await runtimeConfig.init(dir);
-    await runtimeConfig.applyProfile('deep');
-    await runtimeConfig.updateMcpServer('chrome', {
+    await configStore.init(dir);
+    await configStore.applyProfile('deep');
+    await configStore.updateMcpServer('chrome', {
       enabled: false,
       transport: { type: 'sse', url: 'http://127.0.0.1:3099/sse' },
     });
 
-    await runtimeConfig.reset();
+    await configStore.reset();
 
     const saved = JSON.parse(await readFile(path.join(dir, 'config.json'), 'utf8'));
     expect(saved.profile).toBe('custom');
     expect(saved.agent).toEqual({});
     expect(saved.mcpServers.chrome.transport.url).toBe('http://127.0.0.1:3099/sse');
 
-    await runtimeConfig.init(dir);
-    expect(runtimeConfig.document().profile).toBe('custom');
-    expect(runtimeConfig.get()).toEqual(runtimeConfig.defaults());
+    await configStore.init(dir);
+    expect(configStore.document().profile).toBe('custom');
+    expect(configStore.get()).toEqual(configStore.defaults());
+  });
+
+  it('lets explicit startup environment override stored execution mode', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-config-execution-'));
+    await writeFile(path.join(dir, 'config.json'), JSON.stringify({
+      version: 1,
+      execution: { sandboxedWorkers: false, workerSandbox: false, resume: false },
+    }));
+    await configStore.init(dir);
+
+    expect(configStore.execution({})).toEqual({
+      sandboxedWorkers: false,
+      workerSandbox: false,
+      resume: false,
+    });
+    expect(configStore.execution({
+      AGENT_SANDBOXED_WORKERS: 'true',
+      AGENT_WORKER_SANDBOX: 'true',
+      AGENT_RESUME: 'true',
+    })).toEqual({
+      sandboxedWorkers: true,
+      workerSandbox: true,
+      resume: true,
+    });
   });
 });

--- a/test/config-validation.test.ts
+++ b/test/config-validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { computeEnvDefaults, validateConfig, mergeConfig } from '../agent/core/runtime-config.js';
+import { computeEnvDefaults, validateConfig, mergeConfig } from '../agent/core/config-store.js';
 
-describe('computeEnvDefaults', () => {
+describe('config validation and effective defaults', () => {
   it('空 env 用内置默认值（与改造前各处默认一致）', () => {
     const d = computeEnvDefaults({});
     expect(d).toEqual({


### PR DESCRIPTION
## Summary
- add a repository-wide architecture guide covering API, Agent runtime, workers, configuration and persistence
- align English, Chinese and client documentation with current Settings, authentication and MCP behavior
- rename runtime-config to config-store to reflect its persistence and structured-document responsibilities
- make explicit startup execution environment values override stored preferences so npm run sandbox remains deterministic

## Verification
- npm test (45 files, 283 tests)
- npm run lint
- client npm run lint
- npm run typecheck
- npm run build