### PR TITLE
fix(browser): use Edge headless on Windows

### DIFF
--- a/agent/desktop/browser-session-manager.ts
+++ b/agent/desktop/browser-session-manager.ts
@@ -125,22 +125,25 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
       await Promise.resolve(session.view.evaluate('document.readyState'));
       assertCurrentSession(session, generation);
       session.lifecycle = 'ready';
-    } catch {
+    } catch (err: any) {
       session.lifecycle = 'broken';
       if (session === sharedBrowserSession) {
         sharedBrowserSession = null;
         sharedBrowserHeadless = null;
       }
       await closeSessionBounded(session);
-      emit(onEvent, 'degraded', session, { reason: 'initialization_failed' });
-      throw new Error('WebView 初始化失败');
+      const detail = String(err?.message || err);
+      emit(onEvent, 'degraded', session, { reason: 'initialization_failed', error: detail });
+      throw new Error(`WebView 初始化失败: ${detail}`, { cause: err });
     }
 
     state.browserSession = session;
     onEvent?.({
       type: 'status',
       status: 'browser_ready',
-      message: 'Bun.WebView 浏览器已启动并通过健康检查',
+      message: process.platform === 'win32'
+        ? 'Microsoft Edge Headless 浏览器已启动并通过健康检查'
+        : 'Bun.WebView 浏览器已启动并通过健康检查',
       sessionId: session.sessionId,
       generation: session.generation,
     });

--- a/agent/tools/browser/edge-cdp-webview.ts
+++ b/agent/tools/browser/edge-cdp-webview.ts
@@ -1,0 +1,238 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { createServer } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+type PendingCommand = {
+  resolve: (value: any) => void;
+  reject: (reason?: any) => void;
+};
+
+export class EdgeCdpWebView {
+  url = 'about:blank';
+  title = '';
+  private child: ChildProcess | null = null;
+  private socket: WebSocket | null = null;
+  private nextCommandId = 1;
+  private pending = new Map<number, PendingCommand>();
+  private closed = false;
+  private profileDir: string | null = null;
+  private ready: Promise<void>;
+
+  constructor(private options: { width?: number; height?: number } = {}) {
+    this.ready = this.start();
+  }
+
+  private async start() {
+    const candidates = [
+      process.env.PROGRAMFILES && path.join(process.env.PROGRAMFILES, 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+      process.env['PROGRAMFILES(X86)'] && path.join(process.env['PROGRAMFILES(X86)'], 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+      process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+    ].filter(Boolean) as string[];
+    const edgePath = candidates.find(candidate => existsSync(candidate));
+    if (!edgePath) {
+      throw new Error('未找到 Microsoft Edge。Windows 内置浏览器需要已安装 Edge。');
+    }
+
+    const port = await new Promise<number>((resolve, reject) => {
+      const server = createServer();
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        const selectedPort = typeof address === 'object' && address ? address.port : 0;
+        server.close(error => error ? reject(error) : resolve(selectedPort));
+      });
+    });
+    if (this.closed) throw new Error('Invalid state: WebView is closed');
+
+    this.profileDir = mkdtempSync(path.join(os.tmpdir(), 'sagent-edge-'));
+    this.child = spawn(edgePath, [
+      '--headless=new',
+      `--remote-debugging-port=${port}`,
+      `--user-data-dir=${this.profileDir}`,
+      `--window-size=${this.options.width || 1440},${this.options.height || 960}`,
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-background-networking',
+      '--disable-component-update',
+      '--disable-extensions',
+      '--disable-features=msEdgeFirstRunExperience',
+      'about:blank',
+    ], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+
+    let target: any = null;
+    let lastError: any = null;
+    for (let attempt = 0; attempt < 100 && !this.closed; attempt += 1) {
+      // Edge 在 Windows 上可能由当前进程转交给同一安装目录下的新浏览器进程，
+      // 此时启动器会正常退出（exitCode 0），调试端口仍会由新进程继续提供。
+      if (this.child.exitCode !== null && this.child.exitCode !== 0) {
+        throw new Error(`Microsoft Edge 启动失败，退出码: ${this.child.exitCode}`);
+      }
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+        if (response.ok) {
+          const targets: any[] = await response.json();
+          target = targets.find(item => item.type === 'page' && item.webSocketDebuggerUrl);
+          if (target) break;
+        }
+      } catch (err) {
+        lastError = err;
+      }
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    if (!target) {
+      throw new Error(`无法连接 Microsoft Edge 调试端口${lastError ? `: ${String(lastError.message || lastError)}` : ''}`);
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const socket = new WebSocket(target.webSocketDebuggerUrl);
+      this.socket = socket;
+      socket.addEventListener('open', () => resolve(), { once: true });
+      socket.addEventListener('error', () => reject(new Error('Microsoft Edge CDP WebSocket 连接失败')), { once: true });
+      socket.addEventListener('message', event => {
+        let message: any;
+        try {
+          message = JSON.parse(String(event.data));
+        } catch {
+          return;
+        }
+        if (!message.id) return;
+        const command = this.pending.get(message.id);
+        if (!command) return;
+        this.pending.delete(message.id);
+        if (message.error) {
+          command.reject(new Error(message.error.message || 'Edge CDP 命令失败'));
+        } else {
+          command.resolve(message.result);
+        }
+      });
+      socket.addEventListener('close', () => {
+        const error = new Error('Invalid state: WebView is closed');
+        for (const command of this.pending.values()) command.reject(error);
+        this.pending.clear();
+      });
+    });
+
+    await this.command('Page.enable');
+    await this.command('Runtime.enable');
+  }
+
+  private async command(method: string, params: Record<string, any> = {}) {
+    if (this.closed) throw new Error('Invalid state: WebView is closed');
+    if (method !== 'Page.enable' && method !== 'Runtime.enable') await this.ready;
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error('Invalid state: WebView CDP connection is closed');
+    }
+    const id = this.nextCommandId++;
+    const result = new Promise<any>((resolve, reject) => this.pending.set(id, { resolve, reject }));
+    this.socket.send(JSON.stringify({ id, method, params }));
+    return result;
+  }
+
+  async navigate(url: string) {
+    await this.ready;
+    const result = await this.command('Page.navigate', { url });
+    if (result.errorText) throw new Error(`navigation failed: ${result.errorText}`);
+    for (let attempt = 0; attempt < 300; attempt += 1) {
+      const state = await this.evaluate('document.readyState');
+      if (state === 'complete' || state === 'interactive') break;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    const page = await this.evaluate('({ url: window.location.href, title: document.title })');
+    this.url = page?.url || url;
+    this.title = page?.title || '';
+  }
+
+  async evaluate(script: string) {
+    const response = await this.command('Runtime.evaluate', {
+      expression: script,
+      awaitPromise: true,
+      returnByValue: true,
+      userGesture: true,
+    });
+    if (response.exceptionDetails) {
+      const detail = response.exceptionDetails.exception?.description
+        || response.exceptionDetails.text
+        || '页面脚本执行失败';
+      throw new Error(detail);
+    }
+    return response.result?.value;
+  }
+
+  async click(selector: string) {
+    await this.evaluate(`(() => {
+      const element = document.querySelector(${JSON.stringify(selector)});
+      if (!element) throw new Error(${JSON.stringify(`元素不存在: ${selector}`)});
+      element.scrollIntoView({ block: 'center', inline: 'center' });
+      element.click();
+      return true;
+    })()`);
+  }
+
+  async type(selector: string, text: string) {
+    await this.evaluate(`(() => {
+      const element = document.querySelector(${JSON.stringify(selector)});
+      if (!element) throw new Error(${JSON.stringify(`元素不存在: ${selector}`)});
+      element.focus();
+      return true;
+    })()`);
+    await this.command('Input.insertText', { text });
+  }
+
+  async press(key: string) {
+    if (key !== 'Enter') throw new Error(`暂不支持按键: ${key}`);
+    await this.command('Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: 'Enter',
+      code: 'Enter',
+      text: '\r',
+      windowsVirtualKeyCode: 13,
+      nativeVirtualKeyCode: 13,
+    });
+    await this.command('Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      key: 'Enter',
+      code: 'Enter',
+      windowsVirtualKeyCode: 13,
+      nativeVirtualKeyCode: 13,
+    });
+  }
+
+  async close() {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      if (this.socket?.readyState === WebSocket.OPEN) {
+        const id = this.nextCommandId++;
+        const acknowledged = new Promise<void>((resolve, reject) => {
+          this.pending.set(id, { resolve, reject });
+        });
+        this.socket.send(JSON.stringify({ id, method: 'Browser.close', params: {} }));
+        await Promise.race([
+          acknowledged.catch(() => {}),
+          new Promise(resolve => setTimeout(resolve, 1_000)),
+        ]);
+      }
+    } catch {}
+    try { this.socket?.close(); } catch {}
+    try { this.child?.kill(); } catch {}
+    if (this.profileDir) {
+      const tempRoot = path.resolve(os.tmpdir());
+      const resolvedProfile = path.resolve(this.profileDir);
+      if (resolvedProfile.startsWith(`${tempRoot}${path.sep}`) && path.basename(resolvedProfile).startsWith('sagent-edge-')) {
+        for (let attempt = 0; attempt < 5; attempt += 1) {
+          try {
+            rmSync(resolvedProfile, { recursive: true, force: true });
+            break;
+          } catch {
+            await new Promise(resolve => setTimeout(resolve, 100));
+          }
+        }
+      }
+    }
+  }
+}

--- a/agent/tools/browser/webview-session.ts
+++ b/agent/tools/browser/webview-session.ts
@@ -1,11 +1,15 @@
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
+import { EdgeCdpWebView } from './edge-cdp-webview.ts';
 
 let sharedSession = null;
 let webViewFactory = defaultWebViewFactory;
 let dataStoreDir = null;
 
 function defaultWebViewFactory(options) {
+  if (process.platform === 'win32') {
+    return new EdgeCdpWebView(options);
+  }
   const WebView = globalThis.Bun?.WebView;
   if (!WebView) {
     throw new Error('Bun.WebView 不可用。请使用 Bun 1.3+ 运行 sagent，或升级到包含 Bun.WebView 的 Bun 版本。');

--- a/test/browser-webview.test.ts
+++ b/test/browser-webview.test.ts
@@ -114,7 +114,7 @@ describe('Bun.WebView browser session adapter', () => {
     expect(created.closed).toBe(true);
   });
 
-  it('throws a clear runtime error when Bun.WebView is unavailable', () => {
+  it.skipIf(process.platform === 'win32')('throws a clear runtime error when Bun.WebView is unavailable', () => {
     resetWebViewFactoryForTests();
     const originalBun = globalThis.Bun;
 
@@ -143,6 +143,36 @@ describe('Bun.WebView browser observation', () => {
 });
 
 describe('Bun.WebView browser actions', () => {
+  it('preserves the original WebView initialization error', async () => {
+    const originalError = new Error('Chrome WebSocket closed (code 1006)');
+    setWebViewFactoryForTests(options => {
+      const view = new FakeWebView(options);
+      view.navigate = async () => {
+        throw originalError;
+      };
+      return view;
+    });
+    const manager = createSharedBrowserSessionManager();
+    const state = { headless: true, browserSession: null };
+    const events: any[] = [];
+
+    try {
+      await manager.ensureBrowserSession(state, event => events.push(event));
+      throw new Error('预期 WebView 初始化失败');
+    } catch (err: any) {
+      expect(err.message).toBe('WebView 初始化失败: Chrome WebSocket closed (code 1006)');
+      expect(err.cause).toBe(originalError);
+    }
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'browser_session',
+        status: 'degraded',
+        reason: 'initialization_failed',
+        error: 'Chrome WebSocket closed (code 1006)',
+      }),
+    ]));
+  });
+
   it('executes navigation, click, typing, scroll, content, and search actions through WebView', async () => {
     const view = new FakeWebView();
 


### PR DESCRIPTION
## Summary

- launch an isolated Microsoft Edge Headless process through CDP on Windows
- keep the existing `Bun.WebView` backend unchanged on macOS and Linux
- adapt navigation, evaluation, click, typing, Enter, shutdown, and temporary profile cleanup to the existing browser interface
- preserve WebView initialization error details in browser session events and exceptions

## Validation

- `npm run typecheck`
- `npm test -- --run test/browser-webview.test.ts` — 11 passed, 1 skipped
- real Windows smoke test — Edge launched headlessly, navigated, evaluated JavaScript, typed, clicked, and closed successfully
- full `npm test` — 322 passed, 5 failed, 1 skipped
  - 3 failures require Windows symbolic-link privileges
  - 1 existing assertion expects a Unix-style path on Windows
  - 1 existing test invokes unavailable Unix command `ls`

## Security review

- reviewed the complete staged diff before commit
- scanned changed files for API keys, tokens, passwords, private keys, authorization headers, user-specific absolute paths, and local usernames; no matches found
- no new dependency was added
pr-body.md
