### PR TITLE
feat: project-scoped suggestions and session archiving

### DIFF
--- a/agent/core/session-store.ts
+++ b/agent/core/session-store.ts
@@ -37,6 +37,10 @@ function finiteNumber(value: unknown, fallback: number) {
   return Number.isFinite(value) ? Number(value) : fallback;
 }
 
+function isActiveSession(session: StoredSession) {
+  return !session.archivedAt;
+}
+
 function generateSessionId() {
   return `session_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -87,6 +91,7 @@ function normalizeSession(value: unknown, projectId: string | null): StoredSessi
     agentMeta: session.agentMeta && typeof session.agentMeta === 'object' ? session.agentMeta : null,
     agentRuns: normalizeAgentRuns(session.agentRuns),
     projectId,
+    archivedAt: Number.isFinite(session.archivedAt) ? Number(session.archivedAt) : null,
     createdAt: finiteNumber(session.createdAt, now),
     updatedAt: finiteNumber(session.updatedAt, now),
   };
@@ -109,9 +114,9 @@ async function readScopeState(dataDir: string, projectId: string | null): Promis
     const sessions = Array.isArray(parsed.sessions)
       ? parsed.sessions.map((session: unknown) => normalizeSession(session, projectId)).filter(Boolean) as StoredSession[]
       : [];
-    const activeSessionId = sessions.some(session => session.id === parsed.activeSessionId)
+    const activeSessionId = sessions.some(session => session.id === parsed.activeSessionId && isActiveSession(session))
       ? parsed.activeSessionId
-      : sessions[0]?.id || null;
+      : sessions.find(isActiveSession)?.id || null;
     return {
       version: SESSION_VERSION,
       activeSessionId,
@@ -298,8 +303,8 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
         changed = true;
       }
       state.sessions.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
-      if (!state.activeSessionId || !state.sessions.some(session => session.id === state.activeSessionId)) {
-        state.activeSessionId = state.sessions[0]?.id || null;
+      if (!state.activeSessionId || !state.sessions.some(session => session.id === state.activeSessionId && isActiveSession(session))) {
+        state.activeSessionId = state.sessions.find(isActiveSession)?.id || null;
         changed = true;
       }
       if (changed) await writeScopeState(dataDir, state);
@@ -337,11 +342,11 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
       const dismissed = new Set([...previous.dismissedTraceRunIds, ...removedRunIds]);
       for (const runId of nextRunIds) dismissed.delete(runId);
       const nextActiveSessionId = typeof activeSessionId === 'string'
-        && nextSessions.some(session => session.id === activeSessionId)
+        && nextSessions.some(session => session.id === activeSessionId && isActiveSession(session))
         ? activeSessionId
-        : previous.activeSessionId && nextSessions.some(session => session.id === previous.activeSessionId)
+        : previous.activeSessionId && nextSessions.some(session => session.id === previous.activeSessionId && isActiveSession(session))
           ? previous.activeSessionId
-          : nextSessions[0]?.id || null;
+          : nextSessions.find(isActiveSession)?.id || null;
       await writeScopeState(scope.dataDir, {
         ...previous,
         sessions: nextSessions,
@@ -361,8 +366,8 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
         .map(session => normalizeSession(session, scope.projectId))
         .filter(Boolean) as StoredSession[];
       state.sessions.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
-      if (!state.activeSessionId || !state.sessions.some(session => session.id === state.activeSessionId)) {
-        state.activeSessionId = state.sessions[0]?.id || null;
+      if (!state.activeSessionId || !state.sessions.some(session => session.id === state.activeSessionId && isActiveSession(session))) {
+        state.activeSessionId = state.sessions.find(isActiveSession)?.id || null;
       }
       await writeScopeState(scope.dataDir, state);
     });

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1059,29 +1059,6 @@ select,
   background: var(--c-surface-inline);
 }
 
-.session-clear-all-btn {
-  border: none;
-  background: none;
-  color: var(--c-danger);
-  font-size: var(--f-xs);
-  font-weight: 600;
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 4px;
-  transition: background 0.15s;
-  text-align: center;
-  width: 100%;
-}
-
-.session-clear-all-btn:hover:not(:disabled) {
-  background: var(--c-danger-bg);
-}
-
-.session-clear-all-btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
 .session-list {
   flex: 1;
   min-height: 0;
@@ -1462,6 +1439,31 @@ select,
 .session-delete-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.session-card--archived {
+  opacity: 0.82;
+}
+
+.session-main--static {
+  cursor: default;
+}
+
+.session-archive-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-right: 5px;
+}
+
+.session-archive-actions .session-delete-btn {
+  position: static;
+  opacity: 1;
+}
+
+.session-archive-actions .session-delete-btn:not(.danger):hover:not(:disabled) {
+  color: var(--c-primary);
+  background: var(--c-primary-bg);
 }
 
 .main-area {
@@ -7367,8 +7369,7 @@ textarea:focus-visible,
   .agent-stop-btn:hover:not(:disabled),
   .send-btn:hover:not(:disabled),
   .session-card:hover,
-  .session-delete-btn:hover:not(:disabled),
-  .session-clear-all-btn:hover:not(:disabled) {
+  .session-delete-btn:hover:not(:disabled) {
     transform: none;
     box-shadow: none;
   }
@@ -7392,7 +7393,6 @@ textarea:focus-visible,
   .send-btn:active:not(:disabled),
   .session-main:active:not(:disabled),
   .session-delete-btn:active:not(:disabled),
-  .session-clear-all-btn:active:not(:disabled),
   .session-group-header:active {
     filter: brightness(0.96);
   }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -704,7 +704,7 @@ export default function App() {
   // 建议数据从后端拉取;suggestionSeed 触发(刷新按钮 / 提交后)也会重新拉,让"最近使用"即时反映
   useEffect(() => {
     let cancelled = false;
-    fetchSuggestions()
+    fetchSuggestions(activeProjectId)
       .then(data => {
         if (cancelled) return;
         setSuggestionData(data);
@@ -712,7 +712,7 @@ export default function App() {
       })
       .catch(() => {});
     return () => { cancelled = true; };
-  }, [suggestionSeed]);
+  }, [suggestionSeed, activeProjectId]);
 
   useEffect(() => {
     const el = textareaRef.current;
@@ -734,8 +734,9 @@ export default function App() {
   const {
     handleCreateSession,
     handleSelectSession,
-    handleDeleteSession,
-    handleClearAllSessions,
+    handleArchiveSession,
+    handleRestoreSession,
+    handleDeleteArchivedSession,
     handleReset,
   } = useSessionHandlers({
     sessions,
@@ -756,7 +757,7 @@ export default function App() {
     Promise.resolve(activateProject(projectId)).catch(() => {});
     setChatState(prev => {
       const inProject = prev.sessions
-        .filter(s => (s.projectId ?? null) === (projectId ?? null))
+        .filter(s => !s.archivedAt && (s.projectId ?? null) === (projectId ?? null))
         .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
       if (inProject.length > 0) {
         return normalizeChatState({ ...prev, activeSessionId: inProject[0].id });
@@ -777,9 +778,9 @@ export default function App() {
     projectsReconciledRef.current = true;
     setChatState(prev => {
       const cur = prev.sessions.find(s => s.id === prev.activeSessionId);
-      if (cur && (cur.projectId ?? null) === (activeProjectId ?? null)) return prev;
+      if (cur && !cur.archivedAt && (cur.projectId ?? null) === (activeProjectId ?? null)) return prev;
       const inProject = prev.sessions
-        .filter(s => (s.projectId ?? null) === (activeProjectId ?? null))
+        .filter(s => !s.archivedAt && (s.projectId ?? null) === (activeProjectId ?? null))
         .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
       if (inProject.length > 0) {
         return normalizeChatState({ ...prev, activeSessionId: inProject[0].id });
@@ -860,7 +861,7 @@ export default function App() {
     const title = pendingTitleRef.current
       || (titleSource.length > 12 ? titleSource.slice(0, 12) + '…' : titleSource);
     pendingTitleRef.current = null;
-    recordSuggestionUse({ title, text });
+    recordSuggestionUse({ title, text, projectId: activeSession.projectId ?? null });
     // 下次返回 hero 时能看到新的"最近使用"
     setSuggestionSeed(v => v + 1);
 
@@ -1019,8 +1020,9 @@ export default function App() {
           sessions={sessions}
           activeSessionId={activeSession.id}
           modelList={availableModels}
-          onDelete={handleDeleteSession}
-          onClearAll={handleClearAllSessions}
+          onArchive={handleArchiveSession}
+          onRestore={handleRestoreSession}
+          onDeleteArchived={handleDeleteArchivedSession}
           onSelect={(id) => { handleSelectSession(id); if (window.innerWidth < DOCKED_LAYOUT_BREAKPOINT) setShowSessions(false); }}
           locked={sessionLocked}
           showMemoryPanel={showMemoryPanel}

--- a/client/src/api/suggestions.js
+++ b/client/src/api/suggestions.js
@@ -2,16 +2,17 @@
 // GET 拉取 chat + agent 分类数据;POST fire-and-forget 累计使用记录。
 import { apiFetch } from './http.js';
 
-export async function fetchSuggestions() {
-  const res = await apiFetch('/api/suggestions');
+export async function fetchSuggestions(projectId = null) {
+  const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : '';
+  const res = await apiFetch(`/api/suggestions${query}`);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
 }
 
-export function recordSuggestionUse({ title, text }) {
+export function recordSuggestionUse({ title, text, projectId = null }) {
   return apiFetch('/api/suggestions/use', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title, text }),
+    body: JSON.stringify({ title, text, projectId }),
   }).catch(() => {});
 }

--- a/client/src/components/session/SessionList.jsx
+++ b/client/src/components/session/SessionList.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { BarChart3, Brain, ChevronDown, Search, Trash2, X } from 'lucide-react';
+import { Archive, ArchiveRestore, BarChart3, Brain, ChevronDown, Search, Trash2, X } from 'lucide-react';
 import { getSessionTitle } from '../../hooks/useChatSessions.js';
 import { usePersistentState, jsonStorage } from '../../hooks/usePersistentState.js';
 import { formatRelativeTime, formatShortTime, formatFullTime } from '../../utils/format.js';
@@ -55,7 +55,7 @@ function formatSessionModels(session, modelList, t) {
   return labels.length > 2 ? `${visible} +${labels.length - 2}` : visible;
 }
 
-function SessionCard({ session, active, modelLabel, locked, canDelete, onSelect, onDelete }) {
+function SessionCard({ session, active, modelLabel, locked, canArchive, onSelect, onArchive }) {
   const t = useT();
   const ts = lastActivityTs(session);
 
@@ -71,16 +71,39 @@ function SessionCard({ session, active, modelLabel, locked, canDelete, onSelect,
         ) : null}
       </button>
 
-      {canDelete && (
+      {canArchive && (
         <button
           className="session-delete-btn"
-          onClick={() => onDelete(session.id)}
+          onClick={() => onArchive(session.id)}
           disabled={locked}
-          title={t('session.deleteTitle')}
+          title={t('session.archiveTitle')}
         >
-          <Trash2 size={12} />
+          <Archive size={12} />
         </button>
       )}
+    </div>
+  );
+}
+
+function ArchivedSessionCard({ session, modelLabel, locked, onRestore, onDelete }) {
+  const t = useT();
+  const ts = lastActivityTs(session);
+
+  return (
+    <div className="session-card session-card--archived">
+      <div className="session-main session-main--static">
+        <span className="session-card-title">{getSessionTitle(session.messages)}</span>
+        <span className="session-card-meta">{modelLabel} · {t('session.messageCount', { n: session.messages.length })}</span>
+        {ts ? <span className="session-card-time" title={formatFullTime(ts)}>{formatRelativeTime(ts)} · {formatShortTime(ts)}</span> : null}
+      </div>
+      <div className="session-archive-actions">
+        <button className="session-delete-btn" onClick={() => onRestore(session.id)} disabled={locked} title={t('session.restoreTitle')}>
+          <ArchiveRestore size={12} />
+        </button>
+        <button className="session-delete-btn danger" onClick={() => onDelete(session.id)} disabled={locked} title={t('session.deletePermanentlyTitle')}>
+          <Trash2 size={12} />
+        </button>
+      </div>
     </div>
   );
 }
@@ -89,8 +112,9 @@ export function SessionList({
   sessions,
   activeSessionId,
   modelList,
-  onDelete,
-  onClearAll,
+  onArchive,
+  onRestore,
+  onDeleteArchived,
   onSelect,
   locked,
   showMemoryPanel,
@@ -106,12 +130,21 @@ export function SessionList({
   const t = useT();
   const [query, setQuery] = useState('');
   const [showStatsPanel, setShowStatsPanel] = useState(false);
+  const [archivedExpanded, setArchivedExpanded] = useState(false);
   const [collapsedGroups, setCollapsedGroups] = usePersistentState(COLLAPSED_GROUPS_KEY, [], jsonStorage);
 
   // 只显示当前项目的会话；无项目态显示未归属项目的旧会话。
-  const visibleSessions = useMemo(
+  const projectSessions = useMemo(
     () => sessions.filter(s => (s.projectId ?? null) === (activeProjectId ?? null)),
     [sessions, activeProjectId]
+  );
+  const visibleSessions = useMemo(
+    () => projectSessions.filter(s => !s.archivedAt),
+    [projectSessions]
+  );
+  const archivedSessions = useMemo(
+    () => projectSessions.filter(s => Boolean(s.archivedAt)).sort((a, b) => (b.archivedAt || 0) - (a.archivedAt || 0)),
+    [projectSessions]
   );
 
   const groups = useMemo(() => buildGroups(visibleSessions, query), [visibleSessions, query]);
@@ -154,24 +187,24 @@ export function SessionList({
         </div>
       </div>
 
+      <ProjectSwitcher
+        projects={projects}
+        activeProjectId={activeProjectId}
+        onActivate={onActivateProject}
+        onCreate={onCreateProject}
+        onUpdate={onUpdateProject}
+        onDelete={onDeleteProject}
+        locked={locked}
+      />
+
       {showMemoryPanel ? (
         <MemoryPanel onClose={onToggleMemory} activeProjectId={activeProjectId} modelList={modelList} />
       ) : statsPanelOpen ? (
         <AgentStatsPanel
-          sessions={visibleSessions}
+          sessions={projectSessions}
         />
       ) : (
         <>
-          <ProjectSwitcher
-            projects={projects}
-            activeProjectId={activeProjectId}
-            onActivate={onActivateProject}
-            onCreate={onCreateProject}
-            onUpdate={onUpdateProject}
-            onDelete={onDeleteProject}
-            locked={locked}
-          />
-
           <div className="session-search">
             <Search size={14} className="session-search-icon" />
             <input
@@ -213,9 +246,9 @@ export function SessionList({
                         active={session.id === activeSessionId}
                         modelLabel={formatSessionModels(session, modelList, t)}
                         locked={locked}
-                        canDelete={visibleSessions.length > 1}
+                        canArchive={session.messages.length > 0}
                         onSelect={onSelect}
-                        onDelete={onDelete}
+                        onArchive={onArchive}
                       />
                     ))}
                   </div>
@@ -223,8 +256,27 @@ export function SessionList({
               })
             )}
 
-            {visibleSessions.length > 1 && (
-              <button className="session-clear-all-btn" onClick={onClearAll} disabled={locked}>{t('common.clearAll')}</button>
+            {archivedSessions.length > 0 && (
+              <div className="session-group session-archive-group">
+                <button
+                  className={`session-group-header ${archivedExpanded ? '' : 'collapsed'}`}
+                  onClick={() => setArchivedExpanded(value => !value)}
+                >
+                  <ChevronDown size={14} className="session-group-chevron" />
+                  <span className="session-group-label">{t('session.archived')}</span>
+                  <span className="session-group-count">{archivedSessions.length}</span>
+                </button>
+                {archivedExpanded && archivedSessions.map(session => (
+                  <ArchivedSessionCard
+                    key={session.id}
+                    session={session}
+                    modelLabel={formatSessionModels(session, modelList, t)}
+                    locked={locked}
+                    onRestore={onRestore}
+                    onDelete={onDeleteArchived}
+                  />
+                ))}
+              </div>
             )}
           </div>
         </>

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -102,6 +102,7 @@ export function createSession({
   agentMeta = null,
   agentRuns = [],
   projectId = null,
+  archivedAt = null,
   createdAt = Date.now(),
   updatedAt = Date.now(),
 } = {}) {
@@ -116,6 +117,7 @@ export function createSession({
     agentRuns: normalizeAgentRuns(agentRuns),
     // 会话归属的项目；null = 无项目（全局态，向后兼容旧会话）。
     projectId: typeof projectId === 'string' && projectId ? projectId : null,
+    archivedAt: Number.isFinite(archivedAt) ? archivedAt : null,
     createdAt,
     updatedAt,
   };
@@ -158,6 +160,7 @@ export function normalizeChatState(rawState) {
             agentMeta: session.agentMeta,
             agentRuns: session.agentRuns,
             projectId: session.projectId,
+            archivedAt: session.archivedAt,
             createdAt: Number.isFinite(session.createdAt) ? session.createdAt : Date.now(),
             updatedAt: Number.isFinite(session.updatedAt) ? session.updatedAt : Date.now(),
           });

--- a/client/src/hooks/useSessionHandlers.js
+++ b/client/src/hooks/useSessionHandlers.js
@@ -1,7 +1,7 @@
 import { createSession, normalizeChatState, touchSession } from './useChatSessions.js';
 import { tStatic } from '../i18n/locale.js';
 
-// 会话生命周期相关的 handler 集合：新建/切换/删除/清空/重置。
+// 会话生命周期相关的 handler 集合：新建/切换/删除/重置。
 // 这些 handler 各自独立、但都依赖同一组 props 上下文，所以打包成一个 hook 提供。
 export function useSessionHandlers({
   sessions,
@@ -38,7 +38,9 @@ export function useSessionHandlers({
 
     // 复用当前项目下的空白会话；没有则新建并归属当前项目。
     const blankSession = sessions.find(
-      session => session.messages.length === 0 && (session.projectId ?? null) === (activeProjectId ?? null)
+      session => !session.archivedAt
+        && session.messages.length === 0
+        && (session.projectId ?? null) === (activeProjectId ?? null)
     );
     if (blankSession) {
       handleSelectSession(blankSession.id);
@@ -59,18 +61,21 @@ export function useSessionHandlers({
     setTimeout(() => textareaRef.current?.focus(), 0);
   };
 
-  const handleDeleteSession = sessionId => {
-    if (sessionLocked || !window.confirm(tStatic('sessionOps.confirmDelete'))) {
+  const handleArchiveSession = sessionId => {
+    if (sessionLocked) {
       return;
     }
 
     setChatState(prev => {
-      const nextSessions = prev.sessions.filter(session => session.id !== sessionId);
+      const archivedAt = Date.now();
+      const nextSessions = prev.sessions.map(session => (
+        session.id === sessionId ? { ...session, archivedAt } : session
+      ));
       if (sessionId !== prev.activeSessionId) {
         return normalizeChatState({ sessions: nextSessions, activeSessionId: prev.activeSessionId });
       }
       const nextProjectSession = nextSessions.find(
-        session => (session.projectId ?? null) === (activeProjectId ?? null)
+        session => !session.archivedAt && (session.projectId ?? null) === (activeProjectId ?? null)
       );
       if (nextProjectSession) {
         return normalizeChatState({ sessions: nextSessions, activeSessionId: nextProjectSession.id });
@@ -87,24 +92,22 @@ export function useSessionHandlers({
     setTimeout(() => textareaRef.current?.focus(), 0);
   };
 
-  const handleClearAllSessions = () => {
-    if (sessionLocked || !window.confirm(tStatic('sessionOps.confirmClearProject'))) {
-      return;
-    }
-    setChatState(prev => {
-      const otherProjects = prev.sessions.filter(
-        session => (session.projectId ?? null) !== (activeProjectId ?? null)
-      );
-      const blank = createSession({ projectId: activeProjectId });
-      return normalizeChatState({
-        sessions: [blank, ...otherProjects],
-        activeSessionId: blank.id,
-      });
-    });
-    setInput('');
-    setShowReset(false);
-    setShowSessions(false);
-    setTimeout(() => textareaRef.current?.focus(), 0);
+  const handleRestoreSession = sessionId => {
+    if (sessionLocked) return;
+    setChatState(prev => normalizeChatState({
+      ...prev,
+      sessions: prev.sessions.map(session => (
+        session.id === sessionId ? { ...session, archivedAt: null, updatedAt: Date.now() } : session
+      )),
+    }));
+  };
+
+  const handleDeleteArchivedSession = sessionId => {
+    if (sessionLocked || !window.confirm(tStatic('sessionOps.confirmDeleteArchived'))) return;
+    setChatState(prev => normalizeChatState({
+      ...prev,
+      sessions: prev.sessions.filter(session => session.id !== sessionId),
+    }));
   };
 
   const handleReset = () => {
@@ -117,8 +120,9 @@ export function useSessionHandlers({
   return {
     handleCreateSession,
     handleSelectSession,
-    handleDeleteSession,
-    handleClearAllSessions,
+    handleArchiveSession,
+    handleRestoreSession,
+    handleDeleteArchivedSession,
     handleReset,
   };
 }

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -291,7 +291,10 @@ export const en = {
   'session.title': 'Sessions',
   'session.unknownModel': 'Unknown model',
   'session.messageCount': '{n} msgs',
-  'session.deleteTitle': 'Delete session',
+  'session.archiveTitle': 'Archive session',
+  'session.archived': 'Archived',
+  'session.restoreTitle': 'Restore session',
+  'session.deletePermanentlyTitle': 'Delete permanently',
   'session.viewMemory': 'View memory',
   'session.viewAgentStats': 'View Agent stats',
   'session.searchPlaceholder': 'Search sessions…',
@@ -474,6 +477,7 @@ export const en = {
   // Session operations
   'session.newChat': 'New chat',
   'sessionOps.confirmDelete': 'Delete this session? This cannot be undone.',
+  'sessionOps.confirmDeleteArchived': 'Permanently delete this archived session? This cannot be undone.',
   'sessionOps.confirmClearAll': 'Clear all sessions? This cannot be undone.',
   'sessionOps.confirmClearProject': 'Clear all sessions in the current project? Other projects will not be affected. This cannot be undone.',
 };

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -292,7 +292,10 @@ export const zh = {
   'session.title': '会话',
   'session.unknownModel': '未知模型',
   'session.messageCount': '{n} 条',
-  'session.deleteTitle': '删除会话',
+  'session.archiveTitle': '存档会话',
+  'session.archived': '已存档',
+  'session.restoreTitle': '恢复会话',
+  'session.deletePermanentlyTitle': '永久删除',
   'session.viewMemory': '查看记忆',
   'session.viewAgentStats': '查看 Agent 统计',
   'session.searchPlaceholder': '搜索会话…',
@@ -475,6 +478,7 @@ export const zh = {
   // 会话操作
   'session.newChat': '新对话',
   'sessionOps.confirmDelete': '删除这个会话？此操作不可撤销。',
+  'sessionOps.confirmDeleteArchived': '永久删除这个已存档会话？此操作不可撤销。',
   'sessionOps.confirmClearAll': '清空所有会话？此操作不可撤销。',
   'sessionOps.confirmClearProject': '清空当前项目的所有会话？其他项目不会受影响。此操作不可撤销。',
 };

--- a/helpers/suggestion-store.ts
+++ b/helpers/suggestion-store.ts
@@ -24,6 +24,7 @@ const RECENT_LIMIT = 12;
 const SAVE_DEBOUNCE_MS = 2000;
 
 type HistoryEntry = {
+  projectId: string | null;
   title: string;
   text: string;
   uses: number;
@@ -65,6 +66,7 @@ export function createSuggestionStore(dir: string) {
               .map((e: any) => ({
                 title: String(e.title ?? '').slice(0, 32),
                 text: String(e.text),
+                projectId: typeof e.projectId === 'string' && e.projectId.trim() ? e.projectId : null,
                 uses: Number.isFinite(e.uses) ? Math.max(0, Math.floor(e.uses)) : 0,
                 lastUsedAt: typeof e.lastUsedAt === 'string' ? e.lastUsedAt : '',
               }))
@@ -103,21 +105,24 @@ export function createSuggestionStore(dir: string) {
   }
 
   return {
-    async getMerged(locale: SuggestionLocale = 'zh'): Promise<MergedSuggestions> {
+    async getMerged(locale: SuggestionLocale = 'zh', projectId: string | null = null): Promise<MergedSuggestions> {
       const data = await load();
       const defaults = getSuggestionDefaults(locale);
-      const recent = buildRecent(data.history, locale);
+      const recent = buildRecent(
+        data.history.filter(entry => entry.projectId === projectId),
+        locale,
+      );
       const agent = recent ? [recent, ...defaults.agent] : [...defaults.agent];
       return {
         agent,
       };
     },
 
-    async recordUse({ title, text }: { title: string; text: string }): Promise<void> {
+    async recordUse({ title, text, projectId = null }: { title: string; text: string; projectId?: string | null }): Promise<void> {
       const trimmed = text.trim();
       if (!trimmed) return;
       const data = await load();
-      const existing = data.history.find(e => e.text === trimmed);
+      const existing = data.history.find(e => e.projectId === projectId && e.text === trimmed);
       const now = new Date().toISOString();
       if (existing) {
         existing.uses += 1;
@@ -125,6 +130,7 @@ export function createSuggestionStore(dir: string) {
         if (title && !existing.title) existing.title = title;
       } else {
         data.history.push({
+          projectId,
           title: title || trimmed.slice(0, 12),
           text: trimmed,
           uses: 1,

--- a/routes/suggestions.ts
+++ b/routes/suggestions.ts
@@ -1,7 +1,7 @@
 /**
  * Suggestions API — 主页"试试这些任务/问题"建议数据 + 使用记录
  *
- * GET  /api/suggestions          → { chat, agent } (agent 顶部带"最近使用"分类)
+ * GET  /api/suggestions?projectId=... → { chat, agent } (agent 顶部带项目内"最近使用"分类)
  * POST /api/suggestions/use      → { ok: true },累计 uses + lastUsedAt
  */
 
@@ -14,7 +14,10 @@ export function createSuggestionsRouter({ store }: { store: SuggestionStore }) {
 
   router.get('/api/suggestions', async (req, res) => {
     try {
-      const data = await store.getMerged(pickLocale(req));
+      const projectId = typeof req.query.projectId === 'string' && req.query.projectId.trim()
+        ? req.query.projectId
+        : null;
+      const data = await store.getMerged(pickLocale(req), projectId);
       res.json(data);
     } catch (err: any) {
       res.status(500).json({ error: err.message });
@@ -22,7 +25,7 @@ export function createSuggestionsRouter({ store }: { store: SuggestionStore }) {
   });
 
   router.post('/api/suggestions/use', async (req, res) => {
-    const { title, text } = req.body ?? {};
+    const { title, text, projectId } = req.body ?? {};
     if (typeof text !== 'string' || !text.trim()) {
       return res.status(400).json({ error: tReq(req, 'suggestions.textEmpty') });
     }
@@ -30,6 +33,7 @@ export function createSuggestionsRouter({ store }: { store: SuggestionStore }) {
       await store.recordUse({
         title: String(title ?? '').slice(0, 32),
         text,
+        projectId: typeof projectId === 'string' && projectId.trim() ? projectId : null,
       });
       res.json({ ok: true });
     } catch (err: any) {

--- a/test/suggestion-store.test.ts
+++ b/test/suggestion-store.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createSuggestionStore } from '../helpers/suggestion-store.ts';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-suggestions-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('suggestion recent history', () => {
+  it('isolates recent suggestions by project', async () => {
+    const store = createSuggestionStore(tmpDir);
+    await store.recordUse({ title: 'A task', text: 'task for A', projectId: 'project-a' });
+    await store.recordUse({ title: 'B task', text: 'task for B', projectId: 'project-b' });
+    await store.recordUse({ title: 'Global task', text: 'global task' });
+
+    const projectA = await store.getMerged('en', 'project-a');
+    const projectB = await store.getMerged('en', 'project-b');
+    const global = await store.getMerged('en');
+
+    expect(projectA.agent[0]?.id).toBe('recent');
+    expect(projectA.agent[0]?.items.map(item => item.text)).toEqual(['task for A']);
+    expect(projectB.agent[0]?.items.map(item => item.text)).toEqual(['task for B']);
+    expect(global.agent[0]?.items.map(item => item.text)).toEqual(['global task']);
+  });
+});


### PR DESCRIPTION
## Summary
- scope recent task suggestions to the active project
- keep project switching available in Agent stats and memory panels
- replace session deletion with archiving, including restore and permanent delete actions
- keep archived sessions in project Agent statistics

## Tests
- npm test (327 passed)
- npm run typecheck
- npm run build:client