### PR TITLE
feat(settings): polish dialog styling and trim section titles

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -5628,6 +5628,9 @@ textarea:disabled {
   width: min(820px, calc(100vw - 40px));
   height: min(76dvh, 620px);
 }
+/* 设置弹窗专属:主标题略放大 + 头部左右内边距与内容区对齐(不影响共用的模型选择器) */
+.settings-dialog .model-picker-title { font-size: var(--f-base); }
+.settings-dialog .model-picker-header { padding-left: var(--sp-5); padding-right: var(--sp-5); }
 
 /* 左导航 + 右内容两栏布局 */
 .settings-layout { display: flex; gap: 0; flex: 1; min-height: 0; }
@@ -5647,7 +5650,7 @@ textarea:disabled {
   align-items: center;
   gap: 8px;
   text-align: left;
-  min-height: 38px;
+  min-height: 40px;
   padding: 8px 10px;
   border: none;
   border-radius: var(--r-sm);
@@ -5663,7 +5666,7 @@ textarea:disabled {
 .settings-nav-btn.active { background: var(--c-primary-bg); color: var(--c-primary); font-weight: 600; }
 .settings-nav-btn.active .settings-nav-icon { opacity: 1; }
 .settings-content { flex: 1; min-width: 0; overflow-y: auto; }
-.settings-dialog-content { padding: 20px 22px; }
+.settings-dialog-content { padding: var(--sp-5); }
 .settings-content .settings-section:last-child { margin-bottom: 0; }
 
 .project-dialog .settings-close-btn {
@@ -5690,8 +5693,7 @@ textarea:disabled {
 
 .project-dialog .settings-close-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 .settings-dialog-footer {
-  min-height: 58px;
-  padding: 10px 12px;
+  padding: var(--sp-3) var(--sp-5);
   border-top: 1px solid var(--c-border);
   display: flex;
   align-items: center;
@@ -5729,9 +5731,9 @@ textarea:disabled {
   width: 100%;
   height: 36px;
   padding: 0 12px;
-  border: 1px solid var(--c-border);
+  border: 1px solid var(--c-border-input);
   border-radius: var(--r-sm);
-  background: var(--c-settings-glass-inner);
+  background: var(--c-surface-inline);
   color: var(--c-text);
   font-size: var(--f-sm);
   box-sizing: border-box;
@@ -5758,37 +5760,33 @@ textarea:disabled {
 .settings-section > .dialog-desc { margin-bottom: 16px; }
 
 .settings-appearance-stack {
-  margin-top: 14px;
+  margin-top: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.settings-appearance-stack .settings-field-switch {
-  min-height: 48px;
-}
-
 .settings-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .settings-field { display: flex; flex-direction: column; gap: 6px; font-size: var(--f-sm); color: var(--c-text-secondary); }
 .settings-field-label { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.settings-field-label small { color: var(--c-text-muted); font-size: var(--f-xs); font-weight: 400; }
-.settings-field-switch { min-height: 42px; padding: 0 12px; border: 1px solid var(--c-border); border-radius: var(--r-sm); background: var(--c-surface-inline); flex-direction: row; align-items: center; justify-content: space-between; grid-column: 1 / -1; }
+.settings-field-label small { color: var(--c-text-muted); font-size: var(--f-micro); font-weight: 500; text-transform: uppercase; letter-spacing: 0.04em; }
+.settings-field-switch { min-height: 40px; padding: 0 var(--sp-3); border: 1px solid var(--c-border); border-radius: var(--r-sm); background: var(--c-surface-inline); flex-direction: row; align-items: center; justify-content: space-between; grid-column: 1 / -1; }
 .settings-field-switch input { width: 18px; height: 18px; }
 .settings-stepper {
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) 34px;
-  height: 34px;
+  grid-template-columns: 32px minmax(0, 1fr) 32px;
+  height: 32px;
   overflow: hidden;
-  border: 1px solid var(--c-border);
+  border: 1px solid var(--c-border-input);
   border-radius: var(--r-sm);
-  background: var(--c-settings-glass-inner);
+  background: var(--c-surface-inline);
 }
 .settings-stepper-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border: none;
-  background: var(--c-settings-glass-inner);
+  background: transparent;
   color: var(--c-text-secondary);
   cursor: pointer;
   transition: all 0.15s;
@@ -5825,6 +5823,8 @@ textarea:disabled {
 .settings-key-status.off { color: var(--c-text-muted); }
 
 .settings-profile-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 0 0 16px; color: var(--c-text-secondary); font-size: var(--f-sm); }
+/* Agent 页预设分段直接坐在内容面上,给灰底与白面拉开对比 */
+.settings-profile-row .settings-segment { background: var(--c-surface-inline); }
 .settings-advanced-toggle { display: inline-flex; align-items: center; gap: 5px; margin-top: 14px; padding: 5px 0; border: 0; background: transparent; color: var(--c-text-secondary); cursor: pointer; font-size: var(--f-sm); }
 .settings-advanced-toggle:hover { color: var(--c-text); }
 .settings-advanced-grid { margin-top: 10px; }
@@ -5834,7 +5834,7 @@ textarea:disabled {
 .settings-mcp-enabled { display: inline-flex; align-items: center; gap: 7px; color: var(--c-text-secondary); font-size: var(--f-sm); }
 .settings-mcp-enabled input { width: 18px; height: 18px; }
 .settings-mcp-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-.settings-mcp-grid input, .settings-mcp-grid select { min-width: 0; height: 34px; padding: 0 9px; border: 1px solid var(--c-border); border-radius: var(--r-sm); background: var(--c-settings-glass-inner); color: var(--c-text); }
+.settings-mcp-grid input, .settings-mcp-grid select { min-width: 0; height: 32px; padding: 0 9px; border: 1px solid var(--c-border-input); border-radius: var(--r-sm); background: var(--c-surface); color: var(--c-text); }
 .settings-mcp-wide { grid-column: 1 / -1; }
 .settings-mcp-actions { display: flex; align-items: center; gap: 8px; margin-top: 12px; }
 .settings-mcp-actions .settings-ok, .settings-mcp-actions .settings-error { margin: 0 0 0 4px; }
@@ -5845,15 +5845,15 @@ textarea:disabled {
 /* 设置里的分段切换控件（主题 / 语言） */
 .settings-segment {
   display: inline-flex;
-  border: 1px solid var(--c-border);
+  border: 1px solid var(--c-border-input);
   border-radius: var(--r-sm);
   overflow: hidden;
   flex-shrink: 0;
-  background: var(--c-settings-glass-inner);
+  background: var(--c-surface);
 }
 .settings-segment-btn {
-  height: 30px;
-  padding: 0 12px;
+  height: 32px;
+  padding: 0 var(--sp-3);
   font-size: var(--f-sm);
   border: none;
   background: transparent;
@@ -5884,10 +5884,11 @@ textarea:disabled {
   }
   .settings-nav-btn {
     flex: 0 0 auto;
-    min-height: 36px;
+    min-height: 40px;
     padding: 8px 10px;
   }
-  .settings-dialog-content { padding: 16px 14px; }
+  .settings-dialog-content { padding: var(--sp-4); }
+  .settings-dialog .model-picker-header { padding-left: var(--sp-4); padding-right: var(--sp-4); }
   .settings-grid { grid-template-columns: 1fr; }
   .settings-profile-row { align-items: flex-start; flex-direction: column; }
   .settings-mcp-grid { grid-template-columns: 1fr; }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -183,7 +183,7 @@ export default function App() {
   useEffect(() => {
     const revealFromLeftEdge = event => {
       if (window.innerWidth < DOCKED_LAYOUT_BREAKPOINT || sidebarPinned) return;
-      if (event.clientX <= window.innerWidth * 0.1) setShowSessions(true);
+      if (event.clientX <= window.innerWidth * 0.01) setShowSessions(true);
     };
     window.addEventListener('mousemove', revealFromLeftEdge);
     return () => window.removeEventListener('mousemove', revealFromLeftEdge);

--- a/client/src/components/dialogs/SettingsDialog.jsx
+++ b/client/src/components/dialogs/SettingsDialog.jsx
@@ -419,7 +419,6 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
     if (activeGroup === 'appearance') {
       return (
         <div className="settings-section">
-          <p className="settings-section-title">{t('appearance.title')}</p>
           <div className="settings-appearance-stack">
             <div className="settings-field settings-field-switch">
               <span>{t('appearance.theme')}</span>
@@ -470,7 +469,6 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
     if (activeGroup === 'agent') {
       return (
         <div className="settings-section">
-          <p className="settings-section-title">{t('settings.agentParams')}</p>
           <p className="dialog-desc">{t('settings.agentParamsDesc')}</p>
           {renderBackendGuard() || (
             <>
@@ -525,7 +523,6 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
     if (activeGroup === 'memory') {
       return (
         <div className="settings-section">
-          <p className="settings-section-title">{t('settings.group.memory')}</p>
           <p className="dialog-desc">{t('settings.memoryDesc')}</p>
           <div className="settings-grid">
             <label className="settings-field settings-field-switch">
@@ -544,7 +541,6 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
     if (activeGroup === 'mcp') {
       return (
         <div className="settings-section">
-          <p className="settings-section-title">{t('settings.group.mcp')}</p>
           <p className="dialog-desc">{t('settings.mcpDesc')}</p>
           {renderBackendGuard() || (
             <div className="settings-mcp-list">
@@ -575,7 +571,6 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory }) {
     // apiKeys
     return (
       <div className="settings-section">
-        <p className="settings-section-title">{t('settings.apiKeys')}</p>
         <p className="dialog-desc">{t('settings.apiKeysDesc')}</p>
         {renderBackendGuard() || (
           <div className="settings-keys">

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -15,7 +15,6 @@ export const en = {
   'common.submitting': 'Submitting…',
 
   // Appearance / language
-  'appearance.title': 'Appearance',
   'appearance.theme': 'Theme',
   'appearance.theme.light': 'Light',
   'appearance.theme.dark': 'Dark',
@@ -87,7 +86,6 @@ export const en = {
   'settings.group.memory': 'Memory',
   'settings.group.mcp': 'MCP Connections',
   'settings.group.apiKeys': 'API Keys',
-  'settings.agentParams': 'Agent behavior',
   'settings.agentParamsDesc': 'Takes effect on the next task after saving; no backend restart needed.',
   'settings.maxSteps': 'Max steps per task',
   'settings.modelTimeoutSec': 'Per-model timeout (s)',
@@ -122,7 +120,6 @@ export const en = {
   'settings.mcpAdd': 'Add server',
   'settings.mcpDelete': 'Delete server',
   'settings.mcpNamePlaceholder': 'MCP server name',
-  'settings.apiKeys': 'API Keys (read-only)',
   'settings.apiKeysDesc': 'Keys are set in .env; restart the backend after changes.',
   'settings.keyNotConfigured': 'Not configured',
 

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -16,7 +16,6 @@ export const zh = {
   'common.submitting': '提交中…',
 
   // 外观 / 语言
-  'appearance.title': '外观',
   'appearance.theme': '主题',
   'appearance.theme.light': '浅色',
   'appearance.theme.dark': '深色',
@@ -88,7 +87,6 @@ export const zh = {
   'settings.group.memory': '记忆',
   'settings.group.mcp': 'MCP 连接',
   'settings.group.apiKeys': 'API Key',
-  'settings.agentParams': 'Agent 行为参数',
   'settings.agentParamsDesc': '保存后下次任务即生效，无需重启后端。',
   'settings.maxSteps': '单次任务最大步数',
   'settings.modelTimeoutSec': '单模型超时（秒）',
@@ -123,7 +121,6 @@ export const zh = {
   'settings.mcpAdd': '新增服务',
   'settings.mcpDelete': '删除服务',
   'settings.mcpNamePlaceholder': 'MCP server 名称',
-  'settings.apiKeys': 'API Key（只读）',
   'settings.apiKeysDesc': 'Key 在 .env 配置，修改后需重启后端。',
   'settings.keyNotConfigured': '未配置',
 


### PR DESCRIPTION
## 概述
优化设置弹窗的视觉细节，并微调侧边栏边缘触发区域。

## 改动
- **设置弹窗样式**：内边距、边框、背景统一改用设计 token（`--sp-*`、`--c-border-input`、`--c-surface-inline` 等），头部左右内边距与内容区对齐
- **移除冗余标题**：外观 / Agent / 记忆 / MCP / API Key 各分区不再重复展示区块标题，改由左侧导航标签承担；同步清理 i18n 中对应的 `appearance.title`、`settings.agentParams`、`settings.apiKeys` 文案
- **分段控件与步进器**：统一高度（32px）、边框与背景，字段标签小字改为大写微字风格
- **侧边栏**：左边缘唤起区域从视口 10% 收窄至 1%，减少误触

## 验证
- `npm run build` 通过