### PR TITLE
feat: persist sessions on backend and recover from traces

### DIFF
--- a/agent/core/contracts.ts
+++ b/agent/core/contracts.ts
@@ -120,7 +120,7 @@ interface EventTraceFields {
 
 export type AgentEvent = EventTraceFields & (
   | { type: 'status'; status: string; message?: string }
-  | { type: 'run_meta'; startedAt: number; model?: string; agentModels?: string[]; task?: string }
+  | { type: 'run_meta'; startedAt: number; model?: string; agentModels?: string[]; task?: string; sessionId?: string; projectId?: string | null; strategy?: string }
   | { type: 'step'; step: number; stage: 'observe'; observation: unknown }
   | { type: 'step'; step: number; stage: 'action'; rationale?: string; action: AgentAction; usage?: TokenUsage | null }
   | { type: 'step'; step: number; stage: 'result'; result: unknown; resultStatus?: ActionResultStatus; resultError?: string | null }

--- a/agent/core/session-store.ts
+++ b/agent/core/session-store.ts
@@ -1,0 +1,467 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createPersistenceQueue } from '../../helpers/persistence-queue.ts';
+import { listTraceRuns, readTraceEvents } from '../../helpers/trace-store.ts';
+import { projectDataDir, type ProjectStore } from './project-store.ts';
+
+const SESSIONS_FILE = 'chat-sessions.json';
+const SESSION_VERSION = 1;
+
+type StoredSession = Record<string, any>;
+
+interface ScopeState {
+  version: number;
+  activeSessionId: string | null;
+  sessions: StoredSession[];
+  dismissedTraceRunIds: string[];
+  skippedTraceRunIds: string[];
+  updatedAt: string;
+}
+
+interface RunLogEntry {
+  task: string;
+  model: string | null;
+  startedAt: number | null;
+}
+
+function sessionFile(dataDir: string) {
+  return path.join(dataDir, SESSIONS_FILE);
+}
+
+function uniqueStrings(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.filter(item => typeof item === 'string').map(item => item.trim()).filter(Boolean))];
+}
+
+function finiteNumber(value: unknown, fallback: number) {
+  return Number.isFinite(value) ? Number(value) : fallback;
+}
+
+function generateSessionId() {
+  return `session_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function normalizeMessages(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(message => message && typeof message === 'object')
+    .filter((message: any) => (message.role === 'user' || message.role === 'assistant') && typeof message.content === 'string')
+    .map((message: any) => ({
+      role: message.role,
+      content: message.content,
+      ...(Number.isFinite(message.ts) ? { ts: Number(message.ts) } : {}),
+      ...(typeof message.model === 'string' && message.model.trim() ? { model: message.model.trim() } : {}),
+      ...(uniqueStrings(message.modelsUsed).length > 0 ? { modelsUsed: uniqueStrings(message.modelsUsed) } : {}),
+      ...(typeof message.pending === 'string' && message.pending ? { pending: message.pending } : {}),
+    }));
+}
+
+function normalizeAgentRuns(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const runs = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const runId = typeof item.runId === 'string' && item.runId ? item.runId : null;
+    if (!runId || seen.has(runId)) continue;
+    seen.add(runId);
+    runs.push({ runId, trace: [], meta: item.meta && typeof item.meta === 'object' ? item.meta : null });
+  }
+  return runs.slice(0, 30);
+}
+
+function normalizeSession(value: unknown, projectId: string | null): StoredSession | null {
+  if (!value || typeof value !== 'object') return null;
+  const session: any = value;
+  const now = Date.now();
+  const id = typeof session.id === 'string' && session.id.trim() ? session.id.trim() : generateSessionId();
+  const model = typeof session.model === 'string' && session.model.trim() ? session.model.trim() : null;
+  const agentRunId = typeof session.agentRunId === 'string' && session.agentRunId ? session.agentRunId : null;
+  return {
+    id,
+    messages: normalizeMessages(session.messages),
+    model,
+    modelsUsed: uniqueStrings(session.modelsUsed),
+    agentTrace: [],
+    agentRunId,
+    agentMeta: session.agentMeta && typeof session.agentMeta === 'object' ? session.agentMeta : null,
+    agentRuns: normalizeAgentRuns(session.agentRuns),
+    projectId,
+    createdAt: finiteNumber(session.createdAt, now),
+    updatedAt: finiteNumber(session.updatedAt, now),
+  };
+}
+
+function emptyScopeState(): ScopeState {
+  return {
+    version: SESSION_VERSION,
+    activeSessionId: null,
+    sessions: [],
+    dismissedTraceRunIds: [],
+    skippedTraceRunIds: [],
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+async function readScopeState(dataDir: string, projectId: string | null): Promise<ScopeState> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(sessionFile(dataDir), 'utf8'));
+    const sessions = Array.isArray(parsed.sessions)
+      ? parsed.sessions.map((session: unknown) => normalizeSession(session, projectId)).filter(Boolean) as StoredSession[]
+      : [];
+    const activeSessionId = sessions.some(session => session.id === parsed.activeSessionId)
+      ? parsed.activeSessionId
+      : sessions[0]?.id || null;
+    return {
+      version: SESSION_VERSION,
+      activeSessionId,
+      sessions,
+      dismissedTraceRunIds: uniqueStrings(parsed.dismissedTraceRunIds),
+      skippedTraceRunIds: uniqueStrings(parsed.skippedTraceRunIds),
+      updatedAt: typeof parsed.updatedAt === 'string' ? parsed.updatedAt : new Date(0).toISOString(),
+    };
+  } catch {
+    return emptyScopeState();
+  }
+}
+
+async function writeScopeState(dataDir: string, state: ScopeState) {
+  await fs.mkdir(dataDir, { recursive: true });
+  const target = sessionFile(dataDir);
+  const tmp = `${target}.tmp`;
+  const next = { ...state, version: SESSION_VERSION, updatedAt: new Date().toISOString() };
+  await fs.writeFile(tmp, JSON.stringify(next, null, 2), 'utf8');
+  await fs.rename(tmp, target);
+}
+
+function sessionRunIds(session: StoredSession) {
+  return uniqueStrings([
+    session.agentRunId,
+    ...(Array.isArray(session.agentRuns) ? session.agentRuns.map((run: any) => run?.runId) : []),
+  ]);
+}
+
+function eventTime(event: any) {
+  for (const value of [event?.timestamp, event?.end_time, event?.start_time, event?.time, event?.ts]) {
+    if (Number.isFinite(value)) return Number(value);
+    if (typeof value === 'string') {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return null;
+}
+
+function lastEvent(events: any[], predicate: (event: any) => boolean) {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    if (predicate(events[index])) return events[index];
+  }
+  return null;
+}
+
+async function loadRunLogIndex(memoryDir: string) {
+  const index = new Map<string, RunLogEntry>();
+  const logsDir = path.join(memoryDir, 'logs');
+  let files: string[] = [];
+  try {
+    files = (await fs.readdir(logsDir)).filter(file => file.endsWith('.log')).sort();
+  } catch {
+    return index;
+  }
+
+  const pattern = /^\[([^\]]+)\s+INFO\].*POST \/api\/agent model=(\S+) headless=\S+ task=("(?:\\.|[^"\\])*") run_id=(run_[a-z0-9]+_[a-z0-9]+)$/gim;
+  for (const file of files) {
+    let raw = '';
+    try {
+      raw = await fs.readFile(path.join(logsDir, file), 'utf8');
+    } catch {
+      continue;
+    }
+    for (const match of raw.matchAll(pattern)) {
+      try {
+        index.set(match[4], {
+          task: JSON.parse(match[3]),
+          model: match[2] || null,
+          startedAt: Number.isFinite(Date.parse(match[1])) ? Date.parse(match[1]) : null,
+        });
+      } catch {
+        // Ignore malformed historical log entries.
+      }
+    }
+  }
+  return index;
+}
+
+function recoverSessionFromTrace(
+  events: any[],
+  runId: string,
+  projectId: string | null,
+  logEntry: RunLogEntry | undefined,
+) {
+  if (!Array.isArray(events) || events.length === 0) return null;
+  const runMeta = lastEvent(events, event => event?.type === 'run_meta');
+  const task = typeof runMeta?.task === 'string' && runMeta.task.trim()
+    ? runMeta.task.trim()
+    : logEntry?.task?.trim();
+  const model = typeof runMeta?.model === 'string' && runMeta.model.trim()
+    ? runMeta.model.trim()
+    : logEntry?.model || null;
+  if (!task || model === 'test-model' || task === 'trace test') return null;
+
+  const terminal = lastEvent(events, event => event?.type === 'done' || event?.type === 'error');
+  const done = terminal?.type === 'done' ? terminal : null;
+  const error = terminal?.type === 'error' ? terminal : null;
+  const plannedModels = events.flatMap(event => event?.type === 'model_plan'
+    ? (event.model ? [event.model] : event.models || [])
+    : []);
+  const modelsUsed = uniqueStrings([...(done?.meta?.models_used || []), ...plannedModels, model]);
+  const timestamps = events.map(eventTime).filter(Number.isFinite) as number[];
+  const startedAt = timestamps.length > 0 ? Math.min(...timestamps) : (logEntry?.startedAt || Date.now());
+  const endedAt = timestamps.length > 0 ? Math.max(...timestamps) : startedAt;
+  const status = done
+    ? (done.quality?.status || done.meta?.status || 'done')
+    : error?.error === 'Agent 已取消' ? 'cancelled' : error ? 'error' : 'incomplete';
+  const messages: any[] = [{ role: 'user', content: task, ts: startedAt, ...(model ? { model } : {}), ...(modelsUsed.length ? { modelsUsed } : {}) }];
+  if (done?.answer) {
+    messages.push({ role: 'assistant', content: done.answer, ts: endedAt, ...(modelsUsed[0] ? { model: modelsUsed[0] } : {}), ...(modelsUsed.length ? { modelsUsed } : {}) });
+  } else if (error?.error) {
+    messages.push({ role: 'assistant', content: `Agent 运行失败：${error.error}`, ts: endedAt, ...(modelsUsed[0] ? { model: modelsUsed[0] } : {}), ...(modelsUsed.length ? { modelsUsed } : {}) });
+  }
+
+  const sessionId = typeof runMeta?.sessionId === 'string' && runMeta.sessionId.trim()
+    ? runMeta.sessionId.trim()
+    : `session_trace_${runId.slice(4)}`;
+  const agentMeta = {
+    task,
+    startedAt,
+    endedAt,
+    elapsedMs: Number.isFinite(done?.meta?.elapsed_ms) ? done.meta.elapsed_ms : Math.max(0, endedAt - startedAt),
+    totalTokens: 0,
+    stepCount: Number.isFinite(done?.meta?.step_count) ? done.meta.step_count : 0,
+    models: modelsUsed,
+    strategy: typeof runMeta?.strategy === 'string' ? runMeta.strategy : 'race',
+    status,
+    runId,
+  };
+  return normalizeSession({
+    id: sessionId,
+    messages,
+    model: modelsUsed[0] || model,
+    modelsUsed,
+    agentRunId: runId,
+    agentMeta,
+    agentRuns: [{ runId, trace: [], meta: agentMeta }],
+    createdAt: startedAt,
+    updatedAt: endedAt,
+  }, projectId);
+}
+
+export function createSessionStore({ memoryDir, projectStore }: { memoryDir: string; projectStore: ProjectStore }) {
+  const queues = new Map<string, ReturnType<typeof createPersistenceQueue>>();
+  const queueFor = (dataDir: string) => {
+    let queue = queues.get(dataDir);
+    if (!queue) {
+      queue = createPersistenceQueue();
+      queues.set(dataDir, queue);
+    }
+    return queue;
+  };
+  const scopes = () => [
+    { projectId: null as string | null, dataDir: memoryDir },
+    ...projectStore.list().projects.map((project: any) => ({
+      projectId: project.projectId as string,
+      dataDir: projectDataDir(memoryDir, project.projectId),
+    })),
+  ];
+  const resolveScope = (projectId: string | null) => {
+    if (!projectId) return { projectId: null, dataDir: memoryDir };
+    const project = projectStore.get(projectId);
+    if (!project) throw new Error(`项目不存在: ${projectId}`);
+    return { projectId, dataDir: projectDataDir(memoryDir, projectId) };
+  };
+
+  async function loadScope(projectId: string | null, dataDir: string, logIndex: Map<string, RunLogEntry>) {
+    return queueFor(dataDir).enqueue(async () => {
+      const state = await readScopeState(dataDir, projectId);
+      const represented = new Set(state.sessions.flatMap(sessionRunIds));
+      const ignored = new Set([...state.dismissedTraceRunIds, ...state.skippedTraceRunIds]);
+      let changed = false;
+      for (const runId of await listTraceRuns(dataDir)) {
+        if (represented.has(runId) || ignored.has(runId)) continue;
+        const recovered = recoverSessionFromTrace(await readTraceEvents(dataDir, runId), runId, projectId, logIndex.get(runId));
+        if (recovered) {
+          state.sessions.push(recovered);
+          represented.add(runId);
+        } else {
+          state.skippedTraceRunIds.push(runId);
+        }
+        changed = true;
+      }
+      state.sessions.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+      if (!state.activeSessionId || !state.sessions.some(session => session.id === state.activeSessionId)) {
+        state.activeSessionId = state.sessions[0]?.id || null;
+        changed = true;
+      }
+      if (changed) await writeScopeState(dataDir, state);
+      return state;
+    });
+  }
+
+  async function loadAll() {
+    const logIndex = await loadRunLogIndex(memoryDir);
+    const loaded = await Promise.all(scopes().map(scope => loadScope(scope.projectId, scope.dataDir, logIndex)));
+    const sessions = loaded.flatMap(state => state.sessions).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+    const activeProjectId = projectStore.list().activeProjectId ?? null;
+    const activeScopeIndex = scopes().findIndex(scope => scope.projectId === activeProjectId);
+    const activeSessionId = loaded[activeScopeIndex]?.activeSessionId || sessions[0]?.id || null;
+    return { version: SESSION_VERSION, sessions, activeSessionId };
+  }
+
+  async function replaceAll(inputSessions: unknown, activeSessionId: unknown) {
+    if (!Array.isArray(inputSessions)) throw new Error('sessions 必须是数组');
+    const scopeList = scopes();
+    const grouped = new Map<string | null, StoredSession[]>();
+    for (const scope of scopeList) grouped.set(scope.projectId, []);
+    for (const raw of inputSessions) {
+      const requestedProjectId = typeof raw?.projectId === 'string' && raw.projectId ? raw.projectId : null;
+      if (!grouped.has(requestedProjectId)) throw new Error(`项目不存在: ${requestedProjectId}`);
+      const normalized = normalizeSession(raw, requestedProjectId);
+      if (normalized) grouped.get(requestedProjectId)!.push(normalized);
+    }
+
+    await Promise.all(scopeList.map(scope => queueFor(scope.dataDir).enqueue(async () => {
+      const previous = await readScopeState(scope.dataDir, scope.projectId);
+      const nextSessions = grouped.get(scope.projectId) || [];
+      const nextRunIds = new Set(nextSessions.flatMap(sessionRunIds));
+      const removedRunIds = previous.sessions.flatMap(sessionRunIds).filter(runId => !nextRunIds.has(runId));
+      const dismissed = new Set([...previous.dismissedTraceRunIds, ...removedRunIds]);
+      for (const runId of nextRunIds) dismissed.delete(runId);
+      const nextActiveSessionId = typeof activeSessionId === 'string'
+        && nextSessions.some(session => session.id === activeSessionId)
+        ? activeSessionId
+        : previous.activeSessionId && nextSessions.some(session => session.id === previous.activeSessionId)
+          ? previous.activeSessionId
+          : nextSessions[0]?.id || null;
+      await writeScopeState(scope.dataDir, {
+        ...previous,
+        sessions: nextSessions,
+        activeSessionId: nextActiveSessionId,
+        dismissedTraceRunIds: [...dismissed],
+      });
+    })));
+    return loadAll();
+  }
+
+  async function mutateScope(projectId: string | null, updater: (state: ScopeState) => void | Promise<void>) {
+    const scope = resolveScope(projectId);
+    return queueFor(scope.dataDir).enqueue(async () => {
+      const state = await readScopeState(scope.dataDir, scope.projectId);
+      await updater(state);
+      state.sessions = state.sessions
+        .map(session => normalizeSession(session, scope.projectId))
+        .filter(Boolean) as StoredSession[];
+      state.sessions.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+      if (!state.activeSessionId || !state.sessions.some(session => session.id === state.activeSessionId)) {
+        state.activeSessionId = state.sessions[0]?.id || null;
+      }
+      await writeScopeState(scope.dataDir, state);
+    });
+  }
+
+  async function recordRunStart({
+    projectId, sessionId, runId, task, model, models, startedAt, retry,
+  }: {
+    projectId: string | null;
+    sessionId: string | null;
+    runId: string;
+    task: string;
+    model: string;
+    models: string[];
+    startedAt: number;
+    retry?: boolean;
+  }) {
+    const id = sessionId || `session_trace_${runId.slice(4)}`;
+    await mutateScope(projectId, state => {
+      let session = state.sessions.find(item => item.id === id);
+      if (!session) {
+        session = normalizeSession({ id, projectId, createdAt: startedAt, updatedAt: startedAt }, projectId)!;
+        state.sessions.unshift(session);
+      }
+      const runModels = uniqueStrings(models.length ? models : [model]);
+      if (!retry) {
+        session.messages.push({ role: 'user', content: task, ts: startedAt, model, modelsUsed: runModels });
+      }
+      session.messages.push({ role: 'assistant', content: 'Agent 正在运行…', pending: 'run', ts: startedAt, model, modelsUsed: runModels });
+      session.model = model;
+      session.modelsUsed = runModels;
+      session.agentRunId = runId;
+      session.agentMeta = null;
+      session.updatedAt = startedAt;
+      state.activeSessionId = id;
+    });
+  }
+
+  async function recordRunTerminal({
+    projectId, sessionId, runId, task, answer, error, models, status, startedAt, endedAt, meta,
+  }: {
+    projectId: string | null;
+    sessionId: string | null;
+    runId: string;
+    task: string;
+    answer: string | null;
+    error: string | null;
+    models: string[];
+    status: string;
+    startedAt: number;
+    endedAt: number;
+    meta?: Record<string, any>;
+  }) {
+    const id = sessionId || `session_trace_${runId.slice(4)}`;
+    await mutateScope(projectId, state => {
+      let session = state.sessions.find(item => item.id === id);
+      if (!session) {
+        session = normalizeSession({
+          id,
+          messages: [{ role: 'user', content: task, ts: startedAt }],
+          createdAt: startedAt,
+        }, projectId)!;
+        state.sessions.unshift(session);
+      }
+      const runModels = uniqueStrings(models);
+      const content = answer || (error ? `Agent 运行失败：${error}` : 'Agent 运行已结束');
+      let pendingIndex = -1;
+      for (let index = session.messages.length - 1; index >= 0; index -= 1) {
+        if (session.messages[index]?.role === 'assistant' && session.messages[index]?.pending === 'run') {
+          pendingIndex = index;
+          break;
+        }
+      }
+      const assistantMessage = { role: 'assistant', content, ts: endedAt, ...(runModels[0] ? { model: runModels[0] } : {}), ...(runModels.length ? { modelsUsed: runModels } : {}) };
+      if (pendingIndex >= 0) session.messages[pendingIndex] = assistantMessage;
+      else session.messages.push(assistantMessage);
+      const agentMeta = {
+        task,
+        startedAt,
+        endedAt,
+        elapsedMs: Number.isFinite(meta?.elapsed_ms) ? meta!.elapsed_ms : Math.max(0, endedAt - startedAt),
+        totalTokens: 0,
+        stepCount: Number.isFinite(meta?.step_count) ? meta!.step_count : 0,
+        models: runModels,
+        strategy: 'race',
+        status,
+        runId,
+      };
+      session.model = runModels[0] || session.model;
+      session.modelsUsed = runModels;
+      session.agentRunId = runId;
+      session.agentMeta = agentMeta;
+      session.agentRuns = [{ runId, trace: [], meta: agentMeta }, ...normalizeAgentRuns(session.agentRuns).filter(run => run.runId !== runId)].slice(0, 30);
+      session.updatedAt = endedAt;
+      state.activeSessionId = id;
+    });
+  }
+
+  return { loadAll, replaceAll, recordRunStart, recordRunTerminal };
+}
+
+export type SessionStore = ReturnType<typeof createSessionStore>;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -110,6 +110,7 @@ export default function App() {
     activeSession,
     messages,
     updateSession,
+    sessionsLoading,
   } = useChatSessions();
   const {
     projects,
@@ -281,6 +282,7 @@ export default function App() {
   // 2. 再订阅 /api/agent/stream/:runId
   // 3. 同时把 UI 切回 Agent 模式，并用占位消息保住聊天视图连续性
   useEffect(() => {
+    if (sessionsLoading) return undefined;
     const controller = new AbortController();
     let aborted = false;
 
@@ -541,7 +543,7 @@ export default function App() {
     };
   // 这段只负责页面首次加载后的运行态接回；依赖更新不应该重新订阅同一个 run。
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [sessionsLoading]);
 
   // 手机后台/切 tab 时浏览器会冻结 JS、节流网络，SSE reader 可能在后台错过
   // done/error 事件；切回前台时如果前端还以为任务在跑，就调一次持久化的 trace
@@ -771,7 +773,7 @@ export default function App() {
   // 一次性执行；之后的切换走 handleActivateProject，选择会话只在本项目内。
   const projectsReconciledRef = useRef(false);
   useEffect(() => {
-    if (projectsLoading || projectsReconciledRef.current) return;
+    if (projectsLoading || sessionsLoading || projectsReconciledRef.current) return;
     projectsReconciledRef.current = true;
     setChatState(prev => {
       const cur = prev.sessions.find(s => s.id === prev.activeSessionId);
@@ -785,7 +787,7 @@ export default function App() {
       const blank = createSession({ projectId: activeProjectId });
       return normalizeChatState({ sessions: [blank, ...prev.sessions], activeSessionId: blank.id });
     });
-  }, [projectsLoading, activeProjectId, setChatState]);
+  }, [projectsLoading, sessionsLoading, activeProjectId, setChatState]);
 
   const { sendAgentTask, stopAgent, handleRollback, handleApprovalDecision } = useAgentTransport({
     activeSession,

--- a/client/src/hooks/useAgentTransport.js
+++ b/client/src/hooks/useAgentTransport.js
@@ -147,6 +147,7 @@ export function useAgentTransport({
         memory: agentMemory,
         // 当前会话归属的项目，后端据此隔离记忆/文件根/trace/checkpoint。
         projectId: activeSession.projectId ?? null,
+        sessionId,
         signal: controller.signal,
         messages: isRetry ? [] : messages.slice(-10).map(m => ({ role: m.role, content: m.content })),
         ...extraBody,

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -1,11 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { tStatic } from '../i18n/locale.js';
 import { normalizeAgentMeta } from '../utils/agent-stats.js';
+import { apiFetch } from '../api/http.js';
 
-const LEGACY_MESSAGES_KEY = 'nvidia_chat_messages';
-const LEGACY_MODEL_KEY = 'nvidia_chat_model';
-const SESSIONS_KEY = 'nvidia_chat_sessions';
-const ACTIVE_SESSION_KEY = 'nvidia_chat_active_session';
 const MAX_AGENT_RUN_HISTORY = 30;
 
 function generateSessionId() {
@@ -176,37 +173,6 @@ export function normalizeChatState(rawState) {
   return { sessions: nextSessions, activeSessionId };
 }
 
-function loadChatState() {
-  try {
-    const storedSessions = JSON.parse(localStorage.getItem(SESSIONS_KEY) || 'null');
-    if (Array.isArray(storedSessions) && storedSessions.length > 0) {
-      return normalizeChatState({
-        sessions: storedSessions,
-        activeSessionId: localStorage.getItem(ACTIVE_SESSION_KEY),
-      });
-    }
-  } catch {
-    // ignore malformed storage and fall back to migration/default state
-  }
-
-  let legacyMessages = [];
-  try {
-    legacyMessages = JSON.parse(localStorage.getItem(LEGACY_MESSAGES_KEY) || '[]');
-  } catch {
-    legacyMessages = [];
-  }
-
-  const migratedSession = createSession({
-    messages: legacyMessages,
-    model: localStorage.getItem(LEGACY_MODEL_KEY),
-  });
-
-  return normalizeChatState({
-    sessions: [migratedSession],
-    activeSessionId: migratedSession.id,
-  });
-}
-
 export function touchSession(session, patch = {}) {
   return {
     ...session,
@@ -223,15 +189,6 @@ export function getSessionTitle(messages) {
 
   const text = firstUserMessage.content.replace(/\s+/g, ' ').trim();
   return text.length > 20 ? `${text.slice(0, 20)}…` : text;
-}
-
-function isQuotaError(err) {
-  // 浏览器之间 name/code 不一致，这里多覆盖几种。
-  if (!err) return false;
-  return err.name === 'QuotaExceededError'
-    || err.name === 'NS_ERROR_DOM_QUOTA_REACHED'
-    || err.code === 22
-    || err.code === 1014;
 }
 
 function stripAgentRunTraces(agentRuns) {
@@ -255,39 +212,64 @@ function stripAgentTrace(sessions) {
   });
 }
 
-function persistSessions(sessions) {
-  try {
-    localStorage.setItem(SESSIONS_KEY, JSON.stringify(stripAgentTrace(sessions)));
-  } catch (err) {
-    if (!isQuotaError(err)) throw err;
-    // 已经只存元数据还撞配额，说明会话条数太多；保留最近 20 条试一次再吞错。
-    try {
-      const trimmed = stripAgentTrace(sessions)
-        .slice()
-        .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0))
-        .slice(0, 20);
-      localStorage.setItem(SESSIONS_KEY, JSON.stringify(trimmed));
-    } catch (err2) {
-      if (!isQuotaError(err2)) throw err2;
-      console.warn('[useChatSessions] localStorage quota exceeded, sessions not persisted', err2);
-    }
-  }
-}
-
 export function useChatSessions() {
-  const [chatState, setChatState] = useState(loadChatState);
+  const [chatState, setChatState] = useState(() => normalizeChatState({ sessions: [], activeSessionId: null }));
+  const [sessionsLoading, setSessionsLoading] = useState(true);
+  const [sessionsError, setSessionsError] = useState(null);
+  const hydratedRef = useRef(false);
+  const persistChainRef = useRef(Promise.resolve());
   const { sessions, activeSessionId } = chatState;
   const activeSession = sessions.find(session => session.id === activeSessionId) || sessions[0];
 
   useEffect(() => {
-    persistSessions(sessions);
-    try {
-      localStorage.setItem(ACTIVE_SESSION_KEY, activeSession.id);
-      localStorage.removeItem(LEGACY_MESSAGES_KEY);
-      localStorage.removeItem(LEGACY_MODEL_KEY);
-    } catch (err) {
-      if (!isQuotaError(err)) throw err;
-    }
+    const controller = new AbortController();
+    apiFetch('/api/sessions', { signal: controller.signal })
+      .then(async response => {
+        const data = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
+        if (controller.signal.aborted) return;
+        setChatState(normalizeChatState({
+          sessions: data.sessions,
+          activeSessionId: data.activeSessionId,
+        }));
+        hydratedRef.current = true;
+        setSessionsError(null);
+        setSessionsLoading(false);
+      })
+      .catch(err => {
+        if (controller.signal.aborted) return;
+        setSessionsError(err?.message || String(err));
+        setSessionsLoading(false);
+      });
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    if (!hydratedRef.current) return undefined;
+    const payload = {
+      sessions: stripAgentTrace(sessions),
+      activeSessionId: activeSession.id,
+    };
+    const timer = setTimeout(() => {
+      persistChainRef.current = persistChainRef.current
+        .catch(() => {})
+        .then(async () => {
+          const response = await apiFetch('/api/sessions', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          });
+          if (!response.ok) {
+            const data = await response.json().catch(() => ({}));
+            throw new Error(data.error || `HTTP ${response.status}`);
+          }
+        })
+        .catch(err => {
+          console.warn('[useChatSessions] backend persistence failed', err);
+          setSessionsError(err?.message || String(err));
+        });
+    }, 300);
+    return () => clearTimeout(timer);
   }, [activeSession.id, sessions]);
 
   const updateSession = useCallback((sessionId, updater) => {
@@ -306,5 +288,7 @@ export function useChatSessions() {
     activeSession,
     messages: activeSession.messages,
     updateSession,
+    sessionsLoading,
+    sessionsError,
   };
 }

--- a/client/src/hooks/useSessionHandlers.js
+++ b/client/src/hooks/useSessionHandlers.js
@@ -66,14 +66,20 @@ export function useSessionHandlers({
 
     setChatState(prev => {
       const nextSessions = prev.sessions.filter(session => session.id !== sessionId);
-      const nextActiveSessionId =
-        sessionId === prev.activeSessionId
-          ? nextSessions[0]?.id || createSession({ projectId: activeProjectId }).id
-          : prev.activeSessionId;
+      if (sessionId !== prev.activeSessionId) {
+        return normalizeChatState({ sessions: nextSessions, activeSessionId: prev.activeSessionId });
+      }
+      const nextProjectSession = nextSessions.find(
+        session => (session.projectId ?? null) === (activeProjectId ?? null)
+      );
+      if (nextProjectSession) {
+        return normalizeChatState({ sessions: nextSessions, activeSessionId: nextProjectSession.id });
+      }
+      const blank = createSession({ projectId: activeProjectId });
 
       return normalizeChatState({
-        sessions: nextSessions,
-        activeSessionId: nextActiveSessionId,
+        sessions: [blank, ...nextSessions],
+        activeSessionId: blank.id,
       });
     });
     setInput('');
@@ -82,10 +88,19 @@ export function useSessionHandlers({
   };
 
   const handleClearAllSessions = () => {
-    if (sessionLocked || !window.confirm(tStatic('sessionOps.confirmClearAll'))) {
+    if (sessionLocked || !window.confirm(tStatic('sessionOps.confirmClearProject'))) {
       return;
     }
-    setChatState(normalizeChatState({ sessions: [], activeSessionId: null }));
+    setChatState(prev => {
+      const otherProjects = prev.sessions.filter(
+        session => (session.projectId ?? null) !== (activeProjectId ?? null)
+      );
+      const blank = createSession({ projectId: activeProjectId });
+      return normalizeChatState({
+        sessions: [blank, ...otherProjects],
+        activeSessionId: blank.id,
+      });
+    });
     setInput('');
     setShowReset(false);
     setShowSessions(false);

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -475,4 +475,5 @@ export const en = {
   'session.newChat': 'New chat',
   'sessionOps.confirmDelete': 'Delete this session? This cannot be undone.',
   'sessionOps.confirmClearAll': 'Clear all sessions? This cannot be undone.',
+  'sessionOps.confirmClearProject': 'Clear all sessions in the current project? Other projects will not be affected. This cannot be undone.',
 };

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -476,4 +476,5 @@ export const zh = {
   'session.newChat': '新对话',
   'sessionOps.confirmDelete': '删除这个会话？此操作不可撤销。',
   'sessionOps.confirmClearAll': '清空所有会话？此操作不可撤销。',
+  'sessionOps.confirmClearProject': '清空当前项目的所有会话？其他项目不会受影响。此操作不可撤销。',
 };

--- a/routes/agent-run-control.ts
+++ b/routes/agent-run-control.ts
@@ -127,6 +127,9 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
       model: run.meta?.model,
       agentModels: run.meta?.agentModels,
       task: run.meta?.task,
+      sessionId: run.meta?.sessionId,
+      projectId: run.meta?.projectId ?? null,
+      strategy: run.meta?.strategy,
     })}\n\n`);
 
     let writer = null;

--- a/routes/agent-run-request.ts
+++ b/routes/agent-run-request.ts
@@ -22,6 +22,7 @@ export function parseAgentRunRequest(reqBody: any) {
     messages: conversationHistory,
     fromCheckpoint,
     projectId,
+    sessionId,
   } = reqBody ?? {};
 
   if (typeof task !== 'string' || !task.trim()) {
@@ -51,6 +52,7 @@ export function parseAgentRunRequest(reqBody: any) {
     conversationHistory,
     fromCheckpoint,
     projectId: typeof projectId === 'string' && projectId.trim() ? projectId : null,
+    sessionId: typeof sessionId === 'string' && sessionId.trim() ? sessionId.trim() : null,
   };
 }
 

--- a/routes/agent-run-session.ts
+++ b/routes/agent-run-session.ts
@@ -26,6 +26,10 @@ export function createAgentRunSession({
   model,
   agentHeadless,
   normalizedTask,
+  agentModels,
+  strategy,
+  sessionId,
+  projectId,
   runId,
   startedAt,
   agentRunStore,
@@ -36,6 +40,10 @@ export function createAgentRunSession({
   model: string;
   agentHeadless: boolean;
   normalizedTask: string;
+  agentModels: string[];
+  strategy: string;
+  sessionId: string | null;
+  projectId: string | null;
   runId: string;
   startedAt: number;
   agentRunStore: AgentRunStore;
@@ -101,6 +109,17 @@ export function createAgentRunSession({
     status: 'starting',
     runId,
     message: tReq(req, 'run.preparing'),
+  });
+  sendEvent({
+    type: 'run_meta',
+    runId,
+    startedAt,
+    model,
+    agentModels,
+    strategy,
+    task: normalizedTask,
+    sessionId: sessionId || undefined,
+    projectId,
   });
   log.debug(`[SSE] stream started, writableEnded=${res.writableEnded} writableFinished=${res.writableFinished}`);
 

--- a/routes/agent-run-start.ts
+++ b/routes/agent-run-start.ts
@@ -20,6 +20,7 @@ export function createAgentRunStartRouter({
   modelConfig,
   registry,
   projectStore,
+  sessionStore,
 }: AgentRouterContext) {
   const router = Router();
 
@@ -32,7 +33,7 @@ export function createAgentRunStartRouter({
       if ('error' in parsed) {
         return res.status(400).json({ error: tReq(req, parsed.error) });
       }
-      const { task, model, agentModels, strategy, headless, useMemory, conversationHistory, fromCheckpoint, projectId } = parsed;
+      const { task, model, agentModels, strategy, headless, useMemory, conversationHistory, fromCheckpoint, projectId, sessionId } = parsed;
       const incompatibleModels = agentModels.filter(modelId => (
         modelConfig.find(item => item.id === modelId)?.agentCompatible === false
       ));
@@ -73,6 +74,7 @@ export function createAgentRunStartRouter({
         task: normalizedTask,
         // 项目信息盖到 run 记录上，供 trace/checkpoint 读取端点定位落盘目录
         projectId: resolvedProjectId,
+        sessionId,
         dataDir,
         projectRoot,
       }, startedAt, existingRunId, initialEventSeq);
@@ -89,10 +91,24 @@ export function createAgentRunStartRouter({
         model,
         agentHeadless,
         normalizedTask,
+        agentModels,
+        strategy,
+        sessionId,
+        projectId: resolvedProjectId,
         runId,
         startedAt,
         agentRunStore,
         memoryDir: dataDir,
+      });
+      await sessionStore.recordRunStart({
+        projectId: resolvedProjectId,
+        sessionId,
+        runId,
+        task: normalizedTask,
+        model,
+        models: agentModels,
+        startedAt,
+        retry: Boolean(fromCheckpoint),
       });
       agentRunStore.transitionRun(runId, 'running');
 
@@ -148,6 +164,20 @@ export function createAgentRunStartRouter({
         }
       }
       await runRecord.persistence?.flush();
+      const tracking = session.getTrackingState();
+      await sessionStore.recordRunTerminal({
+        projectId: resolvedProjectId,
+        sessionId,
+        runId,
+        task: normalizedTask,
+        answer: finalAnswer,
+        error: agentError?.message || null,
+        models: tracking.modelsUsed.length > 0 ? tracking.modelsUsed : agentModels,
+        status: finalStatus,
+        startedAt,
+        endedAt: Date.now(),
+        meta: { step_count: Math.max(tracking.completedStepCount, tracking.observedStepCount) },
+      });
       session.close({ finalAnswer, agentError, approvalStore });
       await cleanupAgentRun(runCheckpointDir, runId, agentRunStore, { finalStatus });
       return;

--- a/routes/agent-sessions.ts
+++ b/routes/agent-sessions.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+import type { AgentRouterContext } from './agent-types.ts';
+
+export function createAgentSessionsRouter({ sessionStore }: AgentRouterContext) {
+  const router = Router();
+
+  router.get('/api/sessions', async (_req, res) => {
+    try {
+      return res.json(await sessionStore.loadAll());
+    } catch (err: any) {
+      return res.status(500).json({ error: err?.message || String(err) });
+    }
+  });
+
+  router.put('/api/sessions', async (req, res) => {
+    try {
+      const { sessions, activeSessionId } = req.body ?? {};
+      return res.json(await sessionStore.replaceAll(sessions, activeSessionId));
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || String(err) });
+    }
+  });
+
+  return router;
+}

--- a/routes/agent-types.ts
+++ b/routes/agent-types.ts
@@ -2,6 +2,7 @@ import type { ProviderRegistry } from '../agent/core/providers/registry.ts';
 import type { ModelInfo } from '../agent/core/providers/types.ts';
 import type { ConfigStore } from '../agent/core/config-store.ts';
 import type { ProjectStore } from '../agent/core/project-store.ts';
+import type { SessionStore } from '../agent/core/session-store.ts';
 import type {
   AgentRunStore,
   ApprovalStore,
@@ -20,4 +21,5 @@ export interface AgentRouterContext {
   registry: ProviderRegistry;
   configStore: ConfigStore;
   projectStore: ProjectStore;
+  sessionStore: SessionStore;
 }

--- a/routes/agent.ts
+++ b/routes/agent.ts
@@ -21,22 +21,29 @@ import { createAgentUploadsRouter } from './agent-uploads.ts';
 import { createAgentProjectsRouter } from './agent-projects.ts';
 import { createAgentCodegraphRouter } from './agent-codegraph.ts';
 import { createAgentContextRouter } from './agent-context.ts';
+import { createAgentSessionsRouter } from './agent-sessions.ts';
+import { createSessionStore } from '../agent/core/session-store.ts';
 import type { AgentRouterContext } from './agent-types.ts';
 
-export function createAgentRouter(context: AgentRouterContext) {
+export function createAgentRouter(context: Omit<AgentRouterContext, 'sessionStore'> & { sessionStore?: AgentRouterContext['sessionStore'] }) {
   const router = Router();
+  const fullContext: AgentRouterContext = {
+    ...context,
+    sessionStore: context.sessionStore || createSessionStore({ memoryDir: context.memoryDir, projectStore: context.projectStore }),
+  };
 
-  router.use(createAgentRunRouter(context));
-  router.use(createAgentApprovalRouter(context));
-  router.use(createAgentFetchRulesRouter(context));
-  router.use(createAgentConfigRouter(context));
-  router.use(createAgentMemoryRouter(context));
-  router.use(createAgentCheckpointRouter(context));
-  router.use(createAgentTraceRouter(context));
-  router.use(createAgentUploadsRouter(context));
-  router.use(createAgentProjectsRouter(context));
-  router.use(createAgentCodegraphRouter(context));
-  router.use(createAgentContextRouter(context));
+  router.use(createAgentRunRouter(fullContext));
+  router.use(createAgentApprovalRouter(fullContext));
+  router.use(createAgentFetchRulesRouter(fullContext));
+  router.use(createAgentConfigRouter(fullContext));
+  router.use(createAgentMemoryRouter(fullContext));
+  router.use(createAgentCheckpointRouter(fullContext));
+  router.use(createAgentTraceRouter(fullContext));
+  router.use(createAgentUploadsRouter(fullContext));
+  router.use(createAgentProjectsRouter(fullContext));
+  router.use(createAgentCodegraphRouter(fullContext));
+  router.use(createAgentContextRouter(fullContext));
+  router.use(createAgentSessionsRouter(fullContext));
 
   return router;
 }

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createProjectStore, projectDataDir } from '../agent/core/project-store.js';
+import { createSessionStore } from '../agent/core/session-store.js';
+import { appendTraceEvent } from '../helpers/trace-store.js';
+
+describe('backend session store', () => {
+  let tmpDir: string;
+  let projectStore: ReturnType<typeof createProjectStore>;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-sessions-'));
+    projectStore = createProjectStore(tmpDir);
+    await projectStore.init();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('recovers a conversation from run_meta and terminal trace events', async () => {
+    const runId = 'run_session_recover';
+    await appendTraceEvent(tmpDir, runId, {
+      type: 'run_meta',
+      runId,
+      sessionId: 'session_backend',
+      task: '恢复这个问题',
+      model: 'model-a',
+      startedAt: 1000,
+      timestamp: 1000,
+    });
+    await appendTraceEvent(tmpDir, runId, {
+      type: 'done',
+      runId,
+      answer: '恢复后的答案',
+      timestamp: 2000,
+      meta: { models_used: ['model-a'], step_count: 2, status: 'done' },
+    });
+
+    const store = createSessionStore({ memoryDir: tmpDir, projectStore });
+    const state = await store.loadAll();
+
+    expect(state.sessions).toHaveLength(1);
+    expect(state.sessions[0]).toMatchObject({
+      id: 'session_backend',
+      projectId: null,
+      agentRunId: runId,
+      model: 'model-a',
+    });
+    expect(state.sessions[0].messages).toEqual([
+      expect.objectContaining({ role: 'user', content: '恢复这个问题' }),
+      expect.objectContaining({ role: 'assistant', content: '恢复后的答案' }),
+    ]);
+  });
+
+  it('uses historical app logs to recover tasks missing from legacy traces', async () => {
+    const runId = 'run_legacy_trace';
+    await fs.mkdir(path.join(tmpDir, 'logs'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, 'logs', 'app-2026-07-12.log'),
+      `[2026-07-12T08:00:00.000Z INFO] POST /api/agent model=model-b headless=false task="旧版问题" run_id=${runId}\n`,
+      'utf8',
+    );
+    await appendTraceEvent(tmpDir, runId, { type: 'status', status: 'starting', timestamp: 1000 });
+    await appendTraceEvent(tmpDir, runId, { type: 'done', answer: '旧版答案', timestamp: 2000, meta: {} });
+
+    const store = createSessionStore({ memoryDir: tmpDir, projectStore });
+    const state = await store.loadAll();
+
+    expect(state.sessions[0].messages[0].content).toBe('旧版问题');
+    expect(state.sessions[0].messages[1].content).toBe('旧版答案');
+  });
+
+  it('does not resurrect trace sessions after the user removes them', async () => {
+    const runId = 'run_removed_trace';
+    await appendTraceEvent(tmpDir, runId, {
+      type: 'run_meta', task: '稍后删除', model: 'model-a', startedAt: 1000, timestamp: 1000,
+    });
+    await appendTraceEvent(tmpDir, runId, { type: 'done', answer: '答案', timestamp: 2000, meta: {} });
+    const store = createSessionStore({ memoryDir: tmpDir, projectStore });
+    const recovered = await store.loadAll();
+    expect(recovered.sessions).toHaveLength(1);
+
+    await store.replaceAll([{
+      id: 'session_blank',
+      projectId: null,
+      messages: [],
+      createdAt: 3000,
+      updatedAt: 3000,
+    }], 'session_blank');
+    const reloaded = await store.loadAll();
+
+    expect(reloaded.sessions).toHaveLength(1);
+    expect(reloaded.sessions[0].id).toBe('session_blank');
+  });
+
+  it('recovers project traces with the correct project ownership', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-project-root-'));
+    try {
+      const project = await projectStore.create({ name: 'demo', rootPath: projectRoot });
+      const dataDir = projectDataDir(tmpDir, project.projectId);
+      const runId = 'run_project_trace';
+      await appendTraceEvent(dataDir, runId, {
+        type: 'run_meta', task: '项目问题', model: 'model-c', startedAt: 1000, timestamp: 1000,
+      });
+      await appendTraceEvent(dataDir, runId, { type: 'done', answer: '项目答案', timestamp: 2000, meta: {} });
+
+      const store = createSessionStore({ memoryDir: tmpDir, projectStore });
+      const state = await store.loadAll();
+
+      expect(state.sessions).toHaveLength(1);
+      expect(state.sessions[0].projectId).toBe(project.projectId);
+    } finally {
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- persist chat sessions on the backend instead of browser localStorage
- recover deleted historical sessions from trace files and application logs
- write run metadata and terminal results directly into backend session storage
- scope clear-all and deletion behavior to the active project
- prevent explicitly deleted trace sessions from being restored again

## Verification

- npm test (326 tests passed)
- npm run lint
- npm run build
- restored and verified existing backend session data by project