### PR TITLE
feat: streamline prompts, memory, suggestions, and sidebar

### DIFF
--- a/agent/core/config-schema.ts
+++ b/agent/core/config-schema.ts
@@ -10,7 +10,6 @@ export interface RuntimeConfig {
   observeDesktop: boolean;
   maxHistorySteps: number;
   maxResultChars: number;
-  memoryMaxEntries: number;
   autoModelRouting: boolean;
 }
 
@@ -70,7 +69,6 @@ export const AGENT_CONFIG_SCHEMA: Record<RuntimeConfigKey, ConfigFieldSpec> = {
   observeDesktop: { env: 'AGENT_OBSERVE_DESKTOP', type: 'bool', default: false, group: 'execution', advanced: true, restartRequired: false },
   maxHistorySteps: { env: 'AGENT_MAX_HISTORY_STEPS', type: 'int', default: 6, min: 1, max: 200, group: 'context', advanced: true, restartRequired: false },
   maxResultChars: { env: 'AGENT_MAX_RESULT_CHARS', type: 'int', default: 4000, min: 100, max: 200000, group: 'context', advanced: true, restartRequired: false },
-  memoryMaxEntries: { env: 'AGENT_MEMORY_MAX_ENTRIES', type: 'int', default: 20, min: 1, max: 1000, group: 'memory', advanced: false, restartRequired: false },
   autoModelRouting: { env: 'AGENT_AUTO_MODEL_ROUTING', type: 'bool', default: false, group: 'routing', advanced: false, restartRequired: false },
 };
 

--- a/agent/core/memory.ts
+++ b/agent/core/memory.ts
@@ -2,42 +2,27 @@
  * Memory — Agent 跨会话记忆系统 / Cross-session memory system
  *
  * 让 Agent 积累项目经验和用户偏好，跨会话持久化。
- * Persists project knowledge and conversation history across sessions.
+ * Persists project knowledge across sessions.
  *
  * 存储内容 / Storage:
- *   - conversation: 最近 N 次任务的摘要（任务 → 结果 / task → result）
- *     每条记录包含 task, summary, models（该任务各步使用的模型列表）, timestamp
- *   - conversationSummary: LLM 提炼的历史摘要（去重合并）
- *     LLM-distilled summary with deduplication and merging
  *   - projectKnowledge: 项目结构、常用路径、用户偏好、经验积累
- *   - lastCompactedAt: 上次压缩时间
- *
- * 压缩机制 / Compaction:
- *   - 当 conversation 超过 AGENT_MEMORY_MAX_ENTRIES（默认 20）时触发
- *   - 将全部历史条目交给 LLM 提炼为摘要（去重合并），而非简单拼接
- *   - 异步执行，不阻塞 Agent 响应（routes/agent.js res.end() 之后）
- *   - 回退：LLM 不可用时退化为文本拼接
  *
  * 注入方式 / Injection:
  *   buildMemoryPrompt() 将记忆注入 Agent 的 systemPrompt（上限 3000 字）
  *
  * 调用场景 / Callers:
  *   - routes/agent.js POST /api/agent 开始前: loadMemory → buildMemoryPrompt
- *   - routes/agent.js 任务完成后: extractConversationEntry → extractProjectKnowledge → async compactConversationMemory → saveMemory
- *   - routes/agent.js POST /api/agent/compact: 手动触发压缩
+ *   - routes/agent.js 任务完成后: extractProjectKnowledge → saveMemory
  *   - routes/agent.js GET /api/agent/memory: 返回完整记忆数据供前端展示
  *
  * 存储位置: {MEMORY_DIR}/agent-memory.json
  *
- * TODO / 拆分建议 Refactor suggestions:
- *   - 将 buildMemoryPrompt 拆到 agent/core/memory-prompt.js（prompt 构建与存储逻辑分离）
- *   - 将 extractProjectKnowledge 拆到 agent/core/knowledge-extractor.js（知识提取独立为可插拔模块）
+ * TODO: 将知识提取拆为可插拔模块。
  */
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { cleanText } from './utils.ts';
-import { configStore } from './config-store.ts';
 
 const MEMORY_FILE = 'agent-memory.json';
 const MAX_CHARS = 3000;
@@ -46,9 +31,6 @@ const MAX_KNOWLEDGE_PER_CATEGORY = 50;
 function emptyMemory() {
   return {
     version: 1,
-    conversation: [],
-    conversationSummary: '',
-    lastCompactedAt: '',
     projectKnowledge: {
       structure: [],
       paths: {},
@@ -65,7 +47,6 @@ export async function loadMemory(dir) {
     const parsed = JSON.parse(raw);
     return {
       ...emptyMemory(),
-      ...parsed,
       projectKnowledge: {
         ...emptyMemory().projectKnowledge,
         ...(parsed.projectKnowledge || {}),
@@ -84,37 +65,8 @@ export async function saveMemory(dir, memory) {
   await fs.rename(tmpPath, filePath);
 }
 
-function formatTimeAgo(timestamp) {
-  if (!timestamp) return '';
-  const diff = Date.now() - new Date(timestamp).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return '刚刚';
-  if (minutes < 60) return `${minutes}分钟前`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}小时前`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}天前`;
-  return `${Math.floor(days / 30)}月前`;
-}
-
 export function buildMemoryPrompt(memory, { maxChars = MAX_CHARS } = {}) {
   const parts = [];
-
-  // Conversation memory
-  const convLines = [];
-  if (memory.conversationSummary) {
-    convLines.push(`(早期) ${memory.conversationSummary}`);
-  }
-  const recent = memory.conversation.slice(-8);
-  for (const entry of recent) {
-    const taskShort = cleanText(entry.task || '', 60);
-    const summaryShort = cleanText(entry.summary || '', 80);
-    const ago = formatTimeAgo(entry.timestamp);
-    convLines.push(`- ${taskShort} → ${summaryShort} (${ago})`);
-  }
-  if (convLines.length > 0) {
-    parts.push(`最近的任务:\n${convLines.join('\n')}`);
-  }
 
   // Project knowledge
   const pk = memory.projectKnowledge || {};
@@ -155,48 +107,6 @@ export function buildMemoryPrompt(memory, { maxChars = MAX_CHARS } = {}) {
   }
 
   return result;
-}
-
-export function extractConversationEntry({ task, result, model, stepModels }) {
-  const steps = result?.steps || [];
-  const filesTouched = [];
-  const toolsUsed = new Set();
-  const usedModels = new Set();
-
-  for (const step of steps) {
-    const action = step.action;
-    if (!action) continue;
-    toolsUsed.add(action.type || '?');
-    if (action.tool === 'fs' && action.path) {
-      filesTouched.push(action.path);
-    }
-    if (action.tool === 'terminal' && action.command) {
-      const fileHints = action.command.match(/[\w./-]+\.\w+/g);
-      if (fileHints) {
-        filesTouched.push(...fileHints);
-      }
-    }
-    if (stepModels && step.step != null && stepModels[step.step]) {
-      usedModels.add(stepModels[step.step]);
-    }
-  }
-
-  // Also extract models from stepModels directly (covers case where steps is empty)
-  if (stepModels) {
-    for (const m of Object.values(stepModels)) {
-      usedModels.add(m);
-    }
-  }
-
-  return {
-    task: cleanText(task || '', 80),
-    summary: cleanText(result?.answer || '', 120),
-    filesTouched: [...new Set(filesTouched)].slice(0, 10),
-    toolsUsed: [...toolsUsed],
-    models: [...usedModels],
-    model: model || '',
-    timestamp: new Date().toISOString(),
-  };
 }
 
 export function extractProjectKnowledge(memory, { task: _task, result }) {
@@ -253,35 +163,6 @@ export function extractProjectKnowledge(memory, { task: _task, result }) {
       }
     }
   }
-}
-
-export async function compactConversationMemory(memory, { maxEntries, summarizeFn }: { maxEntries?: number; summarizeFn?: (text: string) => Promise<string> } = {}) {
-  if (maxEntries == null) maxEntries = configStore.get().memoryMaxEntries;
-  const conv = memory.conversation;
-  if (conv.length <= maxEntries) {
-    return;
-  }
-
-  const allText = conv
-    .map(e => `${cleanText(e.task || '', 60)} → ${cleanText(e.summary || '', 80)}`)
-    .join('\n');
-
-  const input = memory.conversationSummary
-    ? `${memory.conversationSummary}\n\n--- 历史记录 ---\n${allText}`
-    : allText;
-
-  if (summarizeFn) {
-    try {
-      memory.conversationSummary = await summarizeFn(input);
-    } catch {
-      memory.conversationSummary = input.replace(/\n/g, '; ').slice(0, 2000);
-    }
-  } else {
-    memory.conversationSummary = input.replace(/\n/g, '; ').slice(0, 2000);
-  }
-
-  memory.conversation = conv.slice(-maxEntries);
-  memory.lastCompactedAt = new Date().toISOString();
 }
 
 export async function clearMemory(dir) {

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -78,18 +78,38 @@ export function buildNvidiaActionExampleLines({
   chromeEnabled = false,
   mcpEnabled = false,
   readonly = false,
+  includeToolNames,
 }: {
   ideEnabled?: boolean;
   chromeEnabled?: boolean;
   mcpEnabled?: boolean;
   readonly?: boolean;
+  includeToolNames?: Iterable<string>;
 } = {}) {
+  const allowed = includeToolNames ? new Set(includeToolNames) : null;
   return NVIDIA_ACTION_EXAMPLES
     .filter(example => !readonly || example.readonly)
+    .filter(example => !allowed || allowed.has(String(example.action.type || '')))
     .filter(example => example.capability !== 'ide' || ideEnabled)
     .filter(example => example.capability !== 'chrome' || chromeEnabled)
     .filter(example => example.capability !== 'mcp' || mcpEnabled)
     .map(({ rationale, action }) => JSON.stringify({ rationale, action }));
+}
+
+function buildNvidiaToolSignatureLines(toolNames: Iterable<string>) {
+  const names = new Set(toolNames);
+  const hasAny = (items: string[]) => items.some(name => names.has(name));
+  return [
+    hasAny(WEB_TOOL_NAMES) ? 'browser: navigate(url), click(elementId), type(elementId,text), wait(seconds), scroll(direction,amount), get_page_content(), http_fetch(url,extractLinks?)' : '',
+    hasAny(FILE_TOOL_NAMES) ? 'fs: list_dir(path), get_file_info(path), read_file(path), write_file(path,content,append), search_files(query,path,include?)；codegraph: codegraph_query(query)' : '',
+    hasAny(TERMINAL_TOOL_NAMES) ? 'terminal: run_safe(command), run_confirmed(command), run_review(command)' : '',
+    names.has('web_search') ? 'search: web_search(query,maxResults?)' : '',
+    names.has('image_analyze') ? 'vision: image_analyze(image,question)' : '',
+    hasAny(IDE_TOOL_NAMES) ? 'ide: ide_list_tools(refresh?), ide_call_tool(toolName,arguments)' : '',
+    hasAny(CHROME_TOOL_NAMES) ? 'chrome: chrome_list_tools(refresh?), chrome_call_tool(toolName,arguments,refreshTools?)' : '',
+    hasAny(MCP_TOOL_NAMES) ? 'mcp: mcp_list_servers(), mcp_list_tools(serverName,refresh?), mcp_call_tool(serverName,toolName,arguments,refreshTools?)' : '',
+    'core: ask_user(question), notify_user(message,level), finish(answer)',
+  ].filter(Boolean);
 }
 
 function historyUsesTool(history: any[] | undefined, tool: string) {
@@ -333,27 +353,16 @@ function buildSharedAgentRuleLines(capabilityContext: PromptCapabilityContext = 
   const mcpLines = genericMcpPromptLines(capabilityContext);
   return [
     '规则：',
-    '0. task 字段是本轮唯一执行目标，优先级高于 conversationHistory。历史对话只用于理解指代和上下文，禁止恢复、继续或切换到历史中的旧任务。',
-    '0.1 涉及产品能力、模型目录、版本变化、供应商上下线等可能随时间变化的信息时，优先使用 web_search 核验，不要仅凭记忆回答。',
-    '1. 只有 observation.browser.elements 中存在的 elementId 才能用于 browser.click / browser.type。',
-    '2. 优先使用已知信息，不要重复无意义截图或重复读同一文件。任务一旦完成，必须立即调用 finish，绝不能重复执行已成功的动作。',
-    '2.2 若任务是常识问答、闲聊，或依据已有知识即可直接回答（无需读取文件/网页/桌面/终端），直接用 finish 返回答案，不要为了「显得在执行」而调用 list_dir、read_file 等探索性工具。',
-    '3. 文件写入、终端确认命令、桌面键鼠输入可能需要用户批准，被拒绝后请尝试替代方案。',
-    '4. cd/pushd/popd 等目录切换命令使用 run_review，会触发用户审批。',
-    '5. answer 用简体中文，简洁直接。',
-    '6. 需要全网搜索关键词时，优先使用 web_search（DuckDuckGo，返回标题/URL/摘要），再用 http_fetch 抓具体页面。禁止直接 navigate 到 Google/Bing/百度搜索结果页，这些页面容易触发反爬。',
-    '7. http_fetch 和 navigate 都通过浏览器执行，可以处理需要 JS 渲染的页面。',
-    '8. 需要获取多个页面时，逐个使用 http_fetch 抓取，优先选择最相关、最权威的来源。',
-    '9. 需要用户输入或确认偏好时使用 ask_user，不要自行假设。',
-    '10. 执行中发现重要信息或潜在问题时使用 notify_user 主动告知用户。',
-    '10.1 任务或附件中出现图片（本地路径或 http(s) URL，常见于任务文本中的“[附件]”块或截图）时，必须用 image_analyze 把图片交给多模态模型分析，不要凭文件名猜测内容。image 传图片路径/URL，question 用简体中文写清要从图里得到什么。',
-    '10.2 简单识图任务（例如“这是什么图/图里是什么”）在一次 image_analyze 已得到可用描述后，应立即 finish。若无法确认具体来源、游戏、人物、地点或品牌，必须说明“无法仅凭图片确认”，并给出可见证据和低置信猜测；不要反复调用同一张图来放大猜测。',
-    '10.3 对同一张图片最多连续调用 2 次 image_analyze；第二次只用于明确不同的问题（如 OCR、局部细节、真假核验）。不要编造图片中没有的 UI、文字、按钮、角色名、怪物、道具或数值。',
-    '12. 涉及医保、社保、签证、贷款、股票、基金、汇率、法律、法规、政策、许可、合规等高风险或合规性信息时，必须优先从官方来源核验；如果未能核验，finish 答案必须明确说明“未能完成官方核验”，不要把记忆或常识包装成已确认结论。',
-    '13. finish 之前自检：当任务要求基于网页/官网内容作答，但浏览操作没有真正取得目标页面的实质内容（如反复超时、只到达主页、被反爬挡住），不要用模型常识包装成“已确认结论”。要么继续尝试（换路径、换工具、换源站），要么在 answer 里明确说明“未能从目标页面取得信息，以下来自常识仅供参考”。',
-    '14. 查询酒店/机票/电商等实时价格时，优先用 web_search 获取价格区间或聚合报价；这类价格依赖具体入住/出行日期、常需登录且受反爬限制，难以直接抓取。若拿不到确切数字，直接 finish 给出区间与查询入口，并如实说明“未取得实时精确价”，不要在单个站点反复操作空转。',
-    '15. 浏览器/Chrome 操作要及时止损：对同一目标连续约 5 步仍未取得实质数据时，停止更换手段反复尝试，直接 finish 汇总已知信息并说明未能取得的部分。',
-    ...(chromeDetails ? ['16. 当内置浏览器被反爬拦截时，改用 Chrome MCP 操作真实浏览器访问同一页面。'] : []),
+    '1. task 是本轮唯一目标；conversationHistory 只用于理解指代，不得恢复或切换到旧任务。',
+    '2. 决策顺序：已有信息足够则立即 finish；缺少用户才能决定的信息则 ask_user；否则选择完成目标所需的最少工具。不要为了显得在执行而探索。',
+    '3. 不要重复已成功或无新目的的动作。同一目标连续约 5 步仍无实质进展时停止尝试，finish 汇总已知信息并说明限制。',
+    '4. 文件写入和终端确认命令可能需要审批；cd/pushd/popd 使用 run_review。被拒绝后改用安全替代方案。',
+    '5. browser.click/type 只能使用 observation.browser.elements 中存在的 elementId。搜索先用 web_search 定位来源，再逐个 http_fetch 权威页面；不要 navigate 到搜索引擎结果页。',
+    '6. 不得编造工具结果。时效产品信息和医保、签证、金融、法律、政策等高风险信息优先核验官方来源；未核验或未取得目标网页正文时必须明确说明。',
+    '7. 图片任务必须使用 image_analyze，不得凭文件名猜测。简单识图得到可用结果后立即 finish；同一图片最多连续分析 2 次，无法确认具体来源时区分可见事实与低置信猜测。',
+    '8. 酒店、机票、电商等实时价格优先用 web_search 获取区间；拿不到精确数字时给出查询入口并说明未取得实时精确价。',
+    '9. 重要发现可用 notify_user。finish 的 answer 使用简体中文，简洁直接。',
+    ...(chromeDetails ? ['10. 内置浏览器被 CAPTCHA、403 或 Cloudflare 拦截时，改用 Chrome MCP 访问同一目标。'] : []),
     ...ideLines,
     ...chromeLines,
     ...mcpLines,
@@ -470,7 +479,7 @@ export function buildNvidiaTaskMessages({
   compact?: boolean;
   toolMode?: 'full' | 'readonly';
 }) {
-  const capabilityContext = { task, history, observation };
+  const capabilityContext = { task, history, observation, conversationHistory };
   const ideEnabled = isIdeMcpEnabled();
   const ideDetails = shouldIncludeIdePromptDetails(capabilityContext);
   const chromeEnabled = isChromeMcpAvailable();
@@ -487,6 +496,7 @@ export function buildNvidiaTaskMessages({
   const recentUrlsHint = buildRecentUrlsHint(history);
   const recentSearchesHint = buildRecentSearchesHint(history);
   const promptHistory = compactAgentHistory(history, undefined, undefined, task);
+  const selectedToolNames = selectGeminiToolNames(capabilityContext);
 
   if (toolMode === 'readonly') {
     return [
@@ -535,16 +545,14 @@ export function buildNvidiaTaskMessages({
         '你只能输出一个 JSON 对象，不要输出 Markdown，不要解释。',
         '输出格式固定为 {"rationale":"简短理由","action":{...}}。',
         '可用动作示例（字段名、字段层级、tool 和 type 必须严格照此填写；每一步只输出其中一个 JSON 对象）：',
-        ...buildNvidiaActionExampleLines({ ideEnabled, chromeEnabled, mcpEnabled: mcpEnabled && mcpDetails }),
+        ...buildNvidiaActionExampleLines({
+          ideEnabled,
+          chromeEnabled,
+          mcpEnabled: mcpEnabled && mcpDetails,
+          includeToolNames: selectedToolNames,
+        }),
         '可用动作签名（括号内为主要参数）：',
-        'browser: navigate(url), click(elementId), type(elementId,text), wait(seconds), scroll(direction,amount), get_page_content(), http_fetch(url,extractLinks?)',
-        'fs: list_dir(path), get_file_info(path), read_file(path), write_file(path,content,append), search_files(query,path,include?)',
-        'terminal: run_safe(command), run_confirmed(command), run_review(command)',
-        'search: web_search(query,maxResults?)；codegraph: codegraph_query(query)；vision: image_analyze(image,question)',
-        ...(ideEnabled && ideDetails ? ['ide: ide_list_tools(refresh?), ide_call_tool(toolName,arguments)'] : []),
-        ...(chromeEnabled && chromeDetails ? ['chrome: chrome_list_tools(refresh?), chrome_call_tool(toolName,arguments,refreshTools?)'] : []),
-        ...(mcpEnabled && mcpDetails ? ['mcp: mcp_list_servers(), mcp_list_tools(serverName,refresh?), mcp_call_tool(serverName,toolName,arguments,refreshTools?)'] : []),
-        'core: ask_user(question), notify_user(message,level), finish(answer)',
+        ...buildNvidiaToolSignatureLines(selectedToolNames),
         '重要：每个步骤必须且只能输出一个 JSON 动作。如果你已经收集到足够信息并可以直接回答用户问题，请使用 finish 动作输出答案。绝对不要在 JSON 之外输出解释文字。',
         ...buildSharedAgentRuleLines(capabilityContext),
         systemPrompt ? `附加约束：${systemPrompt}` : '',

--- a/client/ARCHITECTURE.md
+++ b/client/ARCHITECTURE.md
@@ -191,7 +191,7 @@ client/src/
 - **会话切换同步 trace**：切到另一个会话时，把那个会话的 agentTrace 拉出来（去重后写入），并把"上次 agent 任务原文"记到 ref 里供 rollback 重试用。
 - **快捷键**：`Cmd/Ctrl+Shift+E` 折叠面板、`Cmd/Ctrl+Shift+M` 切记忆面板。
 - **自动滚动**：`messages / activeSession.id / agentTrace` 变化时滚到底。
-- **建议数据刷新**：从后端拉取推荐任务；提交任务后刷新"最近使用"。
+- **建议数据刷新**：启动时从后端拉取推荐任务；“换一组”仅重新随机抽取当前分类。
 - **textarea 自适应高度**：根据 `input` 长度计算，最高 144px。
 
 ### ⑦ 卸载清理

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -788,6 +788,20 @@ select,
   display: none;
 }
 
+@media (min-width: 1100px) {
+  .sidebar.floating {
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 30;
+    box-shadow: 4px 0 18px rgba(0, 0, 0, 0.14);
+  }
+
+  .sidebar.floating:not(.open) {
+    pointer-events: none;
+    box-shadow: none;
+  }
+}
+
 .session-panel {
   display: flex;
   flex-direction: column;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1024,7 +1024,11 @@ export default function App() {
           showMemoryPanel={showMemoryPanel}
           onToggleMemory={() => setShowMemoryPanel(v => !v)}
           sidebarPinned={sidebarPinned}
-          onToggleSidebarPin={() => setSidebarPinned(value => !value)}
+          onToggleSidebarPin={() => {
+            const nextPinned = !sidebarPinned;
+            setSidebarPinned(nextPinned);
+            setShowSessions(nextPinned);
+          }}
           projects={projects}
           activeProjectId={activeProjectId}
           onActivateProject={handleActivateProject}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -39,7 +39,7 @@ import { useAgentTransport } from './hooks/useAgentTransport.js';
 import { useQuestionSubmit } from './hooks/useQuestionSubmit.js';
 import { useAttachments } from './hooks/useAttachments.js';
 import { EMPTY_SUGGESTIONS } from './data/suggestions.js';
-import { fetchSuggestions, recordSuggestionUse } from './api/suggestions.js';
+import { fetchSuggestions } from './api/suggestions.js';
 import { apiFetch } from './api/http.js';
 import {
   TABLET_BREAKPOINT,
@@ -135,8 +135,6 @@ export default function App() {
   const [suggestionSeed, setSuggestionSeed] = useState(0);
   const [suggestionData, setSuggestionData] = useState(EMPTY_SUGGESTIONS);
   const [activeCategoryId, setActiveCategoryId] = useState(null);
-  // 卡片点击时把标题暂存,handleSubmit 时上报给后端;手动输入则降级到 text 前 12 字
-  const pendingTitleRef = useRef(null);
   const {
     agentRunning,
     setAgentRunning,
@@ -175,10 +173,21 @@ export default function App() {
   const [showReset, setShowReset] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showPromptPreview, setShowPromptPreview] = useState(false);
+  const [sidebarPinned, setSidebarPinned] = usePersistentState('session_sidebar_pinned', false, booleanStorage);
   const { showSessions, setShowSessions } = useResponsiveLayout({
     dockedBreakpoint: DOCKED_LAYOUT_BREAKPOINT,
     panelSizeKey: PANEL_SIZE_KEY,
+    sidebarPinned,
   });
+
+  useEffect(() => {
+    const revealFromLeftEdge = event => {
+      if (window.innerWidth < DOCKED_LAYOUT_BREAKPOINT || sidebarPinned) return;
+      if (event.clientX <= window.innerWidth * 0.1) setShowSessions(true);
+    };
+    window.addEventListener('mousemove', revealFromLeftEdge);
+    return () => window.removeEventListener('mousemove', revealFromLeftEdge);
+  }, [sidebarPinned, setShowSessions]);
   // Agent 的多模型选择与策略「按项目」存储:useProjectScopedState 内部按 activeProjectId 分桶,
   // 切项目时派生值自动跟着变；memory 仍是应用级偏好。
   const [selectedAgentModels, setSelectedAgentModels] = useProjectScopedState('agent_models_by_project', activeProjectId, EMPTY_AGENT_MODELS);
@@ -701,10 +710,10 @@ export default function App() {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, activeSession.id, agentTrace]);
 
-  // 建议数据从后端拉取;suggestionSeed 触发(刷新按钮 / 提交后)也会重新拉,让"最近使用"即时反映
+  // 建议数据从后端拉取；换一组只改变本地随机种子。
   useEffect(() => {
     let cancelled = false;
-    fetchSuggestions(activeProjectId)
+    fetchSuggestions()
       .then(data => {
         if (cancelled) return;
         setSuggestionData(data);
@@ -712,7 +721,7 @@ export default function App() {
       })
       .catch(() => {});
     return () => { cancelled = true; };
-  }, [suggestionSeed, activeProjectId]);
+  }, []);
 
   useEffect(() => {
     const el = textareaRef.current;
@@ -856,15 +865,6 @@ export default function App() {
       return;
     }
 
-    // 把这次发送累计到后端使用记录；标题用原始用户输入(userText),避免被附件提示污染。
-    const titleSource = userText || readyAttachments[0]?.name || t('attach.taskFallback');
-    const title = pendingTitleRef.current
-      || (titleSource.length > 12 ? titleSource.slice(0, 12) + '…' : titleSource);
-    pendingTitleRef.current = null;
-    recordSuggestionUse({ title, text, projectId: activeSession.projectId ?? null });
-    // 下次返回 hero 时能看到新的"最近使用"
-    setSuggestionSeed(v => v + 1);
-
     await sendAgentTask(text);
     clearAttachments();
   };
@@ -885,10 +885,6 @@ export default function App() {
     void suggestionSeed;
     const cat = agentCategories.find(c => c.id === activeCategoryId) ?? agentCategories[0];
     const pool = cat?.items ?? [];
-    // "最近使用"已按最近请求时间倒序,保持顺序;其它分类随机抽样
-    if (cat?.id === 'recent') {
-      return pool.slice(0, Math.min(8, pool.length));
-    }
     return shuffled(pool).slice(0, Math.min(8, pool.length));
   }, [activeSession.id, suggestionSeed, activeCategoryId, agentCategories]);
 
@@ -1015,7 +1011,7 @@ export default function App() {
   return (
     <ErrorBoundary>
     <div className="app-shell">
-      <SessionSidebar open={showSessions} onClose={() => setShowSessions(false)}>
+      <SessionSidebar open={showSessions} pinned={sidebarPinned} onClose={() => setShowSessions(false)}>
         <SessionList
           sessions={sessions}
           activeSessionId={activeSession.id}
@@ -1027,6 +1023,8 @@ export default function App() {
           locked={sessionLocked}
           showMemoryPanel={showMemoryPanel}
           onToggleMemory={() => setShowMemoryPanel(v => !v)}
+          sidebarPinned={sidebarPinned}
+          onToggleSidebarPin={() => setSidebarPinned(value => !value)}
           projects={projects}
           activeProjectId={activeProjectId}
           onActivateProject={handleActivateProject}
@@ -1051,7 +1049,7 @@ export default function App() {
       )}
       {showHero && (
         <div className="hero-corner-actions">
-          <button className="session-toggle-btn" onClick={() => setShowSessions(v => !v)} title={t('header.sessionList')}>
+          <button className="session-toggle-btn" onClick={() => sidebarPinned ? setSidebarPinned(false) : setShowSessions(v => !v)} title={t('header.sessionList')}>
             <Menu size={16} />
           </button>
           <button className="session-toggle-btn" onClick={() => setShowSettings(true)} title={t('header.settings')}>
@@ -1074,13 +1072,11 @@ export default function App() {
           activeCategoryId={activeCategoryId}
           onSelectCategory={setActiveCategoryId}
           onShuffle={() => setSuggestionSeed(v => v + 1)}
-          onPickSuggestion={(text, title) => {
-            pendingTitleRef.current = title ?? null;
+          onPickSuggestion={(text) => {
             setInput(text);
             textareaRef.current?.focus();
           }}
-          onSubmitSuggestion={(text, title) => {
-            pendingTitleRef.current = title ?? null;
+          onSubmitSuggestion={(text) => {
             setInput(text);
             setTimeout(() => handleSubmit(), 0);
           }}
@@ -1097,7 +1093,7 @@ export default function App() {
             sessionLocked={sessionLocked}
             messagesLength={messages.length}
             modelSelect={modelSelect}
-            onToggleSessions={() => setShowSessions(v => !v)}
+            onToggleSessions={() => sidebarPinned ? setSidebarPinned(false) : setShowSessions(v => !v)}
             onCreateSession={handleCreateSession}
             onReset={() => setShowReset(true)}
             onOpenSettings={() => setShowSettings(true)}

--- a/client/src/api/suggestions.js
+++ b/client/src/api/suggestions.js
@@ -1,18 +1,9 @@
 // 主页"试试这些任务/问题"建议数据 API。
-// GET 拉取 chat + agent 分类数据;POST fire-and-forget 累计使用记录。
+// GET 拉取 agent 分类数据。
 import { apiFetch } from './http.js';
 
-export async function fetchSuggestions(projectId = null) {
-  const query = projectId ? `?projectId=${encodeURIComponent(projectId)}` : '';
-  const res = await apiFetch(`/api/suggestions${query}`);
+export async function fetchSuggestions() {
+  const res = await apiFetch('/api/suggestions');
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
-}
-
-export function recordSuggestionUse({ title, text, projectId = null }) {
-  return apiFetch('/api/suggestions/use', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title, text, projectId }),
-  }).catch(() => {});
 }

--- a/client/src/components/SessionSidebar.jsx
+++ b/client/src/components/SessionSidebar.jsx
@@ -1,10 +1,15 @@
 import { useT } from '../i18n/I18nProvider.jsx';
 
-export function SessionSidebar({ open, onClose, children }) {
+export function SessionSidebar({ open, pinned = false, onClose, children }) {
   const t = useT();
   return (
     <>
-      <div className={`sidebar ${open ? 'open' : ''}`}>
+      <div
+        className={`sidebar ${open ? 'open' : ''} ${pinned ? 'pinned' : 'floating'}`}
+        onMouseLeave={() => {
+          if (!pinned && window.innerWidth >= 1100) onClose();
+        }}
+      >
         {children}
       </div>
       <button

--- a/client/src/components/dialogs/SettingsDialog.jsx
+++ b/client/src/components/dialogs/SettingsDialog.jsx
@@ -6,7 +6,7 @@ import { useI18n, useT } from '../../i18n/I18nProvider.jsx';
 import { DialogShell } from './DialogShell.jsx';
 
 // Agent 行为参数（可写，热生效）。单位与 .env 一致，换算放后端消费点。
-// label 改为 i18n key，渲染时经 t() 取文案。memoryMaxEntries 归到「记忆」组。
+// label 改为 i18n key，渲染时经 t() 取文案。
 const BASIC_AGENT_FIELDS = [
   { key: 'maxSteps', labelKey: 'settings.maxSteps' },
   { key: 'modelTimeoutSec', labelKey: 'settings.modelTimeoutSec' },
@@ -536,7 +536,6 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
                 onChange={e => setAgentMemory(e.target.checked)}
               />
             </label>
-            {renderBackendGuard() || numberField('memoryMaxEntries', 'settings.memoryMaxEntries')}
           </div>
         </div>
       );

--- a/client/src/components/session/MemoryPanel.jsx
+++ b/client/src/components/session/MemoryPanel.jsx
@@ -9,9 +9,7 @@ export function MemoryPanel({ onClose, activeProjectId = null, modelList = [] })
   const t = useT();
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [compacting, setCompacting] = useState(false);
-  const [compactModel, setCompactModel] = useState('');
-  const [tab, setTab] = useState('conversation');
+  const [tab, setTab] = useState('knowledge');
 
   // 记忆按项目隔离：所有请求带上当前项目 id（无项目则查全局）。
   const qs = activeProjectId ? `?projectId=${encodeURIComponent(activeProjectId)}` : '';
@@ -23,31 +21,6 @@ export function MemoryPanel({ onClose, activeProjectId = null, modelList = [] })
       .then(d => { setData(d); setLoading(false); })
       .catch(() => setLoading(false));
   }, [qs]);
-
-  useEffect(() => {
-    if (compactModel && !modelList.some(item => item.id === compactModel)) {
-      setCompactModel('');
-    }
-  }, [compactModel, modelList]);
-
-  const handleCompact = async () => {
-    if (!compactModel) return;
-    setCompacting(true);
-    try {
-      const r = await apiFetch(`/api/agent/compact${qs}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: compactModel }),
-      });
-      const result = await r.json();
-      if (result.ok) {
-        const r2 = await apiFetch(`/api/agent/memory${qs}`);
-        setData(await r2.json());
-      }
-    } finally {
-      setCompacting(false);
-    }
-  };
 
   const handleClear = async (path) => {
     if (!confirm(t('memory.confirmClear'))) return;
@@ -67,9 +40,6 @@ export function MemoryPanel({ onClose, activeProjectId = null, modelList = [] })
     <div className="memory-panel">
       <div className="memory-panel-head">
         <div className="memory-panel-tabs">
-          <button className={`memory-tab ${tab === 'conversation' ? 'active' : ''}`} onClick={() => setTab('conversation')}>
-            {t('memory.tabConversation', { n: data?.conversationCount ?? 0 })}
-          </button>
           <button className={`memory-tab ${tab === 'knowledge' ? 'active' : ''}`} onClick={() => setTab('knowledge')}>
             {t('memory.tabKnowledge', { n: (pk.structure?.length || 0) + Object.keys(pk.paths || {}).length + (pk.preferences?.length || 0) + (pk.learnings?.length || 0) })}
           </button>
@@ -84,35 +54,6 @@ export function MemoryPanel({ onClose, activeProjectId = null, modelList = [] })
           <CodeGraphTab activeProjectId={activeProjectId} modelList={modelList} />
         ) : loading ? (
           <div className="memory-loading">{t('common.loading')}</div>
-        ) : tab === 'conversation' ? (
-          <>
-            {data?.conversationSummary && (
-              <div className="memory-section">
-                <p className="memory-section-title">{t('memory.historySummary')}{data.lastCompactedAt ? t('memory.compactedAt', { time: new Date(data.lastCompactedAt).toLocaleString() }) : ''}</p>
-                <p className="memory-summary-text">{data.conversationSummary}</p>
-              </div>
-            )}
-            {(data?.conversation || []).length === 0 ? (
-              <div className="memory-empty">{t('memory.noConversation')}</div>
-            ) : (
-              <div className="memory-conversation-list">
-                {[...(data.conversation || [])].reverse().map((entry, i) => (
-                  <div key={i} className="memory-conv-item">
-                    <div className="memory-conv-task">{entry.task}</div>
-                    <div className="memory-conv-summary">{entry.summary}</div>
-                    <div className="memory-conv-meta">
-                      {entry.models?.length > 0 ? (
-                        entry.models.map(m => <span key={m} className="memory-conv-model">{m.split('/').pop()}</span>)
-                      ) : entry.model ? (
-                        <span className="memory-conv-model">{entry.model.split('/').pop()}</span>
-                      ) : null}
-                      {entry.timestamp && <span className="memory-conv-time">{new Date(entry.timestamp).toLocaleString()}</span>}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </>
         ) : (
           <>
             {pk.structure?.length > 0 && (
@@ -145,29 +86,11 @@ export function MemoryPanel({ onClose, activeProjectId = null, modelList = [] })
           </>
         )}
       </div>
-      {tab !== 'codegraph' && (
+      {tab === 'knowledge' && (
         <div className="memory-panel-footer">
-          <div className="memory-compact-group">
-            <SingleModelSelector
-              className="memory-compact-model"
-              availableModels={modelList}
-              value={compactModel}
-              onChange={setCompactModel}
-              disabled={compacting || modelList.length === 0}
-              title={t('memory.compactModelTitle')}
-              placeholder={modelList.length === 0 ? t('codegraph.noModel') : t('modelSelector.selectModel')}
-              dialogTitle={t('memory.compactModelTitle')}
-            />
-            <button className="memory-compact-btn" onClick={handleCompact} disabled={compacting || !compactModel}>
-              {compacting ? t('memory.compacting') : t('memory.compactHistory')}
-            </button>
-          </div>
           <div className="memory-clear-group">
-            <button className="memory-clear-btn" onClick={() => handleClear('/api/agent/memory/knowledge')} title={t('memory.clearKnowledgeTitle')}>
+            <button className="memory-clear-btn danger" onClick={() => handleClear('/api/agent/memory')} title={t('memory.clearKnowledgeTitle')}>
               {t('memory.clearKnowledge')}
-            </button>
-            <button className="memory-clear-btn danger" onClick={() => handleClear('/api/agent/memory')} title={t('memory.clearAllTitle')}>
-              {t('common.clearAll')}
             </button>
           </div>
         </div>

--- a/client/src/components/session/MemoryPanel.jsx
+++ b/client/src/components/session/MemoryPanel.jsx
@@ -15,7 +15,6 @@ export function MemoryPanel({ onClose, activeProjectId = null, modelList = [] })
   const qs = activeProjectId ? `?projectId=${encodeURIComponent(activeProjectId)}` : '';
 
   useEffect(() => {
-    setLoading(true);
     apiFetch(`/api/agent/memory${qs}`)
       .then(r => r.json())
       .then(d => { setData(d); setLoading(false); })

--- a/client/src/components/session/SessionList.jsx
+++ b/client/src/components/session/SessionList.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Archive, ArchiveRestore, BarChart3, Brain, ChevronDown, Search, Trash2, X } from 'lucide-react';
+import { Archive, ArchiveRestore, BarChart3, Brain, ChevronDown, Pin, PinOff, Search, Trash2, X } from 'lucide-react';
 import { getSessionTitle } from '../../hooks/useChatSessions.js';
 import { usePersistentState, jsonStorage } from '../../hooks/usePersistentState.js';
 import { formatRelativeTime, formatShortTime, formatFullTime } from '../../utils/format.js';
@@ -119,6 +119,8 @@ export function SessionList({
   locked,
   showMemoryPanel,
   onToggleMemory,
+  sidebarPinned = false,
+  onToggleSidebarPin,
   // project
   projects = [],
   activeProjectId = null,
@@ -164,6 +166,13 @@ export function SessionList({
       <div className="session-panel-header">
         <h2 className="session-panel-title">{t('session.title')}</h2>
         <div className="session-panel-actions">
+          <button
+            className={`session-icon-btn ${sidebarPinned ? 'active' : ''}`}
+            onClick={onToggleSidebarPin}
+            title={t(sidebarPinned ? 'session.unpinSidebar' : 'session.pinSidebar')}
+          >
+            {sidebarPinned ? <PinOff size={13} /> : <Pin size={13} />}
+          </button>
           <button
             className={`session-icon-btn ${statsPanelOpen ? 'active' : ''}`}
             onClick={() => {

--- a/client/src/hooks/useResponsiveLayout.js
+++ b/client/src/hooks/useResponsiveLayout.js
@@ -31,11 +31,5 @@ export function useResponsiveLayout({ dockedBreakpoint, panelSizeKey, sidebarPin
     return () => window.removeEventListener('resize', syncResponsiveState);
   }, [dockedBreakpoint, panelSizeKey]);
 
-  useEffect(() => {
-    if (window.innerWidth >= dockedBreakpoint) {
-      setShowSessions(sidebarPinned);
-    }
-  }, [dockedBreakpoint, sidebarPinned]);
-
   return { showSessions, setShowSessions };
 }

--- a/client/src/hooks/useResponsiveLayout.js
+++ b/client/src/hooks/useResponsiveLayout.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-export function useResponsiveLayout({ dockedBreakpoint, panelSizeKey }) {
-  const [showSessions, setShowSessions] = useState(() => window.innerWidth >= dockedBreakpoint);
+export function useResponsiveLayout({ dockedBreakpoint, panelSizeKey, sidebarPinned = false }) {
+  const [showSessions, setShowSessions] = useState(() => window.innerWidth >= dockedBreakpoint && sidebarPinned);
 
   useEffect(() => {
     const restorePanelWidth = () => {
@@ -30,6 +30,12 @@ export function useResponsiveLayout({ dockedBreakpoint, panelSizeKey }) {
     window.addEventListener('resize', syncResponsiveState);
     return () => window.removeEventListener('resize', syncResponsiveState);
   }, [dockedBreakpoint, panelSizeKey]);
+
+  useEffect(() => {
+    if (window.innerWidth >= dockedBreakpoint) {
+      setShowSessions(sidebarPinned);
+    }
+  }, [dockedBreakpoint, sidebarPinned]);
 
   return { showSessions, setShowSessions };
 }

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -96,9 +96,8 @@ export const en = {
   'settings.batchSize': 'Models launched per batch',
   'settings.maxHistorySteps': 'Max history steps',
   'settings.maxResultChars': 'Max chars per step result',
-  'settings.memoryMaxEntries': 'Memory compaction threshold',
   'settings.memoryEnabled': 'Enable memory',
-  'settings.memoryDesc': 'Whether the agent uses history memory to assist tasks (frontend preference, applies immediately).',
+  'settings.memoryDesc': 'Whether the agent uses project knowledge and the code graph to assist tasks (frontend preference, applies immediately).',
   'settings.observeDesktop': 'Observe macOS desktop',
   'settings.autoModelRouting': 'Dynamic model routing',
   'settings.profile': 'Execution profile',
@@ -313,6 +312,8 @@ export const en = {
   'session.noMatch': 'No matching sessions',
   'session.empty': 'No sessions yet',
   'session.closeSidebar': 'Close session list',
+  'session.pinSidebar': 'Pin sidebar',
+  'session.unpinSidebar': 'Unpin sidebar',
   // Project
   'project.label': 'Project',
   'project.none': 'No project (global)',
@@ -339,22 +340,14 @@ export const en = {
 
   // Memory panel
   'memory.confirmClear': 'Are you sure you want to clear? This cannot be undone.',
-  'memory.tabConversation': 'Chats ({n})',
   'memory.tabKnowledge': 'Knowledge ({n})',
-  'memory.historySummary': 'History summary',
-  'memory.compactedAt': ' · compacted at {time}',
-  'memory.noConversation': 'No conversation history',
   'memory.projectStructure': 'Project structure',
   'memory.commonPaths': 'Common paths',
   'memory.preferences': 'Preferences',
   'memory.learnings': 'Learnings',
   'memory.noKnowledge': 'No project knowledge',
-  'memory.compactModelTitle': 'Select compaction model',
-  'memory.compacting': 'Compacting…',
-  'memory.compactHistory': 'Compact history',
-  'memory.clearKnowledgeTitle': 'Clear project knowledge, keep chats',
+  'memory.clearKnowledgeTitle': 'Clear project knowledge',
   'memory.clearKnowledge': 'Clear knowledge',
-  'memory.clearAllTitle': 'Clear all memory',
 
   // Code Graph
   'codegraph.tab': 'Code Graph',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -97,9 +97,8 @@ export const zh = {
   'settings.batchSize': '每批启动模型数',
   'settings.maxHistorySteps': '最大历史步数',
   'settings.maxResultChars': '每步结果最大字符数',
-  'settings.memoryMaxEntries': '记忆压缩阈值',
   'settings.memoryEnabled': '启用记忆',
-  'settings.memoryDesc': 'Agent 是否使用历史记忆辅助任务（前端偏好，即时生效）。',
+  'settings.memoryDesc': 'Agent 是否使用项目知识和代码图谱辅助任务（前端偏好，即时生效）。',
   'settings.observeDesktop': '观测 macOS 桌面',
   'settings.autoModelRouting': '动态模型路由',
   'settings.profile': '运行配置',
@@ -314,6 +313,8 @@ export const zh = {
   'session.noMatch': '未找到匹配的会话',
   'session.empty': '暂无会话',
   'session.closeSidebar': '关闭会话列表',
+  'session.pinSidebar': '固定侧边栏',
+  'session.unpinSidebar': '取消固定侧边栏',
   // 项目
   'project.label': '项目',
   'project.none': '无项目（全局）',
@@ -340,22 +341,14 @@ export const zh = {
 
   // 记忆面板
   'memory.confirmClear': '确定要清空吗？此操作不可撤销。',
-  'memory.tabConversation': '对话 ({n})',
   'memory.tabKnowledge': '知识 ({n})',
-  'memory.historySummary': '历史摘要',
-  'memory.compactedAt': ' · 压缩于 {time}',
-  'memory.noConversation': '暂无对话记录',
   'memory.projectStructure': '项目结构',
   'memory.commonPaths': '常用路径',
   'memory.preferences': '偏好',
   'memory.learnings': '经验',
   'memory.noKnowledge': '暂无项目知识',
-  'memory.compactModelTitle': '选择压缩模型',
-  'memory.compacting': '压缩中…',
-  'memory.compactHistory': '压缩历史',
-  'memory.clearKnowledgeTitle': '清空项目知识，保留对话',
+  'memory.clearKnowledgeTitle': '清空项目知识',
   'memory.clearKnowledge': '清空知识',
-  'memory.clearAllTitle': '清空全部记忆',
 
   // 代码图谱 Code Graph
   'codegraph.tab': '代码图谱',

--- a/helpers/i18n.ts
+++ b/helpers/i18n.ts
@@ -10,8 +10,6 @@ export type Locale = 'zh' | 'en';
 const MESSAGES: Record<Locale, Record<string, string>> = {
   zh: {
     'trace.notFound': 'trace 不存在',
-    'memory.compacted': '已压缩，保留 {n} 条',
-    'memory.noData': '无记忆数据',
     'config.validationFailed': '配置校验失败',
     'run.taskEmpty': 'task 不能为空',
     'run.modelRequired': '请先选择至少一个模型',
@@ -29,13 +27,9 @@ const MESSAGES: Record<Locale, Record<string, string>> = {
     'checkpoint.rollbackInProgress': '已有回滚请求处理中',
     'fetchRules.notEnabled': 'Domain rules 未启用',
     'fetchRules.domainEmpty': 'domain 不能为空',
-    'suggestions.textEmpty': 'text 不能为空',
-    'suggestions.recent': '最近使用',
   },
   en: {
     'trace.notFound': 'trace not found',
-    'memory.compacted': 'Compacted, kept {n} entries',
-    'memory.noData': 'No memory data',
     'config.validationFailed': 'Config validation failed',
     'run.taskEmpty': 'task cannot be empty',
     'run.modelRequired': 'Select at least one model first',
@@ -53,8 +47,6 @@ const MESSAGES: Record<Locale, Record<string, string>> = {
     'checkpoint.rollbackInProgress': 'A rollback request is already in progress',
     'fetchRules.notEnabled': 'Domain rules are not enabled',
     'fetchRules.domainEmpty': 'domain cannot be empty',
-    'suggestions.textEmpty': 'text cannot be empty',
-    'suggestions.recent': 'Recent',
   },
 };
 

--- a/helpers/suggestion-defaults.ts
+++ b/helpers/suggestion-defaults.ts
@@ -1,9 +1,4 @@
-/**
- * 建议种子数据 / Suggestion seed data
- *
- * 主页"试试这些任务/问题"的默认建议数据,作为后端 GET /api/suggestions 的基础。
- * 用户的使用历史叠加在这之上(history → "最近使用"分类),前端不再硬编码这份数据。
- */
+/** Suggestion data types and runtime validation. Content lives in data/suggestions.json. */
 
 export type SuggestionItem = {
   title: string;
@@ -22,236 +17,42 @@ export type SuggestionDefaults = {
 
 export type SuggestionLocale = 'zh' | 'en';
 
-export const SUGGESTION_DEFAULTS: SuggestionDefaults = {
-  agent: [
-    {
-      id: 'life',
-      label: '生活查询',
-      items: [
-        { title: '搜索天气', text: '打开浏览器搜索今天的天气' },
-        { title: '查天气预报', text: '打开浏览器搜索北京未来三天的天气预报' },
-        { title: '查汇率', text: '打开浏览器查询今日美元兑人民币汇率' },
-        { title: '查股价', text: '打开浏览器搜索苹果公司最新股价' },
-        { title: '查油价', text: '打开浏览器查询今日 92 号汽油价格' },
-        { title: '查空气质量', text: '打开浏览器搜索北京今天的空气质量指数' },
-        { title: '查菜谱', text: '搜索番茄炒蛋的做法,列出食材和步骤' },
-        { title: '查航班', text: '搜索明天北京到上海的航班信息' },
-        { title: '查火车票', text: '搜索明天北京到上海的高铁票信息' },
-        { title: '查旅游', text: '搜索杭州必去的十大景点及门票价格' },
-        { title: '查电影', text: '搜索本周正在热映的电影列表' },
-        { title: '查图书', text: '搜索《三体》的豆瓣评分和简介' },
-        { title: '查音乐', text: '搜索本周华语新歌榜热门歌曲' },
-        { title: '查星座', text: '搜索今日白羊座运势' },
-        { title: '查健身', text: '搜索适合初学者的家庭健身计划' },
-        { title: '查养生', text: '搜索春季养生饮食注意事项' },
-        { title: '查驾考新规', text: '搜索最新驾照考试规定的变化' },
-        { title: '查房价', text: '搜索北京朝阳区最新二手房均价' },
-        { title: '查租房', text: '搜索北京海淀区一居室租房价格' },
-        { title: '查公积金', text: '搜索北京住房公积金最新政策' },
-        { title: '查社保', text: '搜索最新社保缴费基数标准' },
-        { title: '查医保', text: '搜索北京医保报销比例最新标准' },
-        { title: '查个税', text: '搜索最新个人所得税计算方法' },
-        { title: '查信用卡', text: '搜索招商银行信用卡最新优惠活动' },
-        { title: '查疫情', text: '搜索最新的流感疫情数据' },
-        { title: '查节假日', text: '搜索今年法定节假日放假安排' },
-      ],
-    },
-    {
-      id: 'work',
-      label: '工作办公',
-      items: [
-        { title: '网页摘要', text: '抓取 https://finance.sina.com.cn 的内容并总结经济新闻要点' },
-        { title: '搜索新闻', text: '搜索最新的 AI 技术新闻,汇总前 5 条' },
-        { title: '读取文档', text: '读取 README.md 并总结内容' },
-        { title: '翻译文档', text: '读取 README.md 并翻译为英文' },
-        { title: '生成报告', text: '读取 package.json 并生成项目依赖报告' },
-        { title: '查论文', text: '搜索最近关于大语言模型的论文,列出标题和摘要' },
-        { title: '查招聘', text: '搜索前端工程师最新招聘岗位要求' },
-        { title: '查面试题', text: '搜索大厂前端面试高频题目 TOP 10' },
-        { title: '查英语', text: '搜索商务英语常用邮件模板' },
-        { title: '查PPT模板', text: '搜索免费PPT模板下载网站推荐' },
-      ],
-    },
-    {
-      id: 'dev',
-      label: '开发辅助',
-      items: [
-        { title: '分析代码', text: '搜索项目中所有的 TODO 注释并列出来' },
-        { title: '执行脚本', text: '运行 node -e "console.log(process.version)" 查看当前 Node 版本' },
-        { title: '查TODO', text: '搜索所有源代码文件中的 TODO 和 FIXME 注释' },
-        { title: '查console.log', text: '搜索前端代码中所有 console.log 调用' },
-        { title: '查项目结构', text: '从项目结构和依赖关系上分析一下这个仓库的主要模块' },
-        { title: '查代码行数', text: '统计项目中各类型文件的代码行数' },
-        { title: '查Git状态', text: '查看当前项目 Git 状态和最近提交' },
-        { title: '查依赖版本', text: '检查 package.json 中依赖的最新版本' },
-        { title: '查安全漏洞', text: '运行 npm audit 检查项目依赖的安全问题' },
-        { title: '查NPM包', text: '搜索 lodash 的 NPM 下载量和版本信息' },
-        { title: '查开源项目', text: '搜索 GitHub 上最热门的 AI 项目' },
-        { title: '查API文档', text: '打开浏览器搜索 OpenAI API 最新文档' },
-        { title: '查Docker', text: '列出当前运行的 Docker 容器和镜像' },
-        { title: '查Regex', text: '帮我写一个匹配邮箱地址的正则表达式并测试' },
-        { title: '查Cron', text: '帮我写一个每天早上9点执行的 Cron 表达式' },
-        { title: '查SQL', text: '写一个 SQL 查询:按销售额降序取前10名客户' },
-        { title: '查IDE报错', text: '帮我看看这个项目在 IDEA 里哪些文件有报错或 warning' },
-        { title: '查运行配置', text: '看看这个项目在 IDEA 里有哪些运行配置,哪个最适合本地启动' },
-        { title: '查编辑上下文', text: '看看 IDEA 当前打开了哪些文件,并判断我现在最可能在处理什么问题' },
-        { title: '查符号影响', text: '按 IDE 的理解帮我判断这个类改名会影响哪些地方' },
-        { title: '查重构方案', text: '这个改动涉及引用关系,尽量按更安全的重构方式处理' },
-      ],
-    },
-    {
-      id: 'sys',
-      label: '系统操作',
-      items: [
-        { title: '查看文件', text: '查看当前目录的文件结构' },
-        { title: '屏幕截图', text: '截取当前屏幕截图' },
-        { title: '整理文件', text: '列出当前目录下所有 .log 文件并统计大小' },
-        { title: '查最近修改', text: '列出最近7天修改过的文件' },
-        { title: '查空目录', text: '列出当前项目下所有空的文件夹' },
-        { title: '查大文件', text: '找出当前目录下超过 100MB 的文件' },
-        { title: '查重复文件', text: '扫描当前目录下可能重复的文件' },
-        { title: '查压缩包', text: '列出当前目录下所有 zip 文件及大小' },
-        { title: '查图片', text: '统计当前目录下所有图片文件数量和总大小' },
-        { title: '查PDF', text: '统计当前目录下所有 PDF 文件列表' },
-        { title: '查视频', text: '列出当前目录下所有视频文件及时长' },
-        { title: '查音乐文件', text: '列出当前目录下所有 mp3 文件' },
-        { title: '查进程', text: '列出当前占用内存最多的10个进程' },
-        { title: '查端口', text: '查看本机 3000 端口是否被占用' },
-        { title: '查磁盘', text: '查看当前磁盘剩余空间' },
-        { title: '查内存', text: '查看当前系统内存使用详情' },
-        { title: '查CPU', text: '查看当前 CPU 型号和使用率' },
-        { title: '查显示器', text: '查看当前显示器分辨率和刷新率' },
-        { title: '查电池', text: '查看 MacBook 电池健康度和循环次数' },
-        { title: '查蓝牙', text: '查看当前连接的蓝牙设备列表' },
-        { title: '查启动项', text: '查看 macOS 当前开机启动项列表' },
-        { title: '查网络信息', text: '列出当前网络连接信息和IP地址' },
-        { title: '查环境变量', text: '列出所有 Node.js 相关的环境变量' },
-        { title: '查剪贴板', text: '读取当前系统剪贴板内容' },
-        { title: '查日历', text: '查看今天日期和本周日程安排' },
-        { title: '查时区', text: '列出世界主要城市的当前时间' },
-        { title: '查证书', text: '查看 github.com 的 SSL 证书过期时间' },
-        { title: '查网站状态', text: '检测 github.com 是否可以正常访问' },
-      ],
-    },
+const CATEGORY_LABELS: Record<SuggestionLocale, Array<[string, string]>> = {
+  zh: [
+    ['life', '生活查询'],
+    ['work', '工作办公'],
+    ['dev', '开发辅助'],
+    ['sys', '系统操作'],
+  ],
+  en: [
+    ['life', 'Daily life'],
+    ['work', 'Work & office'],
+    ['dev', 'Dev helpers'],
+    ['sys', 'System'],
   ],
 };
 
-// 英文默认建议（与中文一一对应）；中国特有事项映射为对应的通用概念。
-export const SUGGESTION_DEFAULTS_EN: SuggestionDefaults = {
-  agent: [
-    {
-      id: 'life',
-      label: 'Daily life',
-      items: [
-        { title: 'Search weather', text: "Open the browser and search today's weather" },
-        { title: 'Weather forecast', text: "Open the browser and search Beijing's 3-day weather forecast" },
-        { title: 'Exchange rate', text: "Open the browser and look up today's USD to CNY exchange rate" },
-        { title: 'Stock price', text: "Open the browser and search Apple's latest stock price" },
-        { title: 'Fuel price', text: "Open the browser and look up today's gasoline price" },
-        { title: 'Air quality', text: "Open the browser and search Beijing's air quality index today" },
-        { title: 'Recipe', text: 'Search how to make scrambled eggs with tomato, list ingredients and steps' },
-        { title: 'Flights', text: 'Search tomorrow’s flights from Beijing to Shanghai' },
-        { title: 'Train tickets', text: 'Search tomorrow’s high-speed rail tickets from Beijing to Shanghai' },
-        { title: 'Travel', text: 'Search the top 10 attractions in Hangzhou and ticket prices' },
-        { title: 'Movies', text: 'Search the list of movies now playing this week' },
-        { title: 'Books', text: 'Search the rating and synopsis of "The Three-Body Problem"' },
-        { title: 'Music', text: 'Search this week’s trending new Mandarin songs' },
-        { title: 'Horoscope', text: "Search today's Aries horoscope" },
-        { title: 'Fitness', text: 'Search a beginner-friendly home workout plan' },
-        { title: 'Wellness', text: 'Search dietary wellness tips for spring' },
-        { title: 'Driving rules', text: "Search the latest changes to the driver's license test" },
-        { title: 'Home prices', text: 'Search the latest average resale home price in Beijing Chaoyang' },
-        { title: 'Rentals', text: 'Search one-bedroom rental prices in Beijing Haidian' },
-        { title: 'Housing fund', text: "Search Beijing's latest housing provident fund policy" },
-        { title: 'Social security', text: 'Search the latest social security contribution base' },
-        { title: 'Health insurance', text: "Search Beijing's latest medical insurance reimbursement rates" },
-        { title: 'Income tax', text: 'Search the latest personal income tax calculation method' },
-        { title: 'Credit card', text: 'Search the latest credit card offers from China Merchants Bank' },
-        { title: 'Outbreak', text: 'Search the latest flu outbreak data' },
-        { title: 'Holidays', text: "Search this year's public holiday schedule" },
-      ],
-    },
-    {
-      id: 'work',
-      label: 'Work & office',
-      items: [
-        { title: 'Web summary', text: 'Fetch the content of https://finance.sina.com.cn and summarize the key economic news' },
-        { title: 'Search news', text: 'Search the latest AI tech news and summarize the top 5' },
-        { title: 'Read a doc', text: 'Read README.md and summarize it' },
-        { title: 'Translate a doc', text: 'Read README.md and translate it into English' },
-        { title: 'Generate report', text: 'Read package.json and generate a project dependency report' },
-        { title: 'Find papers', text: 'Search recent papers on large language models, list titles and abstracts' },
-        { title: 'Job postings', text: 'Search the latest frontend engineer job requirements' },
-        { title: 'Interview Qs', text: 'Search the top 10 frequently asked frontend interview questions' },
-        { title: 'English', text: 'Search common business English email templates' },
-        { title: 'PPT templates', text: 'Search recommended free PPT template download sites' },
-      ],
-    },
-    {
-      id: 'dev',
-      label: 'Dev helpers',
-      items: [
-        { title: 'Analyze code', text: 'Search all TODO comments in the project and list them' },
-        { title: 'Run script', text: 'Run node -e "console.log(process.version)" to check the current Node version' },
-        { title: 'Find TODOs', text: 'Search all TODO and FIXME comments across source files' },
-        { title: 'Find console.log', text: 'Search all console.log calls in the frontend code' },
-        { title: 'Project structure', text: "Analyze this repo's main modules from its structure and dependencies" },
-        { title: 'Count LOC', text: 'Count lines of code by file type in the project' },
-        { title: 'Git status', text: 'Check the current project Git status and recent commits' },
-        { title: 'Dep versions', text: 'Check the latest versions of dependencies in package.json' },
-        { title: 'Vulnerabilities', text: 'Run npm audit to check the project dependencies for security issues' },
-        { title: 'NPM package', text: 'Search the NPM download count and version info for lodash' },
-        { title: 'Open source', text: 'Search the most popular AI projects on GitHub' },
-        { title: 'API docs', text: 'Open the browser and search the latest OpenAI API docs' },
-        { title: 'Docker', text: 'List the currently running Docker containers and images' },
-        { title: 'Regex', text: 'Write a regex that matches email addresses and test it' },
-        { title: 'Cron', text: 'Write a cron expression that runs every day at 9am' },
-        { title: 'SQL', text: 'Write a SQL query: top 10 customers by sales in descending order' },
-        { title: 'IDE errors', text: 'Check which files in this project have errors or warnings in IDEA' },
-        { title: 'Run configs', text: 'Check the run configurations in IDEA and which is best for local startup' },
-        { title: 'Editor context', text: "Check which files are open in IDEA and infer what I'm most likely working on" },
-        { title: 'Symbol impact', text: "Based on the IDE's understanding, judge what renaming this class affects" },
-        { title: 'Refactor plan', text: 'This change touches references; handle it with a safer refactoring approach' },
-      ],
-    },
-    {
-      id: 'sys',
-      label: 'System',
-      items: [
-        { title: 'View files', text: 'Show the file structure of the current directory' },
-        { title: 'Screenshot', text: 'Take a screenshot of the current screen' },
-        { title: 'Organize files', text: 'List all .log files in the current directory and total their size' },
-        { title: 'Recent changes', text: 'List files modified in the last 7 days' },
-        { title: 'Empty dirs', text: 'List all empty folders under the current project' },
-        { title: 'Large files', text: 'Find files over 100MB in the current directory' },
-        { title: 'Duplicates', text: 'Scan the current directory for possible duplicate files' },
-        { title: 'Archives', text: 'List all zip files in the current directory and their sizes' },
-        { title: 'Images', text: 'Count all image files in the current directory and their total size' },
-        { title: 'PDFs', text: 'List all PDF files in the current directory' },
-        { title: 'Videos', text: 'List all video files in the current directory and their durations' },
-        { title: 'Music files', text: 'List all mp3 files in the current directory' },
-        { title: 'Processes', text: 'List the 10 processes using the most memory' },
-        { title: 'Ports', text: 'Check whether port 3000 is in use on this machine' },
-        { title: 'Disk', text: 'Check the remaining disk space' },
-        { title: 'Memory', text: 'Check the current system memory usage details' },
-        { title: 'CPU', text: 'Check the current CPU model and usage' },
-        { title: 'Display', text: 'Check the current display resolution and refresh rate' },
-        { title: 'Battery', text: 'Check the MacBook battery health and cycle count' },
-        { title: 'Bluetooth', text: 'List the currently connected Bluetooth devices' },
-        { title: 'Startup items', text: 'List the current macOS login/startup items' },
-        { title: 'Network', text: 'List the current network connections and IP address' },
-        { title: 'Env vars', text: 'List all Node.js-related environment variables' },
-        { title: 'Clipboard', text: 'Read the current system clipboard content' },
-        { title: 'Calendar', text: "Check today's date and this week's schedule" },
-        { title: 'Time zones', text: 'List the current time in major world cities' },
-        { title: 'Certificate', text: 'Check the SSL certificate expiry for github.com' },
-        { title: 'Site status', text: 'Check whether github.com is reachable' },
-      ],
-    },
-  ],
-};
+export function emptySuggestionDefaults(locale: SuggestionLocale): SuggestionDefaults {
+  return {
+    agent: CATEGORY_LABELS[locale].map(([id, label]) => ({ id, label, items: [] })),
+  };
+}
 
-// 按语言取默认建议（en → 英文，其它 → 中文）。
-export function getSuggestionDefaults(locale: SuggestionLocale): SuggestionDefaults {
-  return locale === 'en' ? SUGGESTION_DEFAULTS_EN : SUGGESTION_DEFAULTS;
+export function parseSuggestionDefaults(value: unknown, locale: SuggestionLocale): SuggestionDefaults {
+  if (!value || typeof value !== 'object' || !Array.isArray((value as any).agent)) {
+    return emptySuggestionDefaults(locale);
+  }
+
+  const categories = (value as any).agent
+    .filter((category: any) => category && typeof category.id === 'string' && Array.isArray(category.items))
+    .map((category: any) => ({
+      id: category.id,
+      label: typeof category.label === 'string' ? category.label : category.id,
+      items: category.items
+        .filter((item: any) => item && typeof item.title === 'string' && typeof item.text === 'string')
+        .map((item: any) => ({ title: item.title.trim(), text: item.text.trim() }))
+        .filter((item: SuggestionItem) => item.title && item.text),
+    }));
+
+  return categories.length > 0 ? { agent: categories } : emptySuggestionDefaults(locale);
 }

--- a/helpers/suggestion-store.ts
+++ b/helpers/suggestion-store.ts
@@ -1,144 +1,32 @@
-/**
- * Suggestion Store — 主页建议的使用记录持久化
- *
- * 镜像 agent/tools/fetch/domain-rules.ts 的存储模式:
- *   - in-memory cache + lazy load
- *   - 2s 防抖保存
- *   - .tmp + rename 原子写
- *
- * 持久化文件 data/suggestions.json 只存"使用记录",默认建议数据来自 suggestion-defaults.ts。
- * 用户每发送一条指令(无论从卡片点击还是手动输入)都会调 recordUse() 累计 uses 计数。
- */
+/** Read-only runtime suggestion store. Content lives in ignored data/suggestions.json. */
 
-import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { log } from './logger.ts';
 import {
-  getSuggestionDefaults,
+  emptySuggestionDefaults,
+  parseSuggestionDefaults,
   type SuggestionCategory,
   type SuggestionLocale,
 } from './suggestion-defaults.ts';
-import { t } from './i18n.ts';
 
-const RECENT_LIMIT = 12;
-const SAVE_DEBOUNCE_MS = 2000;
-
-type HistoryEntry = {
-  projectId: string | null;
-  title: string;
-  text: string;
-  uses: number;
-  lastUsedAt: string;
-};
-
-type HistoryFile = {
-  version: number;
-  updatedAt: string;
-  history: HistoryEntry[];
-};
-
-export type MergedSuggestions = {
+export type Suggestions = {
   agent: SuggestionCategory[];
 };
 
 export type SuggestionStore = ReturnType<typeof createSuggestionStore>;
 
-function emptyHistory(): HistoryFile {
-  return { version: 1, updatedAt: new Date().toISOString(), history: [] };
-}
-
 export function createSuggestionStore(dir: string) {
   const filePath = path.join(dir, 'suggestions.json');
-  let cache: HistoryFile | null = null;
-  let saveTimer: NodeJS.Timeout | null = null;
-
-  async function load(): Promise<HistoryFile> {
-    if (cache) return cache;
-    try {
-      const raw = await readFile(filePath, 'utf-8');
-      const data = JSON.parse(raw);
-      cache = {
-        version: typeof data.version === 'number' ? data.version : 1,
-        updatedAt: typeof data.updatedAt === 'string' ? data.updatedAt : new Date().toISOString(),
-        history: Array.isArray(data.history)
-          ? data.history
-              .filter((e: any) => e && typeof e.text === 'string')
-              .map((e: any) => ({
-                title: String(e.title ?? '').slice(0, 32),
-                text: String(e.text),
-                projectId: typeof e.projectId === 'string' && e.projectId.trim() ? e.projectId : null,
-                uses: Number.isFinite(e.uses) ? Math.max(0, Math.floor(e.uses)) : 0,
-                lastUsedAt: typeof e.lastUsedAt === 'string' ? e.lastUsedAt : '',
-              }))
-          : [],
-      };
-    } catch {
-      cache = emptyHistory();
-    }
-    return cache;
-  }
-
-  async function save(): Promise<void> {
-    if (!cache) return;
-    const tmp = filePath + '.tmp';
-    await mkdir(dir, { recursive: true });
-    await writeFile(tmp, JSON.stringify(cache, null, 2));
-    await rename(tmp, filePath);
-  }
-
-  function scheduleSave(): void {
-    if (saveTimer) clearTimeout(saveTimer);
-    saveTimer = setTimeout(() => {
-      save().catch(err => log.error('[SuggestionStore] 保存失败:', err.message));
-    }, SAVE_DEBOUNCE_MS);
-  }
-
-  function buildRecent(history: HistoryEntry[], locale: SuggestionLocale): SuggestionCategory | null {
-    const recent = history
-      .filter(e => e.uses > 0)
-      // "最近使用"按最近请求时间倒序;lastUsedAt 为 ISO 串可直接字典序比较
-      .sort((a, b) => (b.lastUsedAt || '').localeCompare(a.lastUsedAt || ''))
-      .slice(0, RECENT_LIMIT)
-      .map(e => ({ title: e.title || e.text.slice(0, 12), text: e.text }));
-    if (recent.length === 0) return null;
-    return { id: 'recent', label: t(locale, 'suggestions.recent'), items: recent };
-  }
 
   return {
-    async getMerged(locale: SuggestionLocale = 'zh', projectId: string | null = null): Promise<MergedSuggestions> {
-      const data = await load();
-      const defaults = getSuggestionDefaults(locale);
-      const recent = buildRecent(
-        data.history.filter(entry => entry.projectId === projectId),
-        locale,
-      );
-      const agent = recent ? [recent, ...defaults.agent] : [...defaults.agent];
-      return {
-        agent,
-      };
-    },
-
-    async recordUse({ title, text, projectId = null }: { title: string; text: string; projectId?: string | null }): Promise<void> {
-      const trimmed = text.trim();
-      if (!trimmed) return;
-      const data = await load();
-      const existing = data.history.find(e => e.projectId === projectId && e.text === trimmed);
-      const now = new Date().toISOString();
-      if (existing) {
-        existing.uses += 1;
-        existing.lastUsedAt = now;
-        if (title && !existing.title) existing.title = title;
-      } else {
-        data.history.push({
-          projectId,
-          title: title || trimmed.slice(0, 12),
-          text: trimmed,
-          uses: 1,
-          lastUsedAt: now,
-        });
+    async get(locale: SuggestionLocale = 'zh'): Promise<Suggestions> {
+      try {
+        const raw = await readFile(filePath, 'utf-8');
+        const data = JSON.parse(raw);
+        return parseSuggestionDefaults(data.defaults?.[locale], locale);
+      } catch {
+        return emptySuggestionDefaults(locale);
       }
-      data.updatedAt = now;
-      scheduleSave();
     },
   };
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint .",
     "stop": "node scripts/stop.js",
     "smoke": "node scripts/smoke-test.mjs",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prompt:bench": "bun scripts/prompt-benchmark.ts"
   },
   "dependencies": {
     "@google/genai": "^2.7.0",

--- a/routes/agent-memory.ts
+++ b/routes/agent-memory.ts
@@ -1,21 +1,14 @@
 import { Router } from 'express';
 import {
   loadMemory,
-  saveMemory,
-  compactConversationMemory,
   clearMemory,
-  clearProjectKnowledge,
 } from '../agent/core/memory.ts';
-import { summarizeText } from '../agent/core/summarizer.ts';
 import { log } from '../helpers/logger.ts';
-import { tReq } from '../helpers/i18n.ts';
 import { resolveRunPaths } from '../agent/core/project-store.ts';
 import type { AgentRouterContext } from './agent-types.ts';
 
 export function createAgentMemoryRouter({
   memoryDir,
-  modelConfig,
-  registry,
   projectStore,
 }: AgentRouterContext) {
   const router = Router();
@@ -30,11 +23,6 @@ export function createAgentMemoryRouter({
     try {
       const memory = await loadMemory(resolveDir(req));
       res.json({
-        conversationCount: memory?.conversation?.length ?? 0,
-        summaryLength: memory?.conversationSummary?.length ?? 0,
-        conversation: memory?.conversation ?? [],
-        conversationSummary: memory?.conversationSummary ?? '',
-        lastCompactedAt: memory?.lastCompactedAt ?? '',
         projectKnowledge: memory?.projectKnowledge ?? { structure: [], paths: {}, preferences: [], learnings: [] },
       });
     } catch (err: any) {
@@ -42,50 +30,9 @@ export function createAgentMemoryRouter({
     }
   });
 
-  router.post('/api/agent/compact', async (req, res) => {
-    try {
-      const dir = resolveDir(req);
-      const memory = await loadMemory(dir);
-      if (memory) {
-        const requestedModel = typeof req.body?.model === 'string' ? req.body.model.trim() : '';
-        if (!requestedModel) {
-          return res.status(400).json({ ok: false, error: 'model is required' });
-        }
-        if (!modelConfig?.some(model => model.id === requestedModel)) {
-          return res.status(400).json({ ok: false, error: 'Unknown model' });
-        }
-        const summaryModel = requestedModel;
-        log.info(`[Memory] 手动压缩 ${memory.conversation.length} 条, 摘要模型: ${summaryModel || '无'}`);
-        const memStart = Date.now();
-        await compactConversationMemory(memory, {
-          summarizeFn: summaryModel
-            ? (text: string) => summarizeText({ text, registry, model: summaryModel })
-            : undefined,
-        });
-        await saveMemory(dir, memory);
-        log.info(`[Memory] 手动压缩完成，保留 ${memory.conversation.length} 条, 耗时 ${Date.now() - memStart}ms`);
-        res.json({ ok: true, message: tReq(req, 'memory.compacted', { n: memory.conversation.length }) });
-      } else {
-        res.json({ ok: false, message: tReq(req, 'memory.noData') });
-      }
-    } catch (err: any) {
-      res.status(500).json({ ok: false, error: err.message });
-    }
-  });
-
   router.delete('/api/agent/memory', async (req, res) => {
     try {
       await clearMemory(resolveDir(req));
-      log.info('[Memory] 已清空全部记忆');
-      res.json({ ok: true });
-    } catch (err: any) {
-      res.status(500).json({ error: err.message });
-    }
-  });
-
-  router.delete('/api/agent/memory/knowledge', async (req, res) => {
-    try {
-      await clearProjectKnowledge(resolveDir(req));
       log.info('[Memory] 已清空项目知识');
       res.json({ ok: true });
     } catch (err: any) {

--- a/routes/agent-run-memory-persist.ts
+++ b/routes/agent-run-memory-persist.ts
@@ -1,12 +1,8 @@
 import {
   saveMemory,
   loadMemory,
-  extractConversationEntry,
   extractProjectKnowledge,
-  compactConversationMemory,
 } from '../agent/core/memory.ts';
-import { summarizeText } from '../agent/core/summarizer.ts';
-import { log } from '../helpers/logger.ts';
 import type { ProviderRegistry } from '../agent/core/providers/registry.ts';
 import type { DesktopAgentResult } from '../agent/core/contracts.ts';
 
@@ -33,27 +29,8 @@ export async function persistAgentRunMemory({
 }) {
   const answer = finalAnswer || (agentError ? `失败: ${agentError.message.slice(0, 60)}` : '无结果');
   const steps = agentResult?.steps || [];
-  const entry = extractConversationEntry({ task: normalizedTask, result: { answer, steps }, model, stepModels });
-  memory.conversation.push(entry);
   extractProjectKnowledge(memory, { task: normalizedTask, result: { answer, steps } });
-
-  const modelCounts: Record<string, number> = {};
-  for (const selectedModel of Object.values(stepModels)) {
-    modelCounts[selectedModel as string] = (modelCounts[selectedModel as string] || 0) + 1;
-  }
-
-  const summaryModel = Object.entries(modelCounts).sort((a, b) => b[1] - a[1])[0]?.[0];
-  const modelStats = Object.entries(modelCounts).map(([m, c]) => `${m.split('/').pop()}×${c}`).join(', ');
-  log.info(`[Memory] 开始压缩记忆 ${memory.conversation.length} 条, 摘要模型: ${summaryModel?.split('/').pop() || '无'} (本轮 ${modelStats || '无竞速'})`);
-
-  const memStart = Date.now();
-  await compactConversationMemory(memory, {
-    summarizeFn: summaryModel
-      ? (text: string) => summarizeText({ text, registry, model: summaryModel })
-      : undefined,
-  });
   await saveMemory(memoryDir, memory);
-  log.info(`[Memory] 压缩完成，保留 ${memory.conversation.length} 条, 耗时 ${Date.now() - memStart}ms, 摘要长度 ${memory.conversationSummary.length}`);
 }
 
 export async function persistRecoveredAgentRunMemory({

--- a/routes/suggestions.ts
+++ b/routes/suggestions.ts
@@ -1,41 +1,20 @@
 /**
- * Suggestions API — 主页"试试这些任务/问题"建议数据 + 使用记录
+ * Suggestions API — 主页"试试这些任务/问题"建议数据
  *
- * GET  /api/suggestions?projectId=... → { chat, agent } (agent 顶部带项目内"最近使用"分类)
- * POST /api/suggestions/use      → { ok: true },累计 uses + lastUsedAt
+ * GET /api/suggestions → { agent }
  */
 
 import { Router } from 'express';
 import type { SuggestionStore } from '../helpers/suggestion-store.ts';
-import { pickLocale, tReq } from '../helpers/i18n.ts';
+import { pickLocale } from '../helpers/i18n.ts';
 
 export function createSuggestionsRouter({ store }: { store: SuggestionStore }) {
   const router = Router();
 
   router.get('/api/suggestions', async (req, res) => {
     try {
-      const projectId = typeof req.query.projectId === 'string' && req.query.projectId.trim()
-        ? req.query.projectId
-        : null;
-      const data = await store.getMerged(pickLocale(req), projectId);
+      const data = await store.get(pickLocale(req));
       res.json(data);
-    } catch (err: any) {
-      res.status(500).json({ error: err.message });
-    }
-  });
-
-  router.post('/api/suggestions/use', async (req, res) => {
-    const { title, text, projectId } = req.body ?? {};
-    if (typeof text !== 'string' || !text.trim()) {
-      return res.status(400).json({ error: tReq(req, 'suggestions.textEmpty') });
-    }
-    try {
-      await store.recordUse({
-        title: String(title ?? '').slice(0, 32),
-        text,
-        projectId: typeof projectId === 'string' && projectId.trim() ? projectId : null,
-      });
-      res.json({ ok: true });
     } catch (err: any) {
       res.status(500).json({ error: err.message });
     }

--- a/scripts/prompt-benchmark.ts
+++ b/scripts/prompt-benchmark.ts
@@ -1,0 +1,30 @@
+import { configStore } from '../agent/core/config-store.ts';
+import { buildGeminiAgentPromptPayload, buildNvidiaTaskMessages } from '../agent/core/prompts.ts';
+import { estimatePayloadTokens } from '../agent/core/context-estimate.ts';
+
+const CASES = [
+  { id: 'casual', task: '你好，介绍一下你自己' },
+  { id: 'web', task: '查询今天苏州天气' },
+  { id: 'code', task: '检查项目代码并运行测试' },
+  { id: 'codex', task: '用 Codex 检查项目可升级项' },
+  { id: 'chrome', task: '用 Chrome DevTools 检查网络请求' },
+  { id: 'ide', task: '用 IntelliJ 检查代码问题' },
+];
+
+await configStore.init('./data');
+
+const rows = CASES.map(({ id, task }) => {
+  const context = { task, step: 1, history: [], observation: {} };
+  const nvidia = buildNvidiaTaskMessages(context);
+  const gemini = buildGeminiAgentPromptPayload(context);
+  return {
+    id,
+    nvidiaTokens: estimatePayloadTokens(nvidia),
+    nvidiaSystemChars: nvidia[0].content.length,
+    geminiTokens: estimatePayloadTokens(gemini),
+    geminiSystemChars: gemini.systemInstruction.length,
+    geminiTools: gemini.tools[0].functionDeclarations.length,
+  };
+});
+
+console.table(rows);

--- a/server.ts
+++ b/server.ts
@@ -248,7 +248,6 @@ const httpServer = app.listen(Number(PORT), HOST, async () => {
   ${row('AGENT_MODEL_TIMEOUT', `${cfg.modelTimeoutSec}s`)}
   ${row('AGENT_STAGGER_DELAY', `${cfg.staggerDelaySec}s`)}
   ${row('AGENT_BATCH_SIZE', cfg.batchSize)}
-  ${row('AGENT_MEMORY_MAX_ENTRIES', cfg.memoryMaxEntries)}
   ${hLine}
   ${row('AGENT_OBSERVE_DESKTOP', cfg.observeDesktop)}
   ${row('AGENT_RESUME', AGENT_RESUME)}

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -84,66 +84,12 @@ describe('POST /api/agent model compatibility', () => {
   });
 });
 
-describe('POST /api/agent/compact', () => {
-  it('returns 200 and compacts memory', async () => {
-    // Write some memory entries
-    const { loadMemory, saveMemory } = await import('../agent/core/memory.js');
-    const mem = await loadMemory(tmpDir);
-    for (let i = 0; i < 25; i++) {
-      mem.conversation.push({ task: `task ${i}`, summary: `result ${i}`, timestamp: new Date().toISOString(), model: 'test', filesTouched: [], toolsUsed: [] });
-    }
-    await saveMemory(tmpDir, mem);
-
-    const res = await request(app)
-      .post('/api/agent/compact')
-      .send({ model: 'test-model' });
-    expect(res.status).toBe(200);
-    expect(res.body.ok).toBe(true);
-    expect(res.body.message).toMatch(/保留 \d+ 条/);
-  });
-
-  it('returns ok:false when no memory', async () => {
-    // loadMemory returns empty memory which is truthy, so this tests the compact of empty data
-    const res = await request(app)
-      .post('/api/agent/compact')
-      .send({ model: 'test-model' });
-    expect(res.status).toBe(200);
-    expect(res.body.ok).toBe(true);
-    expect(res.body.message).toContain('0');
-  });
-
-  it('requires an explicit compact model', async () => {
-    const res = await request(app).post('/api/agent/compact');
-    expect(res.status).toBe(400);
-    expect(res.body.ok).toBe(false);
-    expect(res.body.error).toContain('model');
-  });
-});
-
 describe('GET /api/agent/memory', () => {
-  it('returns counts for empty memory', async () => {
+  it('returns project knowledge only', async () => {
     const res = await request(app).get('/api/agent/memory');
     expect(res.status).toBe(200);
-    expect(res.body.conversationCount).toBe(0);
-    expect(res.body.summaryLength).toBe(0);
-    expect(res.body.conversation).toEqual([]);
-    expect(res.body.conversationSummary).toBe('');
     expect(res.body.projectKnowledge).toBeDefined();
-  });
-
-  it('returns counts after saving memory', async () => {
-    const { loadMemory, saveMemory } = await import('../agent/core/memory.js');
-    const mem = await loadMemory(tmpDir);
-    mem.conversation.push({ task: 'test', summary: 'done', timestamp: new Date().toISOString(), model: 'test', filesTouched: [], toolsUsed: [] });
-    await saveMemory(tmpDir, mem);
-
-    const res = await request(app).get('/api/agent/memory');
-    expect(res.status).toBe(200);
-    expect(res.body.conversationCount).toBe(1);
-    expect(res.body.summaryLength).toBe(0);
-    expect(res.body.conversation).toHaveLength(1);
-    expect(res.body.conversation[0].task).toBe('test');
-    expect(res.body.projectKnowledge).toBeDefined();
+    expect(res.body.conversation).toBeUndefined();
   });
 });
 

--- a/test/config-validation.test.ts
+++ b/test/config-validation.test.ts
@@ -13,7 +13,6 @@ describe('config validation and effective defaults', () => {
       observeDesktop: false,
       maxHistorySteps: 6,
       maxResultChars: 4000,
-      memoryMaxEntries: 20,
       autoModelRouting: false,
     });
   });

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -2,14 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import {
-  loadMemory,
-  saveMemory,
-  compactConversationMemory,
-  buildMemoryPrompt,
-  extractConversationEntry,
-  extractProjectKnowledge,
-} from '../agent/core/memory.ts';
+import { loadMemory, saveMemory, buildMemoryPrompt, extractProjectKnowledge } from '../agent/core/memory.ts';
 
 let tmpDir;
 
@@ -21,155 +14,61 @@ afterEach(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
-function makeEntry(task, summary) {
-  return { task, summary, timestamp: new Date().toISOString(), model: 'test', filesTouched: [], toolsUsed: [] };
-}
-
-describe('loadMemory / saveMemory', () => {
-  it('returns empty memory when no file exists', async () => {
-    const mem = await loadMemory(tmpDir);
-    expect(mem.conversation).toEqual([]);
-    expect(mem.conversationSummary).toBe('');
-    expect(mem.projectKnowledge).toBeDefined();
-  });
-
-  it('round-trips memory to disk', async () => {
-    const mem = await loadMemory(tmpDir);
-    mem.conversation.push(makeEntry('task A', 'result A'));
-    await saveMemory(tmpDir, mem);
-
-    const loaded = await loadMemory(tmpDir);
-    expect(loaded.conversation).toHaveLength(1);
-    expect(loaded.conversation[0].task).toBe('task A');
-  });
-});
-
-describe('compactConversationMemory', () => {
-  const LIMIT = 5;
-
-  it('does nothing when under limit', async () => {
-    const mem = { conversation: [makeEntry('a', 'b')], conversationSummary: '' };
-    await compactConversationMemory(mem, { maxEntries: LIMIT });
-    expect(mem.conversation).toHaveLength(1);
-  });
-
-  it('compacts when over limit', async () => {
-    const mem = { conversation: [], conversationSummary: '' };
-    for (let i = 0; i < 10; i++) {
-      mem.conversation.push(makeEntry(`task ${i}`, `result ${i}`));
-    }
-    await compactConversationMemory(mem, { maxEntries: LIMIT });
-    expect(mem.conversation).toHaveLength(LIMIT);
-    expect(mem.conversationSummary).toContain('task 0');
-    expect(mem.conversationSummary).toContain('task 9');
-  });
-
-  it('truncates summary without summarizeFn', async () => {
-    const mem = { conversation: [], conversationSummary: '' };
-    for (let i = 0; i < 20; i++) {
-      mem.conversation.push(makeEntry(`task ${i} with a longer description`, `result ${i} with details`));
-    }
-    await compactConversationMemory(mem, { maxEntries: LIMIT });
-    expect(mem.conversationSummary.length).toBeLessThanOrEqual(2000);
-  });
-
-  it('uses summarizeFn when provided', async () => {
-    const mem = { conversation: [], conversationSummary: '' };
-    for (let i = 0; i < 10; i++) {
-      mem.conversation.push(makeEntry(`task ${i}`, `result ${i}`));
-    }
-    await compactConversationMemory(mem, {
-      maxEntries: LIMIT,
-      summarizeFn: async (text) => 'LLM summary: ' + text.slice(0, 50),
+describe('knowledge memory', () => {
+  it('returns empty project knowledge when no file exists', async () => {
+    const memory = await loadMemory(tmpDir);
+    expect(memory).toEqual({
+      version: 1,
+      projectKnowledge: { structure: [], paths: {}, preferences: [], learnings: [] },
     });
-    expect(mem.conversation).toHaveLength(LIMIT);
-    expect(mem.conversationSummary).toContain('LLM summary');
   });
 
-  it('falls back to concatenation when summarizeFn fails', async () => {
-    const mem = { conversation: [], conversationSummary: '' };
-    for (let i = 0; i < 10; i++) {
-      mem.conversation.push(makeEntry(`task ${i}`, `result ${i}`));
-    }
-    await compactConversationMemory(mem, {
-      maxEntries: LIMIT,
-      summarizeFn: async () => { throw new Error('LLM error'); },
+  it('drops legacy conversation fields while loading', async () => {
+    await fs.writeFile(path.join(tmpDir, 'agent-memory.json'), JSON.stringify({
+      conversation: [{ task: 'legacy task', summary: 'legacy result' }],
+      conversationSummary: 'legacy summary',
+      projectKnowledge: { learnings: ['keep this knowledge'] },
+    }));
+
+    const memory = await loadMemory(tmpDir);
+    expect('conversation' in memory).toBe(false);
+    expect('conversationSummary' in memory).toBe(false);
+    expect(memory.projectKnowledge.learnings).toEqual(['keep this knowledge']);
+  });
+
+  it('round-trips project knowledge', async () => {
+    const memory = await loadMemory(tmpDir);
+    memory.projectKnowledge.paths.entry = '/src/index.ts';
+    await saveMemory(tmpDir, memory);
+    expect((await loadMemory(tmpDir)).projectKnowledge.paths.entry).toBe('/src/index.ts');
+  });
+
+  it('injects knowledge but no legacy conversation into the prompt', () => {
+    const prompt = buildMemoryPrompt({
+      conversation: [{ task: 'do not include', summary: 'legacy' }],
+      projectKnowledge: { structure: ['src contains the application'], paths: {}, preferences: [], learnings: [] },
     });
-    expect(mem.conversation).toHaveLength(LIMIT);
-    expect(mem.conversationSummary).toContain('task 0');
-  });
-});
-
-describe('buildMemoryPrompt', () => {
-  it('returns empty string for empty memory', () => {
-    const mem = { conversation: [], conversationSummary: '', projectKnowledge: { structure: [], paths: {}, preferences: [], learnings: [] } };
-    expect(buildMemoryPrompt(mem)).toBe('');
-  });
-
-  it('includes conversation entries', () => {
-    const mem = { conversation: [makeEntry('search files', 'found 3 files')], conversationSummary: '', projectKnowledge: {} };
-    const prompt = buildMemoryPrompt(mem);
-    expect(prompt).toContain('search files');
-    expect(prompt).toContain('found 3 files');
-  });
-
-  it('respects maxChars limit', () => {
-    const mem = { conversation: [], conversationSummary: '', projectKnowledge: {} };
-    for (let i = 0; i < 20; i++) {
-      mem.conversation.push(makeEntry(`task ${i} `.repeat(10), `result ${i} `.repeat(10)));
-    }
-    const prompt = buildMemoryPrompt(mem, { maxChars: 200 });
-    expect(prompt.length).toBeLessThanOrEqual(210); // allow for truncation + '...'
-  });
-});
-
-describe('extractConversationEntry', () => {
-  it('extracts task and answer', () => {
-    const entry = extractConversationEntry({
-      task: 'open browser and search',
-      result: { answer: 'searched successfully', steps: [] },
-      model: 'claude',
-      stepModels: {},
-    });
-    expect(entry.task).toContain('open browser');
-    expect(entry.summary).toContain('searched successfully');
-    expect(entry.model).toBe('claude');
-  });
-
-  it('extracts file paths from steps', () => {
-    const entry = extractConversationEntry({
-      task: 'edit code',
-      result: {
-        answer: 'done',
-        steps: [
-          { action: { tool: 'fs', type: 'write_file', path: '/src/index.js' } },
-          { action: { tool: 'terminal', type: 'run_safe', command: 'cat /src/App.jsx' } },
-        ],
-      },
-      model: 'test',
-      stepModels: {},
-    });
-    expect(entry.filesTouched).toContain('/src/index.js');
-    expect(entry.filesTouched).toContain('/src/App.jsx');
+    expect(prompt).toContain('src contains the application');
+    expect(prompt).not.toContain('do not include');
   });
 });
 
 describe('extractProjectKnowledge', () => {
   it('learns directory structure from list_dir', () => {
-    const mem = { conversation: [], conversationSummary: '', projectKnowledge: { structure: [], paths: {}, preferences: [], learnings: [] } };
-    extractProjectKnowledge(mem, {
+    const memory = { projectKnowledge: { structure: [], paths: {}, preferences: [], learnings: [] } };
+    extractProjectKnowledge(memory, {
       task: 'list files',
       result: { steps: [{ action: { type: 'list_dir', path: '/src' }, result: 'index.js App.jsx' }] },
     });
-    expect(mem.projectKnowledge.structure.length).toBeGreaterThan(0);
+    expect(memory.projectKnowledge.structure.length).toBeGreaterThan(0);
   });
 
   it('learns file paths from read/write', () => {
-    const mem = { conversation: [], conversationSummary: '', projectKnowledge: { structure: [], paths: {}, preferences: [], learnings: [] } };
-    extractProjectKnowledge(mem, {
+    const memory = { projectKnowledge: { structure: [], paths: {}, preferences: [], learnings: [] } };
+    extractProjectKnowledge(memory, {
       task: 'edit',
       result: { steps: [{ action: { type: 'read_file', path: '/src/utils.js' } }] },
     });
-    expect((mem.projectKnowledge as any).paths.utils).toBe('/src/utils.js');
+    expect((memory.projectKnowledge as any).paths.utils).toBe('/src/utils.js');
   });
 });

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -106,6 +106,28 @@ describe('agent prompts', () => {
     expect(compact[0].content).not.toContain('Desktop Agent 失败');
   });
 
+  it('keeps NVIDIA action examples scoped to the current task', () => {
+    const casual = buildNvidiaTaskMessages({
+      task: '你好，介绍一下你自己',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+    const code = buildNvidiaTaskMessages({
+      task: '检查项目代码并运行测试',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+
+    expect(casual[0].content).not.toContain('run_safe(command)');
+    expect(casual[0].content).not.toContain('read_file(path)');
+    expect(code[0].content).toContain('run_safe(command)');
+    expect(code[0].content).toContain('read_file(path)');
+    expect(estimatePayloadTokens(casual)).toBeLessThan(900);
+    expect(estimatePayloadTokens(code)).toBeLessThan(1200);
+  });
+
   it('keeps Chrome and IDE MCP details lazy for unrelated tasks', () => {
     vi.stubEnv('CHROME_MCP_ENABLED', 'true');
     vi.stubEnv('IDE_MCP_ENABLED', 'true');
@@ -299,7 +321,7 @@ describe('agent prompts', () => {
 
     expect(payload.contents).toHaveLength(1);
     expect(taskPayload.task).toBe('今天天气怎么样');
-    expect(payload.systemInstruction).toContain('task 字段是本轮唯一执行目标');
+    expect(payload.systemInstruction).toContain('task 是本轮唯一目标');
   });
 
   it('does not let unrelated conversation history activate tools for a new explicit task', () => {

--- a/test/recovered-memory.test.ts
+++ b/test/recovered-memory.test.ts
@@ -14,22 +14,27 @@ afterEach(async () => {
 });
 
 describe('recovered run memory', () => {
-  it('records the completed recovered task in project memory', async () => {
+  it('extracts knowledge without storing the recovered conversation', async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-recovered-memory-'));
     const registry = { resolve() { throw new Error('summary model should not be used'); } } as unknown as ProviderRegistry;
 
     await persistRecoveredAgentRunMemory({
       memoryDir: tmpDir,
       task: '恢复后的项目任务',
-      result: { answer: '恢复完成', steps: [] },
+      result: { answer: '已更新 src/index.ts 的恢复逻辑', steps: [
+        {
+          step: 1,
+          rationale: '读取入口文件',
+          action: { tool: 'fs', type: 'read_file', path: '/src/index.ts', maxBytes: 1000 },
+          result: 'file contents',
+        },
+      ] },
       model: 'test-model',
       registry,
     });
 
     const memory = await loadMemory(tmpDir);
-    expect(memory.conversation.at(-1)).toMatchObject({
-      task: '恢复后的项目任务',
-      summary: '恢复完成',
-    });
+    expect('conversation' in memory).toBe(false);
+    expect(memory.projectKnowledge.paths.index).toBe('/src/index.ts');
   });
 });

--- a/test/suggestion-store.test.ts
+++ b/test/suggestion-store.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { parseSuggestionDefaults } from '../helpers/suggestion-defaults.ts';
 import { createSuggestionStore } from '../helpers/suggestion-store.ts';
 
 let tmpDir: string;
@@ -14,20 +15,40 @@ afterEach(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
-describe('suggestion recent history', () => {
-  it('isolates recent suggestions by project', async () => {
-    const store = createSuggestionStore(tmpDir);
-    await store.recordUse({ title: 'A task', text: 'task for A', projectId: 'project-a' });
-    await store.recordUse({ title: 'B task', text: 'task for B', projectId: 'project-b' });
-    await store.recordUse({ title: 'Global task', text: 'global task' });
+describe('suggestion defaults', () => {
+  it('falls back to the localized category structure when runtime data is missing', () => {
+    expect(parseSuggestionDefaults(undefined, 'zh').agent.map(category => category.id)).toEqual([
+      'life', 'work', 'dev', 'sys',
+    ]);
+    expect(parseSuggestionDefaults(undefined, 'en').agent.map(category => category.label)).toEqual([
+      'Daily life', 'Work & office', 'Dev helpers', 'System',
+    ]);
+  });
 
-    const projectA = await store.getMerged('en', 'project-a');
-    const projectB = await store.getMerged('en', 'project-b');
-    const global = await store.getMerged('en');
+  it('loads defaults without adding usage history', async () => {
+    await fs.writeFile(path.join(tmpDir, 'suggestions.json'), JSON.stringify({
+      defaults: { zh: { agent: [{ id: 'dev', label: '开发辅助', items: [
+        { title: '失败诊断', text: '运行测试并定位根因' },
+      ] }] } },
+    }));
 
-    expect(projectA.agent[0]?.id).toBe('recent');
-    expect(projectA.agent[0]?.items.map(item => item.text)).toEqual(['task for A']);
-    expect(projectB.agent[0]?.items.map(item => item.text)).toEqual(['task for B']);
-    expect(global.agent[0]?.items.map(item => item.text)).toEqual(['global task']);
+    await expect(createSuggestionStore(tmpDir).get('zh')).resolves.toEqual({
+      agent: [{ id: 'dev', label: '开发辅助', items: [
+        { title: '失败诊断', text: '运行测试并定位根因' },
+      ] }],
+    });
+  });
+
+  it('sanitizes runtime suggestion data', () => {
+    expect(parseSuggestionDefaults({
+      agent: [{ id: 'life', label: '生活查询', items: [
+        { title: ' 天气决策 ', text: ' 核对两个天气来源 ' },
+        { title: '', text: 'invalid' },
+      ] }],
+    }, 'zh')).toEqual({
+      agent: [{ id: 'life', label: '生活查询', items: [
+        { title: '天气决策', text: '核对两个天气来源' },
+      ] }],
+    });
   });
 });


### PR DESCRIPTION
## Summary

- reduce and dynamically select agent prompt guidance, with a prompt benchmark command and regression coverage
- move suggestion content to ignored runtime data and remove recent-usage tracking
- remove persistent conversation memory and retain only project knowledge and code graph
- add desktop sidebar edge reveal, auto-hide, and persistent pinning

## Validation

- npm test (310 tests)
- npm run typecheck
- npm run build:client
- git diff --check