### PR TITLE
feat: align Gemini prompts and load tools dynamically

### DIFF
--- a/agent/core/context-estimate.ts
+++ b/agent/core/context-estimate.ts
@@ -1,9 +1,7 @@
 import {
-  buildDesktopAgentSystemPrompt,
-  buildGeminiTaskMessages,
+  buildGeminiAgentPromptPayload,
   buildNvidiaTaskMessages,
 } from './prompts.ts';
-import { createModelTools } from './tool-definitions.ts';
 
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const PROMPT_PREVIEW_CHAR_LIMIT = 60_000;
@@ -184,13 +182,7 @@ function buildPlanningPayload({
   };
 
   if (providerName === 'gemini') {
-    const { contents } = buildGeminiTaskMessages(baseContext);
-    return {
-      systemInstruction: buildDesktopAgentSystemPrompt(systemPrompt || '', 'full', baseContext),
-      contents,
-      tools: createModelTools(),
-      toolConfig: { functionCallingConfig: { mode: 'ANY' } },
-    };
+    return buildGeminiAgentPromptPayload(baseContext);
   }
 
   return {

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -1,19 +1,89 @@
 import { buildIdePromptLines, isIdeMcpEnabled } from '../tools/ide/mcp-client.ts';
 import { buildChromePromptLines, isChromeMcpEnabled } from '../tools/chrome/mcp-client.ts';
 import { configStore } from './config-store.ts';
+import { createModelTools, toolToGeminiTool } from './tool-definitions.ts';
 
 type PromptCapabilityContext = {
   task?: string;
   history?: any[];
   observation?: any;
+  conversationHistory?: Array<{ role?: string; content?: string }>;
+  includeInactiveCapabilityHints?: boolean;
 };
 
 const CHROME_TASK_RE = /\bchrome\b|devtools|开发者工具|真实浏览器|网络面板|performance|lighthouse|控制台|console/i;
 const IDE_TASK_RE = /\bide\b|jetbrains|intellij|webstorm|pycharm|goland|运行配置|重命名重构|代码检查/i;
 const BROWSER_BLOCK_RE = /captcha|cloudflare|403|forbidden|人机验证|反爬|访问受限|被拦截|blocked/i;
+const WEB_TASK_RE = /https?:\/\/|\bwww\.|\bweb\b|browser|website|search|news|weather|price|flight|hotel|online|网页|浏览器|网站|上网|搜索|查询|新闻|天气|实时|价格|机票|航班|酒店|电商|官网/i;
+const FILE_TASK_RE = /\b(project|repo|repository|code|source|file|folder|directory|path|config|dependency|readme)\b|项目|仓库|代码|源码|文件|文件夹|目录|路径|配置|依赖|模块|读取|写入|修改|编辑|创建|删除|重命名|查找|修复/i;
+const TERMINAL_TASK_RE = /\b(shell|terminal|command|npm|pnpm|yarn|bun|git|curl|build|test|lint|install|process|server|log|pull|push|commit|merge|branch|checkout|deploy)\b|命令|终端|运行|执行|构建|测试|安装|启动|停止|服务|进程|日志|拉取|提交|推送|合并|分支|部署/i;
+const MACOS_TASK_RE = /\b(mac(?:os)?|desktop|window|screen|keyboard|mouse|finder)\b|\b(?:open|launch|activate)\s+(?:the\s+)?app\b|桌面|窗口|屏幕|应用|软件|键盘|鼠标|点击坐标|按键|截屏|截个图/i;
+const VISION_TASK_RE = /\[附件\]|\.(?:png|jpe?g|gif|webp|bmp|heic)(?:\b|\?)|\b(image|photo|picture|screenshot|ocr|vision)\b|图片|图像|照片|截图|识图|看图|图里|图中/i;
+const SPAWN_TASK_RE = /\b(batch|parallel|multiple|each|compare)\b|批量|并行|同时|分别|多个|多份|每个|逐个|对比|比较/i;
+
+const CORE_TOOL_NAMES = ['ask_user', 'notify_user', 'finish'];
+const WEB_TOOL_NAMES = ['navigate', 'click', 'type', 'wait', 'scroll', 'get_page_content', 'http_fetch', 'parallel_fetch', 'web_search'];
+const FILE_TOOL_NAMES = ['list_dir', 'read_file', 'get_file_info', 'write_file', 'search_files', 'codegraph_query'];
+const TERMINAL_TOOL_NAMES = ['run_safe', 'run_confirmed', 'run_review'];
+const MACOS_TOOL_NAMES = ['open_app', 'activate_app', 'list_windows', 'capture_screen', 'type_text', 'press_key', 'click_at'];
+const VISION_TOOL_NAMES = ['image_analyze'];
+const SPAWN_TOOL_NAMES = ['spawn'];
+const IDE_TOOL_NAMES = ['ide_list_tools', 'ide_call_tool'];
+const CHROME_TOOL_NAMES = ['chrome_list_tools', 'chrome_call_tool'];
 
 function historyUsesTool(history: any[] | undefined, tool: string) {
   return Array.isArray(history) && history.some(entry => entry?.action?.tool === tool);
+}
+
+function capabilityText(context: PromptCapabilityContext) {
+  const conversation = Array.isArray(context.conversationHistory)
+    ? context.conversationHistory.slice(-8).map(message => message?.content || '').join('\n')
+    : '';
+  return `${context.task || ''}\n${conversation}`;
+}
+
+function addToolGroup(target: Set<string>, names: string[]) {
+  for (const name of names) target.add(name);
+}
+
+export function selectGeminiToolNames(context: PromptCapabilityContext = {}) {
+  const selected = new Set(CORE_TOOL_NAMES);
+  const text = capabilityText(context);
+  const history = Array.isArray(context.history) ? context.history : [];
+  const usedTools = new Set(history.map(entry => entry?.action?.tool).filter(Boolean));
+  const browserObserved = Boolean(
+    context.observation?.browser
+    || context.observation?.url
+    || context.observation?.elements?.length
+  );
+
+  const needsChrome = shouldIncludeChromePromptDetails(context);
+  const needsIde = shouldIncludeIdePromptDetails(context);
+  const needsWeb = WEB_TASK_RE.test(text)
+    || browserObserved
+    || needsChrome
+    || usedTools.has('browser')
+    || usedTools.has('search')
+    || usedTools.has('chrome');
+  const needsFiles = FILE_TASK_RE.test(text)
+    || needsIde
+    || usedTools.has('fs')
+    || usedTools.has('codegraph')
+    || usedTools.has('ide');
+  const needsTerminal = TERMINAL_TASK_RE.test(text) || usedTools.has('terminal');
+  const needsMacos = MACOS_TASK_RE.test(text) || usedTools.has('macos');
+  const needsVision = VISION_TASK_RE.test(text) || needsMacos || usedTools.has('vision');
+  const needsSpawn = SPAWN_TASK_RE.test(text) || usedTools.has('spawn');
+
+  if (needsWeb) addToolGroup(selected, WEB_TOOL_NAMES);
+  if (needsFiles) addToolGroup(selected, FILE_TOOL_NAMES);
+  if (needsTerminal) addToolGroup(selected, TERMINAL_TOOL_NAMES);
+  if (needsMacos) addToolGroup(selected, MACOS_TOOL_NAMES);
+  if (needsVision) addToolGroup(selected, VISION_TOOL_NAMES);
+  if (needsSpawn) addToolGroup(selected, SPAWN_TOOL_NAMES);
+  if (needsIde) addToolGroup(selected, IDE_TOOL_NAMES);
+  if (needsChrome) addToolGroup(selected, CHROME_TOOL_NAMES);
+  return selected;
 }
 
 function historyShowsBrowserBlock(history: any[] | undefined) {
@@ -38,6 +108,7 @@ export function shouldIncludeIdePromptDetails({ task = '', history = [] }: Promp
 function chromePromptLines(context: PromptCapabilityContext) {
   if (!isChromeMcpEnabled()) return [];
   if (shouldIncludeChromePromptDetails(context)) return buildChromePromptLines();
+  if (context.includeInactiveCapabilityHints === false) return [];
   return [
     'Chrome MCP 已启用但默认不展开。仅当任务明确要求 Chrome/DevTools，或内置浏览器遭遇 CAPTCHA、403、Cloudflare 等拦截时，调用 {"tool":"chrome","type":"chrome_list_tools"} 按需获取工具。',
   ];
@@ -46,6 +117,7 @@ function chromePromptLines(context: PromptCapabilityContext) {
 function idePromptLines(context: PromptCapabilityContext) {
   if (!isIdeMcpEnabled()) return [];
   if (shouldIncludeIdePromptDetails(context)) return buildIdePromptLines();
+  if (context.includeInactiveCapabilityHints === false) return [];
   return [
     'IDE MCP 已启用但默认不展开。仅当任务明确需要 JetBrains/IDE 能力时，调用 {"tool":"ide","type":"ide_list_tools"} 按需获取工具。',
   ];
@@ -148,6 +220,47 @@ export function compactAgentHistory(history: any[], maxEntries?: number, maxResu
   });
 }
 
+function buildSharedAgentRuleLines(capabilityContext: PromptCapabilityContext = {}) {
+  const ideLines = idePromptLines(capabilityContext);
+  const chromeDetails = shouldIncludeChromePromptDetails(capabilityContext);
+  const chromeLines = chromePromptLines(capabilityContext);
+  return [
+    '规则：',
+    '1. 只有 observation.browser.elements 中存在的 elementId 才能用于 browser.click / browser.type。',
+    '2. 优先使用已知信息，不要重复无意义截图或重复读同一文件。任务一旦完成，必须立即调用 finish，绝不能重复执行已成功的动作。',
+    '2.1 识别任务中的并行机会：当需要处理多个独立对象（多个文件、多个 URL、多个关键词）时，优先考虑用 spawn 并行处理而非串行逐个处理。',
+    '2.2 若任务是常识问答、闲聊，或依据已有知识即可直接回答（无需读取文件/网页/桌面/终端），直接用 finish 返回答案，不要为了「显得在执行」而调用 list_dir、read_file 等探索性工具。',
+    '3. 文件写入、终端确认命令、桌面键鼠输入可能需要用户批准，被拒绝后请尝试替代方案。',
+    '4. cd/pushd/popd 等目录切换命令使用 run_review，会触发用户审批。',
+    '5. answer 用简体中文，简洁直接。',
+    '6. 需要全网搜索关键词时，优先使用 web_search（DuckDuckGo，返回标题/URL/摘要），再用 http_fetch 抓具体页面。禁止直接 navigate 到 Google/Bing/百度搜索结果页，这些页面容易触发反爬。',
+    '7. http_fetch 和 navigate 都通过浏览器执行，可以处理需要 JS 渲染的页面。',
+    '8. 需要同时获取多个页面时，使用 parallel_fetch 并发抓取（最多 5 个 URL）。',
+    '9. 需要用户输入或确认偏好时使用 ask_user，不要自行假设。',
+    '10. 执行中发现重要信息或潜在问题时使用 notify_user 主动告知用户。',
+    '10.1 任务或附件中出现图片（本地路径或 http(s) URL，常见于任务文本中的“[附件]”块或截图）时，必须用 image_analyze 把图片交给多模态模型分析，不要凭文件名猜测内容。image 传图片路径/URL，question 用简体中文写清要从图里得到什么。',
+    '10.2 简单识图任务（例如“这是什么图/图里是什么”）在一次 image_analyze 已得到可用描述后，应立即 finish。若无法确认具体来源、游戏、人物、地点或品牌，必须说明“无法仅凭图片确认”，并给出可见证据和低置信猜测；不要反复调用同一张图来放大猜测。',
+    '10.3 对同一张图片最多连续调用 2 次 image_analyze；第二次只用于明确不同的问题（如 OCR、局部细节、真假核验）。不要编造图片中没有的 UI、文字、按钮、角色名、怪物、道具或数值。',
+    '11. 当任务涉及多个独立的子目标时（如分析多个文件、查询多个信息源、批量处理），自动使用 spawn 工具并行分发给子 Agent 执行，显著提升效率。最多支持 5 个并行任务。',
+    '12. 涉及医保、社保、签证、贷款、股票、基金、汇率、法律、法规、政策、许可、合规等高风险或合规性信息时，必须优先从官方来源核验；如果未能核验，finish 答案必须明确说明“未能完成官方核验”，不要把记忆或常识包装成已确认结论。',
+    '13. finish 之前自检：当任务要求基于网页/官网内容作答，但浏览操作没有真正取得目标页面的实质内容（如反复超时、只到达主页、被反爬挡住），不要用模型常识包装成“已确认结论”。要么继续尝试（换路径、换工具、换源站），要么在 answer 里明确说明“未能从目标页面取得信息，以下来自常识仅供参考”。',
+    '14. 查询酒店/机票/电商等实时价格时，优先用 web_search 获取价格区间或聚合报价；这类价格依赖具体入住/出行日期、常需登录且受反爬限制，难以直接抓取。若拿不到确切数字，直接 finish 给出区间与查询入口，并如实说明“未取得实时精确价”，不要在单个站点反复操作空转。',
+    '15. 浏览器/Chrome 操作要及时止损：对同一目标连续约 5 步仍未取得实质数据时，停止更换手段反复尝试，直接 finish 汇总已知信息并说明未能取得的部分。',
+    ...(chromeDetails ? ['16. 当内置浏览器被反爬拦截时，改用 Chrome MCP 操作真实浏览器访问同一页面。'] : []),
+    ...ideLines,
+    ...chromeLines,
+  ];
+}
+
+function buildReadonlyAgentRuleLines(systemPrompt: string | null) {
+  return [
+    '你是只读子 Agent，只负责分析并返回结果。',
+    '禁止写文件、运行终端、操作浏览器/Chrome/IDE/macOS、询问或通知用户、继续 spawn。',
+    '路径必须使用项目内相对路径。完成后立即调用 finish 返回简洁结果。',
+    systemPrompt ? `附加约束：${systemPrompt}` : '',
+  ].filter(Boolean);
+}
+
 export function buildDesktopAgentSystemPrompt(
   systemPrompt: string | null,
   toolMode: 'full' | 'readonly' = 'full',
@@ -155,40 +268,14 @@ export function buildDesktopAgentSystemPrompt(
 ) {
   if (toolMode === 'readonly') {
     return [
-      '你是只读子 Agent，只负责分析并返回结果。',
-      '只能使用当前提供的只读工具；禁止写文件、运行终端、操作浏览器/Chrome/IDE/macOS、询问或通知用户、继续 spawn。',
-      '路径必须使用项目内相对路径。完成后立即调用 finish 返回简洁结果。',
-      systemPrompt ? `附加约束：${systemPrompt}` : '',
+      '只能使用当前提供的只读工具。',
+      ...buildReadonlyAgentRuleLines(systemPrompt),
     ].filter(Boolean).join('\n');
   }
-  const ideLines = idePromptLines(capabilityContext);
-  const chromeDetails = shouldIncludeChromePromptDetails(capabilityContext);
-  const chromeLines = chromePromptLines(capabilityContext);
   return [
     '你是 DesktopAgent，负责在浏览器、macOS 桌面、文件系统、终端之间协同完成任务。',
-    '通过工具调用完成任务，只能使用提供的工具，不要输出 JSON 以外的文本。',
-    '规则：',
-    '1. 只有 observation.browser.elements 中存在的 elementId 才能用于 click/type。',
-    '2. 优先使用已知信息，不要重复无意义截图或重复读同一文件。任务一旦完成，必须立即返回 {"action":{"tool":"core","type":"finish","answer":"结果"}}，绝不能重复执行已成功的动作。',
-    '2.1 识别任务中的并行机会：当需要处理多个独立对象（多个文件、多个 URL、多个关键词）时，优先考虑用 spawn 并行处理而非串行逐个处理。',
-    '2.2 若任务是常识问答、闲聊，或依据已有知识即可直接回答（无需读取文件/网页/桌面/终端），直接用 finish 返回答案，不要为了「显得在执行」而调用 list_dir、read_file 等探索性工具。',
-    '3. 文件写入、终端确认命令、桌面键鼠输入可能需要用户批准，被拒绝后请尝试替代方案。',
-    '4. cd/pushd/popd 等目录切换命令使用 run_review，需要用户审批。',
-    '5. answer 用简体中文，简洁直接。',
-    '6. 需要全网搜索关键词时，优先使用 web_search（DuckDuckGo，返回标题/URL/摘要），再用 http_fetch 抓具体页面。禁止直接 navigate 到 Google/Bing/百度搜索结果页，这些页面会触发反爬。',
-    '7. 需要用户输入或确认偏好时使用 ask_user，不要自行假设。',
-    '8. 执行中发现重要信息或潜在问题时使用 notify_user 主动告知用户。',
-    '8.1 任务或附件中出现图片（本地路径或 http(s) URL，常见于任务文本中的”[附件]”块或截图）时，必须用 image_analyze 工具把图片交给多模态模型分析，不要凭文件名猜测内容。',
-    '8.2 简单识图任务（例如“这是什么图/图里是什么”）在一次 image_analyze 已得到可用描述后，应立即 finish。若无法确认具体来源、游戏、人物、地点或品牌，必须说明“无法仅凭图片确认”，并给出可见证据和低置信猜测；不要反复调用同一张图来放大猜测。',
-    '8.3 对同一张图片最多连续调用 2 次 image_analyze；第二次只用于明确不同的问题（如 OCR、局部细节、真假核验）。不要编造图片中没有的 UI、文字、按钮、角色名、怪物、道具或数值。',
-    '9. 当任务涉及多个独立的子目标时（如分析多个文件、查询多个信息源、批量处理），自动使用 spawn 工具并行分发给子 Agent 执行，显著提升效率。最多支持 5 个并行任务。',
-    '10. 涉及医保、社保、签证、贷款、股票、基金、汇率、法律、法规、政策、许可、合规等高风险或合规性信息时，必须优先从官方来源核验；如果未能核验，finish 答案必须明确说明”未能完成官方核验”，不要把记忆或常识包装成已确认结论。',
-    '11. finish 之前自检：当任务要求基于网页/官网内容作答，但你的浏览操作（navigate/click/take_snapshot/http_fetch 等）没有真正取得目标页面的实质内容（如反复超时、只到达主页、被反爬挡住），不要用模型常识包装成”已确认结论”。要么继续尝试（换路径、换工具、换源站），要么在 answer 里明确说明”未能从目标页面取得信息，以下来自常识仅供参考”。',
-    '11.1 查询酒店/机票/电商等实时价格时，优先用 web_search 获取价格区间或聚合报价；这类价格依赖具体入住/出行日期、常需登录且受反爬限制，难以直接抓取。若拿不到确切数字，直接 finish 给出区间与查询入口、并如实说明「未取得实时精确价」，不要在单个站点反复 navigate/snapshot/click 空转。',
-    '11.2 浏览器/Chrome 操作要及时止损：对同一目标连续约 5 步（navigate/snapshot/click/evaluate 等）仍未取得实质数据时，停止更换手段反复尝试，直接 finish 汇总已知信息并说明未能取得的部分。',
-    ...(chromeDetails ? ['11. 当内置浏览器被反爬拦截时，改用 Chrome MCP 操作真实浏览器访问同一页面。'] : []),
-    ...ideLines,
-    ...chromeLines,
+    '每个步骤必须调用且只能调用一个当前提供的工具；任务完成时调用 finish。',
+    ...buildSharedAgentRuleLines(capabilityContext),
     systemPrompt ? `附加约束：${systemPrompt}` : '',
   ]
     .filter(Boolean)
@@ -226,6 +313,34 @@ export function buildGeminiTaskMessages({
   return { contents };
 }
 
+export function buildGeminiAgentPromptPayload(
+  context: any,
+  toolMode: 'full' | 'readonly' = 'full',
+) {
+  const capabilityContext = { ...context, includeInactiveCapabilityHints: false };
+  const systemInstruction = buildDesktopAgentSystemPrompt(
+    context.systemPrompt || '',
+    toolMode,
+    capabilityContext,
+  );
+  const { contents } = buildGeminiTaskMessages(context);
+  const includeToolNames = toolMode === 'readonly' ? undefined : selectGeminiToolNames(context);
+  const tools = [{
+    functionDeclarations: createModelTools({
+      mode: toolMode,
+      includeChromeMcp: shouldIncludeChromePromptDetails(context),
+      includeIdeMcp: shouldIncludeIdePromptDetails(context),
+      includeToolNames,
+    }).map(toolToGeminiTool),
+  }];
+  return {
+    systemInstruction,
+    contents,
+    tools,
+    toolConfig: { functionCallingConfig: { mode: 'ANY' } },
+  };
+}
+
 export function buildNvidiaTaskMessages({
   task,
   systemPrompt,
@@ -248,10 +363,8 @@ export function buildNvidiaTaskMessages({
   const capabilityContext = { task, history, observation };
   const ideEnabled = isIdeMcpEnabled();
   const ideDetails = shouldIncludeIdePromptDetails(capabilityContext);
-  const ideLines = idePromptLines(capabilityContext);
   const chromeEnabled = isChromeMcpEnabled();
   const chromeDetails = shouldIncludeChromePromptDetails(capabilityContext);
-  const chromeLines = chromePromptLines(capabilityContext);
   const conversationSummary = conversationHistory?.length
     ? '\n\n之前的对话（供参考）：\n' + conversationHistory
         .map(message => `${message.role === 'user' ? '用户' : '助手'}: ${message.content}`)
@@ -267,11 +380,9 @@ export function buildNvidiaTaskMessages({
       {
         role: 'system',
         content: [
-          '你是只读子 Agent，只能输出一个 JSON 对象。',
+          '每个步骤必须且只能输出一个 JSON 对象。',
           '可用动作只有：fs list_dir/read_file/get_file_info/search_files；search web_search；vision image_analyze；codegraph codegraph_query；core finish。',
-          '禁止写文件、运行终端、操作浏览器/Chrome/IDE/macOS、询问或通知用户、继续 spawn。',
-          '路径必须使用项目内相对路径。完成后立即 finish。',
-          systemPrompt ? `附加约束：${systemPrompt}` : '',
+          ...buildReadonlyAgentRuleLines(systemPrompt || null),
         ].filter(Boolean).join(' '),
       },
       {
@@ -311,7 +422,7 @@ export function buildNvidiaTaskMessages({
         '{"rationale":"搜索天气","action":{"tool":"search","type":"web_search","query":"杭州今日天气"}}',
         '{"rationale":"任务完成","action":{"type":"finish","answer":"最终结果"}}',
         '可用动作签名（括号内为主要参数）：',
-        'browser: navigate(url), click(elementId), type(elementId,text), scroll(direction,amount), get_page_content(), http_fetch(url,extractLinks?), parallel_fetch(urls)',
+        'browser: navigate(url), click(elementId), type(elementId,text), wait(seconds), scroll(direction,amount), get_page_content(), http_fetch(url,extractLinks?), parallel_fetch(urls)',
         'fs: list_dir(path), get_file_info(path), read_file(path), write_file(path,content,append), search_files(query,path,include?)',
         'terminal: run_safe(command), run_confirmed(command), run_review(command)',
         'macos: activate_app(app), open_app(app), list_windows(), capture_screen(), type_text(text), press_key(key,modifiers), click_at(x,y)',
@@ -320,29 +431,7 @@ export function buildNvidiaTaskMessages({
         ...(chromeEnabled && chromeDetails ? ['chrome: chrome_list_tools(refresh?), chrome_call_tool(toolName,arguments,refreshTools?)'] : []),
         'core: ask_user(question), notify_user(message,level), finish(answer)',
         '重要：每个步骤必须且只能输出一个 JSON 动作。如果你已经收集到足够信息并可以直接回答用户问题，请使用 finish 动作输出答案。绝对不要在 JSON 之外输出解释文字。',
-        '规则：',
-        '1. 只有 observation.browser.elements 中存在的 elementId 才能用于 browser.click / browser.type。',
-        '2. 优先使用已知信息，不要重复无意义截图或重复读同一文件。',
-        '2.1 识别任务中的并行机会：当需要处理多个独立对象（多个文件、多个 URL、多个关键词）时，优先考虑用 spawn 并行处理而非串行逐个处理。',
-        '2.2 若任务是常识问答、闲聊，或依据已有知识即可直接回答（无需读取文件/网页/桌面/终端），直接用 finish 返回答案，不要为了「显得在执行」而调用 list_dir、read_file 等探索性工具。',
-        '3. 文件写入、终端确认命令、桌面键鼠输入可能需要用户批准，被拒绝后请尝试替代方案。',
-        '4. cd/pushd/popd 等目录切换命令使用 run_review，会触发用户审批。',
-        '5. answer 用简体中文，简洁直接。',
-        '6. 需要全网搜索关键词时，优先使用 web_search（DuckDuckGo，返回标题/URL/摘要），再用 http_fetch 抓具体页面。禁止直接 navigate 到 Google/Bing/百度搜索结果页。',
-        '7. http_fetch 和 navigate 都通过浏览器执行，可以处理需要 JS 渲染的页面。',
-        '8. 需要同时获取多个页面时，使用 parallel_fetch 并发抓取（最多5个URL）。',
-        '9. 需要用户输入或确认偏好时使用 ask_user。',
-        '10. 发现重要信息或问题时使用 notify_user 主动告知用户。',
-        '10.1 任务或附件中出现图片（本地路径或 http(s) URL，常见于任务文本中的”[附件]”块或截图）时，必须用 image_analyze（tool=vision）把图片交给多模态模型分析，不要凭文件名猜测内容。image 传图片路径/URL，question 用简体中文写清要从图里得到什么。',
-        '10.2 简单识图任务（例如“这是什么图/图里是什么”）在一次 image_analyze 已得到可用描述后，应立即 finish。若无法确认具体来源、游戏、人物、地点或品牌，必须说明“无法仅凭图片确认”，并给出可见证据和低置信猜测；不要反复调用同一张图来放大猜测。',
-        '10.3 对同一张图片最多连续调用 2 次 image_analyze；第二次只用于明确不同的问题（如 OCR、局部细节、真假核验）。不要编造图片中没有的 UI、文字、按钮、角色名、怪物、道具或数值。',
-        '11. 当任务涉及多个独立的子目标时（如分析多个文件、查询多个信息源、批量处理），自动使用 spawn 工具并行分发给子 Agent 执行，显著提升效率。最多支持 5 个并行任务。',
-        '12. 涉及医保、社保、签证、贷款、股票、基金、汇率、法律、法规、政策、许可、合规等高风险或合规性信息时，必须优先从官方来源核验；如果未能核验，finish 答案必须明确说明”未能完成官方核验”，不要把记忆或常识包装成已确认结论。',
-        '13. 查询酒店/机票/电商等实时价格时，优先用 web_search 获取价格区间或聚合报价；这类价格依赖具体入住/出行日期、常需登录且受反爬限制，难以直接抓取。若拿不到确切数字，直接 finish 给出区间与查询入口、并如实说明「未取得实时精确价」，不要在单个站点反复 navigate/snapshot/click 空转。',
-        '14. 浏览器/Chrome 操作要及时止损：对同一目标连续约 5 步（navigate/snapshot/click/evaluate 等）仍未取得实质数据时，停止更换手段反复尝试，直接 finish 汇总已知信息并说明未能取得的部分。',
-        ...(chromeDetails ? ['15. 当内置浏览器被反爬拦截时，改用 Chrome MCP 操作真实浏览器。'] : []),
-        ...ideLines,
-        ...chromeLines,
+        ...buildSharedAgentRuleLines(capabilityContext),
         systemPrompt ? `附加约束：${systemPrompt}` : '',
         conversationSummary,
       ]

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -20,8 +20,11 @@ const TERMINAL_TASK_RE = /\b(shell|terminal|command|npm|pnpm|yarn|bun|git|curl|b
 const MACOS_TASK_RE = /\b(mac(?:os)?|desktop|window|screen|keyboard|mouse|finder)\b|\b(?:open|launch|activate)\s+(?:the\s+)?app\b|桌面|窗口|屏幕|应用|软件|键盘|鼠标|点击坐标|按键|截屏|截个图/i;
 const VISION_TASK_RE = /\[附件\]|\.(?:png|jpe?g|gif|webp|bmp|heic)(?:\b|\?)|\b(image|photo|picture|screenshot|ocr|vision)\b|图片|图像|照片|截图|识图|看图|图里|图中/i;
 const SPAWN_TASK_RE = /\b(batch|parallel|multiple|each|compare)\b|批量|并行|同时|分别|多个|多份|每个|逐个|对比|比较/i;
+const FOLLOWUP_TASK_RE = /^\s*(?:(?:继续|接着|重试|再试|这个|那个|上面|刚才|照旧)(?:\s|$)|(?:continue|retry|that|it)\b)/i;
 
-const CORE_TOOL_NAMES = ['ask_user', 'notify_user', 'finish'];
+// web_search 作为轻量信息查询兜底常驻，避免产品目录、模型上下线、版本变化等
+// 时效性问题未命中关键词分类后只剩 finish，导致模型把问题原样返回。
+const CORE_TOOL_NAMES = ['web_search', 'ask_user', 'notify_user', 'finish'];
 const WEB_TOOL_NAMES = ['navigate', 'click', 'type', 'wait', 'scroll', 'get_page_content', 'http_fetch', 'parallel_fetch', 'web_search'];
 const FILE_TOOL_NAMES = ['list_dir', 'read_file', 'get_file_info', 'write_file', 'search_files', 'codegraph_query'];
 const TERMINAL_TOOL_NAMES = ['run_safe', 'run_confirmed', 'run_review'];
@@ -36,14 +39,49 @@ function historyUsesTool(history: any[] | undefined, tool: string) {
 }
 
 function capabilityText(context: PromptCapabilityContext) {
-  const conversation = Array.isArray(context.conversationHistory)
-    ? context.conversationHistory.slice(-8).map(message => message?.content || '').join('\n')
+  const task = context.task || '';
+  const conversation = FOLLOWUP_TASK_RE.test(task)
+    ? sanitizeConversationHistory(context.conversationHistory).slice(-8).map(message => message.content).join('\n')
     : '';
-  return `${context.task || ''}\n${conversation}`;
+  return `${task}\n${conversation}`;
 }
 
 function addToolGroup(target: Set<string>, names: string[]) {
   for (const name of names) target.add(name);
+}
+
+function comparableConversationText(value: string) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[\s\p{P}\p{S}]+/gu, '');
+}
+
+export function sanitizeConversationHistory(value: PromptCapabilityContext['conversationHistory']) {
+  if (!Array.isArray(value)) return [];
+  const sanitized: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+  const rejectedEchoes = new Set<string>();
+
+  for (const message of value.slice(-10)) {
+    if (!message || (message.role !== 'user' && message.role !== 'assistant')) continue;
+    const content = typeof message.content === 'string' ? message.content.trim() : '';
+    if (!content) continue;
+    const comparable = comparableConversationText(content);
+
+    if (message.role === 'assistant') {
+      if (rejectedEchoes.has(comparable)) continue;
+      const previous = sanitized.at(-1);
+      if (previous?.role === 'user' && comparable && comparable === comparableConversationText(previous.content)) {
+        sanitized.pop();
+        rejectedEchoes.add(comparable);
+        continue;
+      }
+      if (previous?.role === 'assistant' && comparable === comparableConversationText(previous.content)) continue;
+    }
+
+    sanitized.push({ role: message.role, content });
+  }
+
+  return sanitized;
 }
 
 export function selectGeminiToolNames(context: PromptCapabilityContext = {}) {
@@ -226,6 +264,8 @@ function buildSharedAgentRuleLines(capabilityContext: PromptCapabilityContext = 
   const chromeLines = chromePromptLines(capabilityContext);
   return [
     '规则：',
+    '0. task 字段是本轮唯一执行目标，优先级高于 conversationHistory。历史对话只用于理解指代和上下文，禁止恢复、继续或切换到历史中的旧任务。',
+    '0.1 涉及产品能力、模型目录、版本变化、供应商上下线等可能随时间变化的信息时，优先使用 web_search 核验，不要仅凭记忆回答。',
     '1. 只有 observation.browser.elements 中存在的 elementId 才能用于 browser.click / browser.type。',
     '2. 优先使用已知信息，不要重复无意义截图或重复读同一文件。任务一旦完成，必须立即调用 finish，绝不能重复执行已成功的动作。',
     '2.1 识别任务中的并行机会：当需要处理多个独立对象（多个文件、多个 URL、多个关键词）时，优先考虑用 spawn 并行处理而非串行逐个处理。',
@@ -298,8 +338,9 @@ export function buildGeminiTaskMessages({
   conversationHistory?: Array<{ role: string; content: string }>;
 }) {
   const contents: any[] = [];
-  if (conversationHistory?.length) {
-    for (const msg of conversationHistory) {
+  const sanitizedConversation = sanitizeConversationHistory(conversationHistory);
+  if (sanitizedConversation.length) {
+    for (const msg of sanitizedConversation) {
       contents.push({ role: msg.role === 'assistant' ? 'model' : 'user', parts: [{ text: msg.content }] });
     }
   }
@@ -365,8 +406,9 @@ export function buildNvidiaTaskMessages({
   const ideDetails = shouldIncludeIdePromptDetails(capabilityContext);
   const chromeEnabled = isChromeMcpEnabled();
   const chromeDetails = shouldIncludeChromePromptDetails(capabilityContext);
-  const conversationSummary = conversationHistory?.length
-    ? '\n\n之前的对话（供参考）：\n' + conversationHistory
+  const sanitizedConversation = sanitizeConversationHistory(conversationHistory);
+  const conversationSummary = sanitizedConversation.length
+    ? '\n\n之前的对话（仅用于理解当前 task 的指代，不得继续旧任务）：\n' + sanitizedConversation
         .map(message => `${message.role === 'user' ? '用户' : '助手'}: ${message.content}`)
         .join('\n')
     : '';

--- a/agent/core/providers/gemini-catalog.ts
+++ b/agent/core/providers/gemini-catalog.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ModelInfo } from './types.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OVERRIDES_PATH = path.resolve(__dirname, '../../../config/model-catalog/gemini-overrides.json');
+
+let cachedOverrides: Map<string, Partial<ModelInfo>> | null = null;
+
+function normalizeModelId(value: string) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function sanitizeOverride(model: any): Partial<ModelInfo> {
+  const out: Partial<ModelInfo> = {};
+  if (Array.isArray(model?.aliases)) out.aliases = model.aliases.filter((item: any) => typeof item === 'string' && item.trim());
+  if (typeof model?.label === 'string' && model.label.trim()) out.label = model.label.trim();
+  if (typeof model?.description === 'string' && model.description.trim()) out.description = model.description.trim();
+  if (typeof model?.catalogUrl === 'string' && model.catalogUrl.trim()) out.catalogUrl = model.catalogUrl.trim();
+  if (typeof model?.publisher === 'string' && model.publisher.trim()) out.publisher = model.publisher.trim();
+  if (typeof model?.updated === 'string' && model.updated.trim()) out.updated = model.updated.trim();
+  if (Number.isFinite(Number(model?.contextWindow)) && Number(model.contextWindow) > 0) out.contextWindow = Number(model.contextWindow);
+  if (Array.isArray(model?.inputModalities)) out.inputModalities = model.inputModalities;
+  if (Array.isArray(model?.outputModalities)) out.outputModalities = model.outputModalities;
+  if (Array.isArray(model?.supportedGenerationMethods)) out.supportedGenerationMethods = model.supportedGenerationMethods;
+  if (Array.isArray(model?.supportedMessageRoles)) out.supportedMessageRoles = model.supportedMessageRoles;
+  if (Array.isArray(model?.supportedMessageTypes)) out.supportedMessageTypes = model.supportedMessageTypes;
+  if (Array.isArray(model?.supportedParameters)) out.supportedParameters = model.supportedParameters;
+  if (typeof model?.agentCompatible === 'boolean') out.agentCompatible = model.agentCompatible;
+  return out;
+}
+
+function loadOverrides() {
+  if (cachedOverrides) return cachedOverrides;
+  cachedOverrides = new Map();
+  if (!fs.existsSync(OVERRIDES_PATH)) return cachedOverrides;
+
+  const payload = JSON.parse(fs.readFileSync(OVERRIDES_PATH, 'utf8'));
+  const models = payload?.models && typeof payload.models === 'object' ? payload.models : {};
+  for (const [id, model] of Object.entries(models) as Array<[string, any]>) {
+    const metadata = sanitizeOverride(model);
+    const aliases = [id, ...(Array.isArray(model?.aliases) ? model.aliases : [])];
+    for (const alias of aliases) {
+      if (typeof alias === 'string' && alias.trim()) {
+        cachedOverrides.set(normalizeModelId(alias), metadata);
+      }
+    }
+  }
+  return cachedOverrides;
+}
+
+export function getGeminiCatalogModelMetadata(modelId: string): Partial<ModelInfo> {
+  return loadOverrides().get(normalizeModelId(modelId)) || {};
+}

--- a/agent/core/providers/gemini.ts
+++ b/agent/core/providers/gemini.ts
@@ -10,10 +10,8 @@
 
 import { GoogleGenAI } from '@google/genai';
 import {
-  buildDesktopAgentSystemPrompt,
-  buildGeminiTaskMessages,
+  buildGeminiAgentPromptPayload,
 } from '../prompts.ts';
-import { createModelTools, toolToGeminiTool } from '../tool-definitions.ts';
 import { normalizeDesktopAgentDecision } from '../schemas.ts';
 import { isChatCapableModel } from '../ai-client.ts';
 import { resolveAgentMaxTokens } from '../planner.ts';
@@ -22,6 +20,7 @@ import { initSse, writeSse, writeSseDone } from '../../../helpers/streaming.ts';
 import { retryAsync } from '../../../helpers/retry.ts';
 import { buildSummaryPrompt } from './summary-prompt.ts';
 import { extractModelMetadata } from './model-metadata.ts';
+import { getGeminiCatalogModelMetadata } from './gemini-catalog.ts';
 import { configStore } from '../config-store.ts';
 import type {
   LLMProvider,
@@ -114,9 +113,11 @@ export function createGeminiProvider(client: GoogleGenAI): LLMProvider {
         if (!supportsGenerate) continue;
         if (!isChatCapableModel(id)) continue;
         if (/imagen|veo|embedding|aqa|tts|-image|image-|gemma-(?:2|3n)/i.test(id)) continue;
+        const catalogMetadata = getGeminiCatalogModelMetadata(id);
         models.push({
+          ...catalogMetadata,
           id,
-          label: (m as any).displayName || id,
+          label: catalogMetadata.label || (m as any).displayName || id,
           provider: 'gemini',
           ...extractModelMetadata(m),
         });
@@ -126,10 +127,12 @@ export function createGeminiProvider(client: GoogleGenAI): LLMProvider {
 
     async agentPlan(opts: AgentPlanOpts): Promise<AgentPlanResult> {
       const { model, signal, systemPrompt, modelConfig, toolMode = 'full' } = opts;
-      const system = buildDesktopAgentSystemPrompt(systemPrompt, toolMode as 'full' | 'readonly', opts as any);
-      const { contents } = buildGeminiTaskMessages(opts as any);
-      const tools = [{ functionDeclarations: createModelTools({ mode: toolMode as 'full' | 'readonly' }).map(toolToGeminiTool) }];
-      const toolConfig = { functionCallingConfig: { mode: 'ANY' } };
+      const {
+        systemInstruction: system,
+        contents,
+        tools,
+        toolConfig,
+      } = buildGeminiAgentPromptPayload(opts, toolMode as 'full' | 'readonly');
       const maxOutputTokens = resolveAgentMaxTokens({
         model,
         modelConfig,
@@ -146,7 +149,11 @@ export function createGeminiProvider(client: GoogleGenAI): LLMProvider {
       };
       if (signal) config.abortSignal = signal;
 
-      logLlmRequest(model, contents);
+      logLlmRequest(model, [
+        { role: 'system', content: system },
+        ...contents.map((message: any) => ({ role: message.role, content: message.parts })),
+        { role: 'tools', content: tools },
+      ]);
       const response = await retryAsync(() => client.models.generateContent({ model, contents, config } as any), undefined, undefined, { retryRateLimit: false });
       const usage = buildGeminiUsage((response as any).usageMetadata);
       logLlmResponse(model, { usage: { input_tokens: usage?.prompt_tokens, output_tokens: usage?.completion_tokens }, choices: [{ message: response }] });

--- a/agent/core/runtime.ts
+++ b/agent/core/runtime.ts
@@ -56,6 +56,19 @@ function observationText(observation: unknown, key: 'url' | 'title'): string | u
   return typeof value === 'string' ? value : undefined;
 }
 
+function comparableTaskText(value: unknown) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[\s\p{P}\p{S}]+/gu, '');
+}
+
+export function isTaskEchoFinish(task: string, action: AgentAction | undefined) {
+  if (action?.type !== 'finish') return false;
+  const normalizedTask = comparableTaskText(task);
+  const normalizedAnswer = comparableTaskText(action.answer);
+  return normalizedTask.length > 0 && normalizedTask === normalizedAnswer;
+}
+
 function compressHistory(history: AgentStep[], maxSteps?: number) {
   // 历史截断预算每次从运行时配置读取，前台改完无需重启即生效
   const { maxHistorySteps, maxResultChars: MAX_RESULT_CHARS, maxParallelResultChars: MAX_PARALLEL_RESULT_CHARS } = configStore.get();
@@ -380,6 +393,39 @@ export async function runAgentRuntime({
 
       if (cancelled()) {
         throw new Error("Agent 已取消");
+      }
+
+      if (isTaskEchoFinish(task, decision.action)) {
+        const result = '无效 finish：answer 只是重复当前 task，没有回答问题。请重新分析当前 task，并选择合适工具或给出实质答案。';
+        const resultStatus = 'failed';
+        const resultError = 'finish answer echoed task';
+        onEvent?.({
+          type: "step",
+          step,
+          stage: "action",
+          rationale: decision.rationale,
+          action: decision.action,
+          usage: decision.usage || null,
+        });
+        history.push({
+          step,
+          rationale: decision.rationale,
+          action: decision.action,
+          result,
+          resultStatus,
+          resultError,
+          url: observationText(observation, 'url'),
+          title: observationText(observation, 'title'),
+        });
+        onEvent?.({
+          type: "step",
+          step,
+          stage: "result",
+          result,
+          resultStatus,
+          resultError,
+        });
+        continue;
       }
 
       const repeatedLoop = detectRepeatedActionLoop(history, decision.action);

--- a/agent/core/tool-definitions.ts
+++ b/agent/core/tool-definitions.ts
@@ -21,7 +21,17 @@ const READONLY_TOOL_NAMES = new Set([
   'finish',
 ]);
 
-export function createModelTools({ mode = 'full' }: { mode?: 'full' | 'readonly' } = {}) {
+export function createModelTools({
+  mode = 'full',
+  includeIdeMcp = true,
+  includeChromeMcp = true,
+  includeToolNames,
+}: {
+  mode?: 'full' | 'readonly';
+  includeIdeMcp?: boolean;
+  includeChromeMcp?: boolean;
+  includeToolNames?: Iterable<string>;
+} = {}) {
   const tools: any[] = [
     {
       name: 'navigate',
@@ -80,6 +90,11 @@ export function createModelTools({ mode = 'full' }: { mode?: 'full' | 'readonly'
         },
         required: ['direction'],
       },
+    },
+    {
+      name: 'get_page_content',
+      description: '提取当前浏览器页面的正文文本和基础页面信息。',
+      input_schema: { type: 'object', properties: {} },
     },
     {
       name: 'list_dir',
@@ -356,7 +371,7 @@ export function createModelTools({ mode = 'full' }: { mode?: 'full' | 'readonly'
     },
   ];
 
-  if (isIdeMcpEnabled()) {
+  if (includeIdeMcp && isIdeMcpEnabled()) {
     tools.splice(tools.length - 1, 0,
       {
         name: 'ide_list_tools',
@@ -388,7 +403,7 @@ export function createModelTools({ mode = 'full' }: { mode?: 'full' | 'readonly'
     );
   }
 
-  if (isChromeMcpEnabled()) {
+  if (includeChromeMcp && isChromeMcpEnabled()) {
     tools.splice(tools.length - 1, 0,
       {
         name: 'chrome_list_tools',
@@ -420,7 +435,12 @@ export function createModelTools({ mode = 'full' }: { mode?: 'full' | 'readonly'
     );
   }
 
-  return mode === 'readonly' ? tools.filter(tool => READONLY_TOOL_NAMES.has(tool.name)) : tools;
+  let selected = mode === 'readonly' ? tools.filter(tool => READONLY_TOOL_NAMES.has(tool.name)) : tools;
+  if (includeToolNames) {
+    const allowed = new Set(includeToolNames);
+    selected = selected.filter(tool => allowed.has(tool.name));
+  }
+  return selected;
 }
 
 // Gemini FunctionDeclaration：name/description + parametersJsonSchema（标准 JSON Schema，

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -5082,7 +5082,15 @@ a.model-encyclopedia-field-value:hover {
   background: var(--c-surface-dim);
 }
 
-.prompt-preview-text {
+.prompt-preview-mode .settings-segment-btn {
+  height: 26px;
+  padding: 0 9px;
+  font-size: var(--f-xs);
+}
+
+.prompt-preview-text,
+.prompt-preview-editor,
+.prompt-preview-markdown {
   margin: 0;
   min-height: 100%;
   padding: 14px 16px;
@@ -5092,8 +5100,37 @@ a.model-encyclopedia-field-value:hover {
   color: var(--c-text);
   font-size: var(--f-xs);
   line-height: 1.6;
-  white-space: pre-wrap;
   word-break: break-word;
+}
+
+.prompt-preview-text {
+  white-space: pre-wrap;
+}
+
+.prompt-preview-editor {
+  display: block;
+  width: 100%;
+  height: 100%;
+  resize: none;
+  font-family: var(--font-mono, 'SF Mono', Menlo, monospace);
+  outline: none;
+}
+
+.prompt-preview-editor:focus {
+  border-color: var(--c-primary-light);
+  box-shadow: 0 0 0 3px var(--c-primary-bg);
+}
+
+.prompt-preview-markdown {
+  font-size: var(--f-sm);
+}
+
+.prompt-preview-markdown > :first-child {
+  margin-top: 0;
+}
+
+.prompt-preview-markdown > :last-child {
+  margin-bottom: 0;
 }
 
 .toolbar-chip {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -5042,62 +5042,56 @@ a.model-encyclopedia-field-value:hover {
   font-size: var(--f-micro);
 }
 
-.context-prompt-details {
-  position: relative;
-  flex: 0 0 auto;
-  border: 1px solid transparent;
-  border-radius: var(--r-sm);
-  background: transparent;
-}
-
-.context-prompt-summary {
+.context-prompt-trigger {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 4px;
   height: 20px;
   padding: 0 4px;
+  flex: 0 0 auto;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  background: transparent;
   color: var(--c-text-hint);
+  font: inherit;
   cursor: pointer;
-  list-style: none;
 }
 
-.context-prompt-summary::-webkit-details-marker {
-  display: none;
-}
-
-.context-prompt-summary span:first-child {
+.context-prompt-trigger span:first-child {
   font-weight: 500;
 }
 
-.context-prompt-summary span:last-child {
+.context-prompt-trigger span:last-child {
   display: none;
   font-variant-numeric: tabular-nums;
 }
 
-.context-prompt-details:hover,
-.context-prompt-details[open] {
+.context-prompt-trigger:hover,
+.context-prompt-trigger:focus-visible {
   border-color: var(--c-border);
   background: var(--c-surface);
+  outline: none;
 }
 
-.context-prompt-text {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 6px);
-  z-index: 20;
-  width: min(720px, calc(100vw - 32px));
-  max-height: 260px;
-  margin: 0;
-  padding: 8px;
+.prompt-preview-content {
+  flex: 1;
+  min-height: 0;
   overflow: auto;
-  border: 1px solid var(--c-border);
-  border-radius: var(--r-sm);
-  box-shadow: var(--shadow-lg);
+  padding: 16px;
   background: var(--c-surface-dim);
+}
+
+.prompt-preview-text {
+  margin: 0;
+  min-height: 100%;
+  padding: 14px 16px;
+  border: 1px solid var(--c-border);
+  border-radius: var(--r-md);
+  background: var(--c-surface);
   color: var(--c-text);
-  font-size: var(--f-micro);
-  line-height: 1.5;
+  font-size: var(--f-xs);
+  line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -14,6 +14,7 @@ import { ResetDialog } from './components/dialogs/ResetDialog.jsx';
 import { ApprovalDialog } from './components/dialogs/ApprovalDialog.jsx';
 import { QuestionDialog } from './components/dialogs/QuestionDialog.jsx';
 import { SettingsDialog } from './components/dialogs/SettingsDialog.jsx';
+import { PromptPreviewDialog } from './components/dialogs/PromptPreviewDialog.jsx';
 import { SessionList } from './components/session/SessionList.jsx';
 import { AgentPanel } from './components/agent/AgentPanel.jsx';
 import { ModelSelector } from './components/ModelSelector.jsx';
@@ -172,6 +173,7 @@ export default function App() {
   const [agentMemory, setAgentMemory] = usePersistentState('agent_memory', true, booleanStorage);
   const [showReset, setShowReset] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [showPromptPreview, setShowPromptPreview] = useState(false);
   const { showSessions, setShowSessions } = useResponsiveLayout({
     dockedBreakpoint: DOCKED_LAYOUT_BREAKPOINT,
     panelSizeKey: PANEL_SIZE_KEY,
@@ -948,7 +950,12 @@ export default function App() {
   const visibleContextEstimate = agentRunning && actualContextEstimate
     ? actualContextEstimate
     : contextEstimate;
-  const contextMeter = <ContextMeter estimate={visibleContextEstimate} />;
+  const contextMeter = (
+    <ContextMeter
+      estimate={visibleContextEstimate}
+      onOpenPrompt={() => setShowPromptPreview(true)}
+    />
+  );
   const sendButton = (
     <SendButton
       agentRunning={agentRunning}
@@ -1157,6 +1164,12 @@ export default function App() {
 
       {showReset && <ResetDialog onConfirm={handleReset} onCancel={() => setShowReset(false)} />}
       {showSettings && <SettingsDialog onClose={() => setShowSettings(false)} agentMemory={agentMemory} setAgentMemory={setAgentMemory} />}
+      {showPromptPreview && visibleContextEstimate?.promptPreview?.text && (
+        <PromptPreviewDialog
+          estimate={visibleContextEstimate}
+          onClose={() => setShowPromptPreview(false)}
+        />
+      )}
     </div>
     </ErrorBoundary>
   );

--- a/client/src/components/ContextMeter.jsx
+++ b/client/src/components/ContextMeter.jsx
@@ -1,18 +1,12 @@
-import { useState } from 'react';
 import { useT } from '../i18n/I18nProvider.jsx';
-import { DialogShell } from './dialogs/DialogShell.jsx';
 
-export function ContextMeter({ estimate }) {
+export function ContextMeter({ estimate, onOpenPrompt }) {
   const t = useT();
-  const [promptOpen, setPromptOpen] = useState(false);
   if (!estimate) return null;
 
   const percent = Math.max(0, Math.min(100, estimate.percent || 0));
   const actual = estimate.source === 'actual_prompt_usage';
   const promptPreview = estimate.promptPreview;
-  const promptText = promptPreview?.text
-    ? `${promptPreview.text}${promptPreview.truncated ? `\n\n${t('context.promptTruncated', { chars: promptPreview.chars })}` : ''}`
-    : '';
   const contextTitle = t(actual ? 'context.actualSummary' : 'context.summary', {
     percent,
     used: estimate.usedLabel,
@@ -26,35 +20,18 @@ export function ContextMeter({ estimate }) {
         <span className="context-meter-value">{estimate.usedLabel}</span>
       </div>
       {promptPreview?.text && (
-        <>
-          <button
-            type="button"
-            className="context-prompt-trigger"
-            title={t('context.promptTitle')}
-            onClick={() => setPromptOpen(true)}
-          >
-            <span>{t('context.promptToggle')}</span>
-            <span title={promptPreview.modelId || ''}>{t('context.promptMeta', {
-              model: promptPreview.modelId || '-',
-              used: estimate.usedLabel || promptPreview.usedTokens || '-',
-            })}</span>
-          </button>
-          {promptOpen && (
-            <DialogShell
-              title={t('context.promptTitle')}
-              subtitle={t('context.promptMeta', {
-                model: promptPreview.modelId || '-',
-                used: estimate.usedLabel || promptPreview.usedTokens || '-',
-              })}
-              onClose={() => setPromptOpen(false)}
-              dialogClassName="settings-dialog"
-            >
-              <div className="prompt-preview-content">
-                <pre className="prompt-preview-text">{promptText}</pre>
-              </div>
-            </DialogShell>
-          )}
-        </>
+        <button
+          type="button"
+          className="context-prompt-trigger"
+          title={t('context.promptTitle')}
+          onClick={onOpenPrompt}
+        >
+          <span>{t('context.promptToggle')}</span>
+          <span title={promptPreview.modelId || ''}>{t('context.promptMeta', {
+            model: promptPreview.modelId || '-',
+            used: estimate.usedLabel || promptPreview.usedTokens || '-',
+          })}</span>
+        </button>
       )}
     </div>
   );

--- a/client/src/components/ContextMeter.jsx
+++ b/client/src/components/ContextMeter.jsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
 import { useT } from '../i18n/I18nProvider.jsx';
+import { DialogShell } from './dialogs/DialogShell.jsx';
 
 export function ContextMeter({ estimate }) {
   const t = useT();
+  const [promptOpen, setPromptOpen] = useState(false);
   if (!estimate) return null;
 
   const percent = Math.max(0, Math.min(100, estimate.percent || 0));
@@ -23,16 +26,35 @@ export function ContextMeter({ estimate }) {
         <span className="context-meter-value">{estimate.usedLabel}</span>
       </div>
       {promptPreview?.text && (
-        <details className="context-prompt-details">
-          <summary className="context-prompt-summary" title={t('context.promptTitle')}>
+        <>
+          <button
+            type="button"
+            className="context-prompt-trigger"
+            title={t('context.promptTitle')}
+            onClick={() => setPromptOpen(true)}
+          >
             <span>{t('context.promptToggle')}</span>
             <span title={promptPreview.modelId || ''}>{t('context.promptMeta', {
               model: promptPreview.modelId || '-',
               used: estimate.usedLabel || promptPreview.usedTokens || '-',
             })}</span>
-          </summary>
-          <pre className="context-prompt-text">{promptText}</pre>
-        </details>
+          </button>
+          {promptOpen && (
+            <DialogShell
+              title={t('context.promptTitle')}
+              subtitle={t('context.promptMeta', {
+                model: promptPreview.modelId || '-',
+                used: estimate.usedLabel || promptPreview.usedTokens || '-',
+              })}
+              onClose={() => setPromptOpen(false)}
+              dialogClassName="settings-dialog"
+            >
+              <div className="prompt-preview-content">
+                <pre className="prompt-preview-text">{promptText}</pre>
+              </div>
+            </DialogShell>
+          )}
+        </>
       )}
     </div>
   );

--- a/client/src/components/dialogs/PromptPreviewDialog.jsx
+++ b/client/src/components/dialogs/PromptPreviewDialog.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useT } from '../../i18n/I18nProvider.jsx';
+import { MarkdownBlock } from '../markdown/MarkdownBlock.jsx';
+import { DialogShell } from './DialogShell.jsx';
+
+function promptTextFromEstimate(estimate, truncatedMessage) {
+  const preview = estimate?.promptPreview;
+  if (!preview?.text) return '';
+  return `${preview.text}${preview.truncated ? `\n\n${truncatedMessage}` : ''}`;
+}
+
+// value/onChange/editable are intentionally part of the API now so this viewer can
+// become an editor later without changing its callers or duplicating another dialog.
+export function PromptPreviewDialog({
+  estimate,
+  onClose,
+  value,
+  onChange,
+  editable = false,
+  initialMode = 'source',
+}) {
+  const t = useT();
+  const preview = estimate?.promptPreview;
+  const sourceText = useMemo(() => promptTextFromEstimate(
+    estimate,
+    t('context.promptTruncated', { chars: preview?.chars || 0 }),
+  ), [estimate, preview?.chars, t]);
+  const [mode, setMode] = useState(initialMode);
+  const [draft, setDraft] = useState(value ?? sourceText);
+
+  useEffect(() => {
+    setDraft(value ?? sourceText);
+  }, [sourceText, value]);
+
+  if (!preview?.text) return null;
+
+  const updateDraft = nextValue => {
+    setDraft(nextValue);
+    onChange?.(nextValue);
+  };
+
+  return (
+    <DialogShell
+      title={t('context.promptTitle')}
+      subtitle={t('context.promptMeta', {
+        model: preview.modelId || '-',
+        used: estimate.usedLabel || preview.usedTokens || '-',
+      })}
+      onClose={onClose}
+      dialogClassName="settings-dialog prompt-preview-dialog"
+      headerActions={(
+        <div className="settings-segment prompt-preview-mode" role="group" aria-label={t('context.promptViewMode')}>
+          <button
+            type="button"
+            className={`settings-segment-btn${mode === 'source' ? ' active' : ''}`}
+            onClick={() => setMode('source')}
+          >
+            {t('context.promptSource')}
+          </button>
+          <button
+            type="button"
+            className={`settings-segment-btn${mode === 'markdown' ? ' active' : ''}`}
+            onClick={() => setMode('markdown')}
+          >
+            {t('context.promptMarkdown')}
+          </button>
+        </div>
+      )}
+    >
+      <div className="prompt-preview-content">
+        {mode === 'source' && editable ? (
+          <textarea
+            className="prompt-preview-editor"
+            value={draft}
+            onChange={event => updateDraft(event.target.value)}
+            spellCheck={false}
+          />
+        ) : mode === 'source' ? (
+          <pre className="prompt-preview-text">{draft}</pre>
+        ) : (
+          <MarkdownBlock content={draft} className="prompt-preview-markdown" />
+        )}
+      </div>
+    </DialogShell>
+  );
+}

--- a/client/src/components/dialogs/PromptPreviewDialog.jsx
+++ b/client/src/components/dialogs/PromptPreviewDialog.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useT } from '../../i18n/I18nProvider.jsx';
 import { MarkdownBlock } from '../markdown/MarkdownBlock.jsx';
 import { DialogShell } from './DialogShell.jsx';
@@ -27,10 +27,7 @@ export function PromptPreviewDialog({
   ), [estimate, preview?.chars, t]);
   const [mode, setMode] = useState(initialMode);
   const [draft, setDraft] = useState(value ?? sourceText);
-
-  useEffect(() => {
-    setDraft(value ?? sourceText);
-  }, [sourceText, value]);
+  const displayedValue = editable ? (value ?? draft) : sourceText;
 
   if (!preview?.text) return null;
 
@@ -71,14 +68,14 @@ export function PromptPreviewDialog({
         {mode === 'source' && editable ? (
           <textarea
             className="prompt-preview-editor"
-            value={draft}
+            value={displayedValue}
             onChange={event => updateDraft(event.target.value)}
             spellCheck={false}
           />
         ) : mode === 'source' ? (
-          <pre className="prompt-preview-text">{draft}</pre>
+          <pre className="prompt-preview-text">{displayedValue}</pre>
         ) : (
-          <MarkdownBlock content={draft} className="prompt-preview-markdown" />
+          <MarkdownBlock content={displayedValue} className="prompt-preview-markdown" />
         )}
       </div>
     </DialogShell>

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -69,6 +69,9 @@ export const en = {
   'context.promptTitle': 'View first prompt',
   'context.promptMeta': '{model} · {used} tok',
   'context.promptTruncated': 'Prompt is long and was truncated; full length {chars} chars.',
+  'context.promptViewMode': 'Prompt view mode',
+  'context.promptSource': 'Source',
+  'context.promptMarkdown': 'Markdown',
 
   // Attachments (task text block + display)
   'attach.taskBlockHeader': '[Attachments]',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -70,6 +70,9 @@ export const zh = {
   'context.promptTitle': '查看首轮提示词',
   'context.promptMeta': '{model} · {used} tok',
   'context.promptTruncated': '提示词过长，已截断；完整长度 {chars} 字符。',
+  'context.promptViewMode': '提示词查看方式',
+  'context.promptSource': '原文',
+  'context.promptMarkdown': 'Markdown',
 
   // 附件（任务文本块 + 展示）
   'attach.taskBlockHeader': '[附件]',

--- a/config/model-catalog/gemini-overrides.json
+++ b/config/model-catalog/gemini-overrides.json
@@ -1,0 +1,60 @@
+{
+  "source": {
+    "catalog": "https://ai.google.dev/gemini-api/docs/pricing",
+    "note": "Locally verified Gemini API free-tier and Desktop Agent compatibility overrides. Keep separate from the provider model listing."
+  },
+  "models": {
+    "gemini-3-pro-preview": {
+      "agentCompatible": false,
+      "description": "Excluded from free-tier Agent runs because this alias resolves to a Gemini 3 Pro model whose free tier is unavailable."
+    },
+    "gemini-3.1-pro-preview": {
+      "agentCompatible": false,
+      "description": "Gemini API Free Tier is not available for this model."
+    },
+    "gemini-3.1-pro-preview-customtools": {
+      "agentCompatible": false,
+      "description": "Gemini API Free Tier is not available for this model."
+    },
+    "gemini-pro-latest": {
+      "agentCompatible": false,
+      "description": "Excluded from free-tier Agent runs because the moving alias can resolve to a paid-only Pro model."
+    },
+    "gemini-omni-flash-preview": {
+      "agentCompatible": false,
+      "description": "Gemini API Free Tier is not available for this model."
+    },
+    "gemini-2.5-computer-use-preview-10-2025": {
+      "agentCompatible": false,
+      "description": "Gemini API Free Tier is not available for this model."
+    },
+    "nano-banana-pro-preview": {
+      "agentCompatible": false,
+      "description": "Image generation model; excluded from Desktop Agent planning and free-tier smoke runs."
+    },
+    "lyria-3-clip-preview": {
+      "agentCompatible": false,
+      "description": "Music generation model; excluded from Desktop Agent planning."
+    },
+    "lyria-3-pro-preview": {
+      "agentCompatible": false,
+      "description": "Music generation model; excluded from Desktop Agent planning."
+    },
+    "antigravity-preview-05-2026": {
+      "agentCompatible": false,
+      "description": "Managed agent model; excluded from local Desktop Agent planning and free-tier smoke runs."
+    },
+    "deep-research-max-preview-04-2026": {
+      "agentCompatible": false,
+      "description": "Managed research agent; excluded from local Desktop Agent planning and free-tier smoke runs."
+    },
+    "deep-research-preview-04-2026": {
+      "agentCompatible": false,
+      "description": "Managed research agent; excluded from local Desktop Agent planning and free-tier smoke runs."
+    },
+    "deep-research-pro-preview-12-2025": {
+      "agentCompatible": false,
+      "description": "Managed research agent; excluded from local Desktop Agent planning and free-tier smoke runs."
+    }
+  }
+}

--- a/test/model-metadata.test.ts
+++ b/test/model-metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { extractModelMetadata } from '../agent/core/providers/model-metadata.ts';
 import { getNvidiaCatalogModelMetadata, hasNvidiaCatalogModel } from '../agent/core/providers/nvidia-catalog.ts';
+import { getGeminiCatalogModelMetadata } from '../agent/core/providers/gemini-catalog.ts';
 import { createGeminiProvider } from '../agent/core/providers/gemini.ts';
 import { createOpenAICompatProvider } from '../agent/core/providers/openai-compat.ts';
 
@@ -80,6 +81,16 @@ describe('model metadata', () => {
       supportedMessageRoles: ['user', 'assistant'],
     });
     expect(getNvidiaCatalogModelMetadata('deepseek-ai/deepseek-v4-pro')).not.toHaveProperty('supportedMessageRoles');
+  });
+
+  it('loads Gemini free-tier and Agent compatibility overrides', () => {
+    expect(getGeminiCatalogModelMetadata('gemini-3.1-pro-preview')).toMatchObject({
+      agentCompatible: false,
+    });
+    expect(getGeminiCatalogModelMetadata('GEMINI-3-PRO-PREVIEW')).toMatchObject({
+      agentCompatible: false,
+    });
+    expect(getGeminiCatalogModelMetadata('gemini-2.5-flash')).toEqual({});
   });
 
   it('only exposes official NVIDIA API models still present in the public catalog', async () => {
@@ -162,5 +173,23 @@ describe('model metadata', () => {
       maxOutputTokens: 65_536,
       supportedGenerationMethods: ['generateContent', 'countTokens'],
     }]);
+  });
+
+  it('enriches Gemini model listings from local overrides', async () => {
+    const provider = createGeminiProvider({
+      models: {
+        list: vi.fn().mockResolvedValue(asyncItems([{
+          name: 'models/gemini-3.1-pro-preview',
+          displayName: 'Gemini 3.1 Pro Preview',
+          supportedGenerationMethods: ['generateContent'],
+        }])),
+      },
+    } as any);
+
+    await expect(provider.listModels()).resolves.toEqual([expect.objectContaining({
+      id: 'gemini-3.1-pro-preview',
+      provider: 'gemini',
+      agentCompatible: false,
+    })]);
   });
 });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { buildGeminiTaskMessages, buildNvidiaTaskMessages, compactAgentHistory } from '../agent/core/prompts.ts';
+import {
+  buildGeminiAgentPromptPayload,
+  buildGeminiTaskMessages,
+  buildNvidiaTaskMessages,
+  compactAgentHistory,
+  selectGeminiToolNames,
+} from '../agent/core/prompts.ts';
 import { estimatePayloadTokens } from '../agent/core/context-estimate.ts';
 
 describe('agent prompts', () => {
@@ -96,6 +102,155 @@ describe('agent prompts', () => {
 
     expect(messages[0].content).toContain('Chrome DevTools 工具可用于');
     expect(messages[0].content).not.toContain('Chrome MCP 已启用但默认不展开');
+  });
+
+  it('omits inactive Chrome and IDE capabilities from Gemini prompts and tools', () => {
+    vi.stubEnv('CHROME_MCP_ENABLED', 'true');
+    vi.stubEnv('IDE_MCP_ENABLED', 'true');
+    const payload = buildGeminiAgentPromptPayload({
+      task: '杭州今天天气怎么样？',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+    const toolNames = payload.tools[0].functionDeclarations.map(tool => tool.name);
+
+    expect(payload.systemInstruction).not.toContain('Chrome MCP');
+    expect(payload.systemInstruction).not.toContain('IDE MCP');
+    expect(toolNames).not.toContain('chrome_list_tools');
+    expect(toolNames).not.toContain('chrome_call_tool');
+    expect(toolNames).not.toContain('ide_list_tools');
+    expect(toolNames).not.toContain('ide_call_tool');
+  });
+
+  it('loads Gemini Chrome and IDE capabilities when the task requires them', () => {
+    vi.stubEnv('CHROME_MCP_ENABLED', 'true');
+    vi.stubEnv('IDE_MCP_ENABLED', 'true');
+    const payload = buildGeminiAgentPromptPayload({
+      task: '用 Chrome DevTools 和 IntelliJ 检查页面及代码问题',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+    const toolNames = payload.tools[0].functionDeclarations.map(tool => tool.name);
+
+    expect(payload.systemInstruction).toContain('Chrome DevTools 工具可用于');
+    expect(payload.systemInstruction).toContain('当 IDE MCP 已启用时');
+    expect(toolNames).toContain('chrome_list_tools');
+    expect(toolNames).toContain('chrome_call_tool');
+    expect(toolNames).toContain('ide_list_tools');
+    expect(toolNames).toContain('ide_call_tool');
+  });
+
+  it('keeps shared Gemini and NVIDIA agent rules semantically identical', () => {
+    const context = {
+      task: '读取官网并总结内容',
+      systemPrompt: '[Agent 记忆]\n偏好：简洁回答',
+      step: 2,
+      history: [{
+        step: 1,
+        action: { tool: 'browser', type: 'navigate', url: 'https://example.com' },
+        result: '页面内容',
+      }],
+      observation: { browser: { text: 'Example page' } },
+      conversationHistory: [
+        { role: 'user', content: '先打开官网' },
+        { role: 'assistant', content: '好的' },
+      ],
+    };
+    const gemini = buildGeminiAgentPromptPayload(context);
+    const nvidia = buildNvidiaTaskMessages(context);
+    const normalize = (value: string) => value.replace(/\s+/g, ' ').trim();
+    const ruleSection = (value: string) => normalize(value.split('规则：')[1].split('附加约束：')[0]);
+
+    expect(ruleSection(gemini.systemInstruction)).toBe(ruleSection(nvidia[0].content));
+    expect(JSON.parse(gemini.contents.at(-1)!.parts[0].text)).toEqual(JSON.parse(nvidia[1].content));
+    expect(gemini.contents[0].parts[0].text).toBe('先打开官网');
+    expect(nvidia[0].content).toContain('用户: 先打开官网');
+    expect(gemini.systemInstruction).toContain('[Agent 记忆]');
+    expect(nvidia[0].content).toContain('[Agent 记忆]');
+  });
+
+  it('exposes the same browser wait and page-content capabilities to both providers', () => {
+    const gemini = buildGeminiAgentPromptPayload({
+      task: '检查当前网页',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+    const geminiToolNames = gemini.tools[0].functionDeclarations.map(tool => tool.name);
+    const nvidia = buildNvidiaTaskMessages({
+      task: '检查当前网页',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+
+    expect(geminiToolNames).toContain('wait');
+    expect(geminiToolNames).toContain('get_page_content');
+    expect(nvidia[0].content).toContain('wait(seconds)');
+    expect(nvidia[0].content).toContain('get_page_content()');
+  });
+
+  it('selects Gemini base tool schemas dynamically by task', () => {
+    const chatTools = selectGeminiToolNames({ task: '你好，介绍一下你自己' });
+    const webTools = selectGeminiToolNames({ task: '查询今天苏州天气' });
+    const codeTools = selectGeminiToolNames({ task: '检查项目代码并运行测试' });
+    const imageTools = selectGeminiToolNames({ task: '分析这张图片\n[附件]\n- 图片: /tmp/example.png' });
+    const desktopTools = selectGeminiToolNames({ task: '打开 macOS 应用并查看窗口' });
+    const gitTools = selectGeminiToolNames({ task: '拉取最新' });
+
+    expect([...chatTools].sort()).toEqual(['ask_user', 'finish', 'notify_user']);
+    expect(webTools.has('web_search')).toBe(true);
+    expect(webTools.has('navigate')).toBe(true);
+    expect(webTools.has('read_file')).toBe(false);
+    expect(codeTools.has('read_file')).toBe(true);
+    expect(codeTools.has('codegraph_query')).toBe(true);
+    expect(codeTools.has('run_safe')).toBe(true);
+    expect(codeTools.has('web_search')).toBe(false);
+    expect(imageTools.has('image_analyze')).toBe(true);
+    expect(imageTools.has('run_safe')).toBe(false);
+    expect(desktopTools.has('open_app')).toBe(true);
+    expect(desktopTools.has('image_analyze')).toBe(true);
+    expect(gitTools.has('run_safe')).toBe(true);
+    expect(gitTools.has('read_file')).toBe(false);
+    expect(gitTools.has('web_search')).toBe(false);
+  });
+
+  it('keeps Gemini tool groups loaded after they appear in execution history', () => {
+    const selected = selectGeminiToolNames({
+      task: '继续',
+      history: [
+        { action: { tool: 'browser', type: 'navigate' } },
+        { action: { tool: 'fs', type: 'read_file' } },
+      ],
+    });
+
+    expect(selected.has('navigate')).toBe(true);
+    expect(selected.has('web_search')).toBe(true);
+    expect(selected.has('read_file')).toBe(true);
+    expect(selected.has('codegraph_query')).toBe(true);
+  });
+
+  it('keeps the complete readonly Gemini tool set for delegated analysis', () => {
+    const payload = buildGeminiAgentPromptPayload({
+      task: '分析这个问题',
+      step: 1,
+      history: [],
+      observation: {},
+    }, 'readonly');
+    const names = payload.tools[0].functionDeclarations.map(tool => tool.name);
+
+    expect(names).toEqual(expect.arrayContaining([
+      'list_dir',
+      'read_file',
+      'get_file_info',
+      'search_files',
+      'web_search',
+      'image_analyze',
+      'codegraph_query',
+      'finish',
+    ]));
   });
 
   it('bounds prompt history count and individual result size', () => {

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -4,6 +4,7 @@ import {
   buildGeminiTaskMessages,
   buildNvidiaTaskMessages,
   compactAgentHistory,
+  sanitizeConversationHistory,
   selectGeminiToolNames,
 } from '../agent/core/prompts.ts';
 import { estimatePayloadTokens } from '../agent/core/context-estimate.ts';
@@ -200,21 +201,78 @@ describe('agent prompts', () => {
     const desktopTools = selectGeminiToolNames({ task: '打开 macOS 应用并查看窗口' });
     const gitTools = selectGeminiToolNames({ task: '拉取最新' });
 
-    expect([...chatTools].sort()).toEqual(['ask_user', 'finish', 'notify_user']);
+    expect([...chatTools].sort()).toEqual(['ask_user', 'finish', 'notify_user', 'web_search']);
     expect(webTools.has('web_search')).toBe(true);
     expect(webTools.has('navigate')).toBe(true);
     expect(webTools.has('read_file')).toBe(false);
     expect(codeTools.has('read_file')).toBe(true);
     expect(codeTools.has('codegraph_query')).toBe(true);
     expect(codeTools.has('run_safe')).toBe(true);
-    expect(codeTools.has('web_search')).toBe(false);
+    expect(codeTools.has('web_search')).toBe(true);
+    expect(codeTools.has('navigate')).toBe(false);
     expect(imageTools.has('image_analyze')).toBe(true);
     expect(imageTools.has('run_safe')).toBe(false);
     expect(desktopTools.has('open_app')).toBe(true);
     expect(desktopTools.has('image_analyze')).toBe(true);
     expect(gitTools.has('run_safe')).toBe(true);
     expect(gitTools.has('read_file')).toBe(false);
-    expect(gitTools.has('web_search')).toBe(false);
+    expect(gitTools.has('web_search')).toBe(true);
+    expect(gitTools.has('navigate')).toBe(false);
+  });
+
+  it('keeps web_search as a lightweight fallback for uncategorized current-information questions', () => {
+    const tools = selectGeminiToolNames({ task: 'kimi为什么从英伟达模型nim里拿掉了' });
+
+    expect(tools.has('web_search')).toBe(true);
+    expect(tools.has('navigate')).toBe(false);
+    expect(tools.has('finish')).toBe(true);
+  });
+
+  it('removes corrupted assistant echoes and their dangling user turns from conversation history', () => {
+    const sanitized = sanitizeConversationHistory([
+      { role: 'user', content: 'kimi为什么从英伟达模型nim里拿掉了' },
+      { role: 'assistant', content: 'kimi为什么从英伟达模型nim里拿掉了' },
+      { role: 'assistant', content: 'kimi为什么从英伟达模型nim里拿掉了' },
+      { role: 'user', content: '保留这个有效问题' },
+      { role: 'assistant', content: '这是有效回答' },
+    ]);
+
+    expect(sanitized).toEqual([
+      { role: 'user', content: '保留这个有效问题' },
+      { role: 'assistant', content: '这是有效回答' },
+    ]);
+  });
+
+  it('keeps a new Gemini task isolated from corrupted previous turns', () => {
+    const payload = buildGeminiAgentPromptPayload({
+      task: '今天天气怎么样',
+      step: 1,
+      history: [],
+      observation: {},
+      conversationHistory: [
+        { role: 'user', content: 'kimi为什么从英伟达模型nim里拿掉了' },
+        { role: 'assistant', content: 'kimi为什么从英伟达模型nim里拿掉了' },
+        { role: 'assistant', content: 'kimi为什么从英伟达模型nim里拿掉了' },
+      ],
+    });
+    const taskPayload = JSON.parse(payload.contents.at(-1).parts[0].text);
+
+    expect(payload.contents).toHaveLength(1);
+    expect(taskPayload.task).toBe('今天天气怎么样');
+    expect(payload.systemInstruction).toContain('task 字段是本轮唯一执行目标');
+  });
+
+  it('does not let unrelated conversation history activate tools for a new explicit task', () => {
+    const tools = selectGeminiToolNames({
+      task: '你好',
+      conversationHistory: [
+        { role: 'user', content: '检查项目文件并运行测试' },
+        { role: 'assistant', content: '已完成' },
+      ],
+    });
+
+    expect(tools.has('read_file')).toBe(false);
+    expect(tools.has('run_safe')).toBe(false);
   });
 
   it('keeps Gemini tool groups loaded after they appear in execution history', () => {

--- a/test/session-checkpoint.test.ts
+++ b/test/session-checkpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
@@ -145,6 +145,38 @@ const events = () => {
 };
 
 describe('runtime: session checkpoint integration', () => {
+  it('rejects a finish answer that only echoes the task and retries the next step', async () => {
+    const cancelSignal = new AbortController().signal;
+    const execute = vi.fn((_state, action) => (
+      action.type === 'finish' ? action.answer : 'verified search result'
+    ));
+
+    const result = await runAgentRuntime({
+      task: 'kimi为什么从英伟达模型nim里拿掉了',
+      maxSteps: 3,
+      onEvent: noop,
+      cancelSignal,
+      initialize,
+      observe,
+      decide: ({ step }) => {
+        if (step === 1) return decision({ type: 'finish', answer: 'kimi为什么从英伟达模型nim里拿掉了' });
+        if (step === 2) return decision({ tool: 'search', type: 'web_search', query: 'Kimi NVIDIA NIM model removed' });
+        return decision({ type: 'finish', answer: 'Kimi 的 NIM 上架状态需要以 NVIDIA 当前模型目录为准。' });
+      },
+      authorize: approve,
+      execute,
+      cleanup: noop,
+    });
+
+    expect(result.steps[0]).toMatchObject({
+      action: { type: 'finish' },
+      resultStatus: 'failed',
+      resultError: 'finish answer echoed task',
+    });
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(result.answer).toBe('Kimi 的 NIM 上架状态需要以 NVIDIA 当前模型目录为准。');
+  });
+
   it('records action target URL in history instead of the previous observation URL', async () => {
     const cancelSignal = new AbortController().signal;
     const result = await runAgentRuntime({


### PR DESCRIPTION
## Summary

- unify shared NVIDIA and Gemini agent rules while preserving provider-specific request formats
- dynamically select Gemini Function Declarations from task, conversation, observation, and execution history
- keep `web_search` as a lightweight fallback for uncategorized time-sensitive questions
- make the current `task` authoritative over conversation history and remove corrupted assistant echo turns
- reject `finish` actions that only repeat the task so the Agent retries with a substantive action
- lazily load Chrome and JetBrains MCP prompts/tools, and align missing browser capabilities across providers
- make Gemini request logging and context preview use the same complete prompt payload
- use one shared Prompt preview dialog on both the home and conversation composers
- support Source and Markdown preview modes, with an editable value/onChange API reserved for future prompt editing
- add Gemini model compatibility overrides for unsupported or paid-only models

## Testing

- `npm test` — 45 files, 302 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run build:client`
- manually verified the shared Prompt dialog from both home and conversation pages
- manually verified Source/Markdown switching, scrolling, and Escape close behavior
- reproduced and regression-tested the Kimi echo → weather task drift failure chain