### PR TITLE
Make the built-in browser read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ sagent stores project experience under the configured data directory. Memory inc
 
 ### Browser And MCP Integrations
 
-Chrome DevTools MCP adds browser inspection and control through `chrome_list_tools` and `chrome_call_tool`. Generic MCP servers (including `codex mcp-server`) are exposed through `mcp_list_servers`, `mcp_list_tools`, and `mcp_call_tool`. All integrations are optional and documented in [CONFIGURATION.md](CONFIGURATION.md).
+The built-in Browser is read-only and is limited to navigation and content extraction. All interactive web operations—including clicking, typing, login, form submission, upload, and download—are delegated to Chrome DevTools MCP through `chrome_list_tools` and `chrome_call_tool`. Generic MCP servers (including `codex mcp-server`) are exposed through `mcp_list_servers`, `mcp_list_tools`, and `mcp_call_tool`. All integrations are optional and documented in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Common Commands
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -110,7 +110,7 @@ sagent 会在配置的数据目录下保存项目经验，包括近期任务摘�
 
 ### 浏览器与 MCP 集成
 
-Chrome DevTools MCP 会增加 `chrome_list_tools` 和 `chrome_call_tool`。包括 `codex mcp-server` 在内的通用 MCP server 会通过 `mcp_list_servers`、`mcp_list_tools` 和 `mcp_call_tool` 接入。所有集成都是可选能力，配置方式见 [CONFIGURATION.md](CONFIGURATION.md)。
+内置 Browser 仅用于只读信息浏览和正文提取；点击、输入、登录、提交、上传、下载等网页交互统一由 Chrome DevTools MCP 负责。Chrome MCP 会增加 `chrome_list_tools` 和 `chrome_call_tool`。包括 `codex mcp-server` 在内的通用 MCP server 会通过 `mcp_list_servers`、`mcp_list_tools` 和 `mcp_call_tool` 接入。所有集成都是可选能力，配置方式见 [CONFIGURATION.md](CONFIGURATION.md)。
 
 ## 常用命令
 

--- a/agent/core/prompts.ts
+++ b/agent/core/prompts.ts
@@ -14,6 +14,8 @@ type PromptCapabilityContext = {
 };
 
 const CHROME_TASK_RE = /\bchrome\b|devtools|开发者工具|真实浏览器|网络面板|performance|lighthouse|控制台|console/i;
+// 内置 browser 只读；命中这些意图时需要加载 Chrome MCP，而不是重新开放 browser.click/type。
+const INTERACTIVE_BROWSER_TASK_RE = /\b(?:click|type|fill|input|submit|login|sign[ -]?in|upload|download|checkout|purchase)\b|点击|输入|填写|提交|登录|登入|注册|上传|下载|下单|购买|支付|勾选|选择下拉|拖拽|验证码/i;
 const GENERIC_MCP_TASK_RE = /\bmcp\b|codex|编码专家|coding expert|外部工具|工具服务器/i;
 const BROWSER_BLOCK_RE = /captcha|cloudflare|403|forbidden|人机验证|反爬|访问受限|被拦截|blocked/i;
 const WEB_TASK_RE = /https?:\/\/|\bwww\.|\bweb\b|browser|website|search|news|weather|price|flight|hotel|online|网页|浏览器|网站|上网|搜索|查询|新闻|天气|实时|价格|机票|航班|酒店|电商|官网/i;
@@ -25,7 +27,7 @@ const FOLLOWUP_TASK_RE = /^\s*(?:(?:继续|接着|重试|再试|这个|那个|�
 // web_search 作为轻量信息查询兜底常驻，避免产品目录、模型上下线、版本变化等
 // 时效性问题未命中关键词分类后只剩 finish，导致模型把问题原样返回。
 const CORE_TOOL_NAMES = ['web_search', 'ask_user', 'notify_user', 'finish'];
-const WEB_TOOL_NAMES = ['navigate', 'click', 'type', 'wait', 'scroll', 'get_page_content', 'http_fetch', 'web_search'];
+const WEB_TOOL_NAMES = ['navigate', 'wait', 'scroll', 'get_page_content', 'http_fetch', 'web_search'];
 const FILE_TOOL_NAMES = ['list_dir', 'read_file', 'get_file_info', 'write_file', 'search_files', 'codegraph_query'];
 const TERMINAL_TOOL_NAMES = ['run_safe', 'run_confirmed', 'run_review'];
 const VISION_TOOL_NAMES = ['image_analyze'];
@@ -33,7 +35,6 @@ const CHROME_TOOL_NAMES = ['chrome_list_tools', 'chrome_call_tool'];
 const MCP_TOOL_NAMES = ['mcp_list_servers', 'mcp_list_tools', 'mcp_call_tool'];
 const COMPACT_TOOL_NAMES = new Set([
   'navigate',
-  'click',
   'get_page_content',
   'http_fetch',
   'list_dir',
@@ -44,6 +45,8 @@ const COMPACT_TOOL_NAMES = new Set([
   'image_analyze',
   'ask_user',
   'notify_user',
+  'chrome_list_tools',
+  'chrome_call_tool',
   'finish',
 ]);
 
@@ -213,7 +216,8 @@ export function selectGeminiToolNames(context: PromptCapabilityContext = {}) {
   if (needsFiles) addToolGroup(selected, FILE_TOOL_NAMES);
   if (needsTerminal) addToolGroup(selected, TERMINAL_TOOL_NAMES);
   if (needsVision) addToolGroup(selected, VISION_TOOL_NAMES);
-  if (needsChrome) addToolGroup(selected, CHROME_TOOL_NAMES);
+  // 任务“需要 Chrome”不代表运行时“能够调用 Chrome”；不可用时不要把幽灵工具名传给提示词。
+  if (needsChrome && isChromeMcpAvailable()) addToolGroup(selected, CHROME_TOOL_NAMES);
   if (needsMcp) addToolGroup(selected, MCP_TOOL_NAMES);
   return selected;
 }
@@ -228,6 +232,7 @@ function historyShowsBrowserBlock(history: any[] | undefined) {
 
 export function shouldIncludeChromePromptDetails({ task = '', history = [], observation }: PromptCapabilityContext = {}) {
   return CHROME_TASK_RE.test(task)
+    || INTERACTIVE_BROWSER_TASK_RE.test(task)
     || historyUsesTool(history, 'chrome')
     || historyShowsBrowserBlock(history)
     || BROWSER_BLOCK_RE.test(String(observation?.browser?.text || ''));
@@ -252,7 +257,7 @@ function chromePromptLines(context: PromptCapabilityContext) {
   if (shouldIncludeChromePromptDetails(context)) return buildChromePromptLines();
   if (context.includeInactiveCapabilityHints === false) return [];
   return [
-    'Chrome MCP 已启用但默认不展开。仅当任务明确要求 Chrome/DevTools，或内置浏览器遭遇 CAPTCHA、403、Cloudflare 等拦截时，调用 {"tool":"chrome","type":"chrome_list_tools"} 按需获取工具。',
+    'Chrome MCP 已启用但默认不展开。网页点击、输入、登录、提交、上传和下载必须使用 Chrome MCP；内置浏览器只读。需要交互或遇到 CAPTCHA、403、Cloudflare 时，调用 {"tool":"chrome","type":"chrome_list_tools"} 按需获取工具。',
   ];
 }
 
@@ -402,13 +407,14 @@ function buildSharedAgentRuleLines(
     '- 不要重复已成功或无新目的的动作。同一目标连续约 5 步仍无实质进展时停止尝试，finish 汇总已知信息并说明限制。',
     '- 不得编造工具结果。',
     ...(approvalToolsEnabled ? ['- 文件写入和终端确认命令可能需要审批；cd/pushd/popd 使用 run_review。被拒绝后改用安全替代方案。'] : []),
-    ...(browserEnabled ? ['- browser.click/type 只能使用 observation.browser.elements 中存在的 elementId；不要 navigate 到搜索引擎结果页。scroll 返回内容未变化后，不得继续滚动，改用 get_page_content、http_fetch 或 finish。'] : []),
+    ...(browserEnabled ? ['- 内置 browser 是只读信息浏览器，只能 navigate、wait、scroll、get_page_content、http_fetch；禁止点击、输入、登录、提交、上传或下载。如果当前提供 chrome_call_tool，网页交互必须使用它；否则明确说明无法执行。不要 navigate 到搜索引擎结果页；scroll 返回内容未变化后改用 get_page_content、http_fetch 或 finish。'] : []),
     ...(webDetails ? ['- 网络任务中，web_search 只用于发现来源；拿到候选 URL 后优先用 http_fetch 提取正文，不要先 navigate。不得仅凭标题或摘要回答需核验的问题。选择最相关的 1～3 个官方、原始或权威 URL，逐个核验正文，只提取与问题直接相关的事实、数字、时间和条件，并保留来源对应关系。正文无明确答案时说明未找到，不得用常识补全；来源冲突时分别列出。'] : []),
     ...(visionEnabled ? ['- 图片任务必须使用 image_analyze，不得凭文件名猜测。附件图片使用 @attachment/N（按出现顺序从 1 开始），不得复制或改写 @uploads 路径。简单识图得到结果后立即 finish；同一图片最多连续分析 2 次，证据不足时区分可见事实与低置信猜测。'] : []),
     ...(webDetails ? ['- 酒店、机票、电商等实时价格优先用 web_search 获取区间；拿不到精确数字时给出查询入口并说明未取得实时精确价。'] : []),
     '- 重要发现可用 notify_user。finish 的 answer 使用简体中文，简洁直接。',
     '- currentDateTime 是当前日期时间；涉及“今天”“最新”“近期”等相对时间时必须以它为准，不得猜测年份。',
-    ...(chromeEnabled && chromeDetails ? ['- 内置浏览器被 CAPTCHA、403 或 Cloudflare 拦截时，改用 Chrome MCP 访问同一目标。'] : []),
+    ...(chromeEnabled && chromeDetails ? ['- 网页交互以及 CAPTCHA、403、Cloudflare 等真实浏览器场景必须使用 Chrome MCP。'] : []),
+    ...(!chromeEnabled && INTERACTIVE_BROWSER_TASK_RE.test(capabilityText(capabilityContext)) ? ['- 当前未启用 Chrome MCP，无法执行网页点击、输入、登录、提交、上传或下载；不得回退到内置 browser 模拟交互，应明确说明需要启用 Chrome MCP。'] : []),
     ...chromeLines,
     ...mcpLines,
   ];
@@ -419,6 +425,9 @@ function buildCompactAgentRuleLines(
   definitions: ModelToolDefinition[],
 ) {
   const toolNames = new Set(definitions.map(definition => definition.name));
+  const interactiveBrowserTask = INTERACTIVE_BROWSER_TASK_RE.test(capabilityText(capabilityContext));
+  // compact 提示不读取全量 Chrome 说明，以实际保留下来的调用工具判断能力是否可用。
+  const chromeEnabled = toolNames.has('chrome_call_tool');
   const webDetails = WEB_TASK_RE.test(capabilityText(capabilityContext))
     || historyUsesTool(capabilityContext.history, 'search')
     || historyUsesTool(capabilityContext.history, 'browser');
@@ -426,7 +435,9 @@ function buildCompactAgentRuleLines(
     '规则：',
     '- task 是本轮唯一目标；已有信息足够则立即 finish，缺少关键选择时才 ask_user。',
     '- 只选择完成目标所需的最少动作，不得编造工具结果或重复无进展的动作。',
-    ...(hasAnyTool(toolNames, ['click']) ? ['- click 只能使用 observation.browser.elements 中存在的 elementId；scroll 返回内容未变化后改用 get_page_content、http_fetch 或 finish。'] : []),
+    ...(hasAnyTool(toolNames, ['navigate', 'scroll', 'get_page_content', 'http_fetch']) ? ['- 内置 browser 只读；网页点击、输入、登录和提交不能使用内置 browser。scroll 无变化后改用 get_page_content、http_fetch 或 finish。'] : []),
+    ...(chromeEnabled && interactiveBrowserTask ? ['- 当前提供 chrome_call_tool，网页点击、输入、登录和提交必须使用 Chrome MCP。'] : []),
+    ...(!chromeEnabled && interactiveBrowserTask ? ['- 当前未启用 Chrome MCP，无法执行网页点击、输入、登录、提交、上传或下载；不得回退到内置 browser 模拟交互，应明确说明需要启用 Chrome MCP。'] : []),
     ...(webDetails && toolNames.has('web_search') && toolNames.has('http_fetch') ? ['- web_search 只用于发现来源；需要事实核验时必须 http_fetch 权威正文，不得仅凭摘要回答。'] : []),
     ...(toolNames.has('image_analyze') ? ['- 附件图片使用 @attachment/N，不得复制或改写 @uploads 路径。'] : []),
     '- currentDateTime 是当前日期时间；涉及相对时间时以它为准，不得猜测年份。finish.answer 使用简体中文，简洁直接。',
@@ -573,8 +584,12 @@ export function buildNvidiaTaskMessages({
   }
 
   if (compact) {
+    // compact 仍须保留 Chrome 交互入口，否则移除 browser.click/type 后小上下文重试将无法完成交互任务。
     const compactToolNames = [...selectedToolNames].filter(name => COMPACT_TOOL_NAMES.has(name));
-    const compactToolDefinitions = selectPromptToolDefinitions({ includeToolNames: compactToolNames });
+    const compactToolDefinitions = selectPromptToolDefinitions({
+      chromeEnabled: chromeEnabled && chromeDetails,
+      includeToolNames: compactToolNames,
+    });
     return [
       {
         role: 'system',

--- a/agent/core/tool-definitions.ts
+++ b/agent/core/tool-definitions.ts
@@ -1,7 +1,7 @@
 /**
  * Tool Definitions — Agent 可用的所有工具 schema 定义
  *
- * 定义了 DesktopAgent 能调用的全部工具（浏览器、文件系统、终端、HTTP 抓取、核心动作）。
+ * 定义了 DesktopAgent 能调用的全部工具（只读浏览器、文件系统、终端、HTTP 抓取、核心动作）。
  *
  * 调用场景：
  *   - 各 provider 的 agentPlan() 将工具列表传给对应模型 API
@@ -33,10 +33,11 @@ export function createModelTools({
   includeGenericMcp?: boolean;
   includeToolNames?: Iterable<string>;
 } = {}) {
+  // browser 工具集只负责读取页面；所有会改变网页状态的操作由可选 Chrome MCP 动态注入。
   const tools: ModelToolDefinition[] = [
     {
       name: 'navigate',
-      description: '在浏览器中打开指定 URL',
+      description: '在只读内置浏览器中打开指定 URL；不得用于点击、输入、登录或提交操作',
       example: { rationale: '打开网页', input: { url: 'https://example.com' } },
       input_schema: {
         type: 'object',
@@ -44,32 +45,6 @@ export function createModelTools({
           url: { type: 'string', description: '目标 URL' },
         },
         required: ['url'],
-      },
-    },
-    {
-      name: 'click',
-      description: '点击网页元素（通过 elementId）',
-      example: { rationale: '点击网页元素', input: { elementId: '3' } },
-      input_schema: {
-        type: 'object',
-        properties: {
-          elementId: { type: 'string', description: '元素的 data-agent-node-id' },
-        },
-        required: ['elementId'],
-      },
-    },
-    {
-      name: 'type',
-      description: '在输入框中输入文字',
-      example: { rationale: '在网页输入框输入文字', input: { elementId: '3', text: 'hello', submit: true } },
-      input_schema: {
-        type: 'object',
-        properties: {
-          elementId: { type: 'string', description: '输入框的 elementId' },
-          text: { type: 'string', description: '要输入的文字' },
-          submit: { type: 'boolean', description: '输入后按回车' },
-        },
-        required: ['elementId', 'text'],
       },
     },
     {
@@ -86,7 +61,7 @@ export function createModelTools({
     },
     {
       name: 'scroll',
-      description: '滚动网页（当页面内容超出视口时使用）',
+      description: '在只读内置浏览器中滚动网页（当页面内容超出视口时使用）',
       example: { rationale: '向下滚动页面', input: { direction: 'down', amount: 3 } },
       input_schema: {
         type: 'object',
@@ -99,7 +74,7 @@ export function createModelTools({
     },
     {
       name: 'get_page_content',
-      description: '提取当前浏览器页面的正文文本和基础页面信息。',
+      description: '从只读内置浏览器提取当前页面的正文文本和基础页面信息。',
       example: { rationale: '获取浏览器当前页面文本内容', input: {} },
       input_schema: { type: 'object', properties: {} },
     },
@@ -155,7 +130,7 @@ export function createModelTools({
     },
     {
       name: 'http_fetch',
-      description: '用浏览器打开 URL 并提取页面文本内容。extractLinks=true 时提取页面中的链接列表（用于搜索结果页）。',
+      description: '用只读内置浏览器打开 URL 并提取页面文本内容。extractLinks=true 时提取页面中的链接列表。不得用于点击、输入、登录或提交操作。',
       example: { rationale: '抓取网页内容', input: { url: 'https://example.com', extractLinks: false } },
       input_schema: {
         type: 'object',

--- a/agent/tools/browser/edge-cdp-webview.ts
+++ b/agent/tools/browser/edge-cdp-webview.ts
@@ -10,6 +10,7 @@ type PendingCommand = {
 };
 
 export class EdgeCdpWebView {
+  // 该适配器刻意保持只读：只实现导航、页面求值和截图，不提供 CDP 输入事件。
   url = 'about:blank';
   title = '';
   private child: ChildProcess | null = null;
@@ -161,45 +162,6 @@ export class EdgeCdpWebView {
       throw new Error(detail);
     }
     return response.result?.value;
-  }
-
-  async click(selector: string) {
-    await this.evaluate(`(() => {
-      const element = document.querySelector(${JSON.stringify(selector)});
-      if (!element) throw new Error(${JSON.stringify(`元素不存在: ${selector}`)});
-      element.scrollIntoView({ block: 'center', inline: 'center' });
-      element.click();
-      return true;
-    })()`);
-  }
-
-  async type(selector: string, text: string) {
-    await this.evaluate(`(() => {
-      const element = document.querySelector(${JSON.stringify(selector)});
-      if (!element) throw new Error(${JSON.stringify(`元素不存在: ${selector}`)});
-      element.focus();
-      return true;
-    })()`);
-    await this.command('Input.insertText', { text });
-  }
-
-  async press(key: string) {
-    if (key !== 'Enter') throw new Error(`暂不支持按键: ${key}`);
-    await this.command('Input.dispatchKeyEvent', {
-      type: 'keyDown',
-      key: 'Enter',
-      code: 'Enter',
-      text: '\r',
-      windowsVirtualKeyCode: 13,
-      nativeVirtualKeyCode: 13,
-    });
-    await this.command('Input.dispatchKeyEvent', {
-      type: 'keyUp',
-      key: 'Enter',
-      code: 'Enter',
-      windowsVirtualKeyCode: 13,
-      nativeVirtualKeyCode: 13,
-    });
   }
 
   async screenshot(options: { format?: 'png' | 'jpeg'; quality?: number; encoding?: string } = {}) {

--- a/agent/tools/browser/execute.ts
+++ b/agent/tools/browser/execute.ts
@@ -217,19 +217,6 @@ async function extractPageTextOrLinks(view, url, extractLinks) {
     : cleaned;
 }
 
-function elementSelector(elementId) {
-  const id = String(elementId).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  return `[data-agent-node-id="${id}"]`;
-}
-
-function queryElementScript(selector, body) {
-  return `(() => {
-    const element = document.querySelector(${JSON.stringify(selector)});
-    if (!element) throw new Error('元素不存在: ${selector.replace(/'/g, "\\'")}');
-    ${body}
-  })()`;
-}
-
 export async function executeBrowserAction(view, action, opts: { signal?: AbortSignal; recoveryAttempt?: number } = {}) {
   const activeView = view || getWebView();
   const signal = opts.signal;
@@ -290,54 +277,19 @@ async function _executeBrowserAction(view, action, opts: { recoveryAttempt?: num
   }
 
   if (action.type === 'click') {
-    if (!action.elementId) {
-      throw new Error('click 缺少 elementId');
-    }
-
-    const selector = elementSelector(action.elementId);
-    await view.click(selector, { timeout: 10000 });
-    await delay(ACTION_SETTLE_MS);
-    return `已点击元素 ${action.elementId}`;
+    // 兼容旧 trace/checkpoint 或过期客户端：保留动作识别，但绝不在内置 WebView 中执行交互。
+    return failedResult(
+      '内置浏览器是只读信息浏览器，不支持点击操作。请启用并使用 Chrome MCP（chrome_call_tool）。',
+      '内置浏览器不支持交互操作',
+    );
   }
 
   if (action.type === 'type') {
-    if (!action.elementId) {
-      throw new Error('type 缺少 elementId');
-    }
-
-    const selector = elementSelector(action.elementId);
-    const elementInfo = await safeEvaluate(view, queryElementScript(selector, `
-      return {
-        tagName: element.tagName.toLowerCase(),
-        isEditable: Boolean(element.isContentEditable),
-      };
-    `));
-
-    await view.click(selector, { timeout: 10000 });
-
-    if (elementInfo.tagName === 'input' || elementInfo.tagName === 'textarea') {
-      await safeEvaluate(view, queryElementScript(selector, `
-        element.focus();
-        element.value = '';
-        element.dispatchEvent(new Event('input', { bubbles: true }));
-      `));
-      await view.type(selector, action.text || '');
-    } else if (elementInfo.isEditable) {
-      await safeEvaluate(view, queryElementScript(selector, `
-        element.focus();
-        element.textContent = '';
-      `));
-      await view.type(selector, action.text || '');
-    } else {
-      throw new Error(`元素 ${action.elementId} 不可输入`);
-    }
-
-    if (action.submit) {
-      await view.press('Enter');
-      await delay(ACTION_SETTLE_MS);
-    }
-
-    return `已在元素 ${action.elementId} 输入内容`;
+    // 与 click 一样只做明确拒绝；网页输入和提交统一交给 Chrome MCP。
+    return failedResult(
+      '内置浏览器是只读信息浏览器，不支持输入或提交操作。请启用并使用 Chrome MCP（chrome_call_tool）。',
+      '内置浏览器不支持交互操作',
+    );
   }
 
   if (action.type === 'wait') {

--- a/agent/tools/browser/observe.ts
+++ b/agent/tools/browser/observe.ts
@@ -2,63 +2,14 @@ import { cleanText } from '../../core/utils.ts';
 import { getWebView } from './webview-session.ts';
 
 const OBSERVATION_SCRIPT = String.raw`(() => {
-  const isVisible = element => {
-    const style = window.getComputedStyle(element);
-    const rect = element.getBoundingClientRect();
-    return (
-      style &&
-      style.visibility !== 'hidden' &&
-      style.display !== 'none' &&
-      rect.width > 0 &&
-      rect.height > 0
-    );
-  };
-
-  const getText = element => {
-    const directText = [
-      element.innerText,
-      element.getAttribute('aria-label'),
-      element.getAttribute('placeholder'),
-      element.getAttribute('title'),
-      element.getAttribute('alt'),
-      element.getAttribute('value'),
-      element.getAttribute('name'),
-    ]
-      .filter(Boolean)
-      .join(' ')
-      .replace(/\s+/g, ' ')
-      .trim();
-
-    return directText.slice(0, 160);
-  };
-
-  const elements = Array.from(
-    document.querySelectorAll(
-      'a, button, input, textarea, select, [role="button"], [contenteditable="true"]'
-    )
-  )
-    .filter(isVisible)
-    .slice(0, 30)
-    .map((element, index) => {
-      const elementId = String(index + 1);
-      element.setAttribute('data-agent-node-id', elementId);
-
-      return {
-        id: elementId,
-        tag: element.tagName.toLowerCase(),
-        text: getText(element),
-        type: element.getAttribute('type') || '',
-        href: element.getAttribute('href') || '',
-      };
-    });
-
   const bodyText = (document.body?.innerText || '').replace(/\s+/g, ' ').trim().slice(0, 5000);
 
   return {
     title: document.title,
     url: window.location.href,
     bodyText,
-    elements,
+    // 内置 browser 只提供页面信息，不再注入 elementId 或向模型暴露可交互元素。
+    elements: [],
   };
 })()`;
 
@@ -67,7 +18,7 @@ export function summarizeBrowserObservation(observation) {
     title: observation.title,
     url: observation.url,
     text: cleanText(observation.bodyText, 320),
-    elements: Array.isArray(observation.elements) ? observation.elements.slice(0, 8) : [],
+    elements: [],
   };
 }
 

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -221,7 +221,7 @@ export function buildChromePromptLines(env = process.env) {
   }
   const lines = [
     '当 Chrome DevTools MCP 已启用时，使用 chrome_call_tool 调用具体工具；toolName 取自下方工具列表，arguments 传对应参数对象。',
-    'Chrome DevTools 工具可用于浏览器页面操作、截图、网络请求检查、性能分析等。',
+    'Chrome DevTools 工具可用于并负责所有网页交互，包括点击、输入、登录、提交、上传、下载，以及截图、网络请求检查和性能分析；内置 browser 只用于只读信息浏览。',
     '只有当怀疑工具列表已变更（例如调用报"未找到 Chrome 工具"）时，才需要 chrome_list_tools 主动刷新；正常情况下直接使用 chrome_call_tool。',
     'uid 形如 "3_12"，下划线前的数字是 snapshotId。每次 take_snapshot（或带 includeSnapshot 的操作）后 snapshotId 都会变，旧 uid 立即失效——禁止跨 snapshot 复用 uid，使用前请取最新 snapshot。',
     'take_snapshot / take_screenshot 只对"当前已选中的页面"生效，需先用 navigate_page(url=...) 打开目标页面；navigate_page 成功后已自动附带页面快照，无需再单独 take_snapshot。',

--- a/test/browser-webview.test.ts
+++ b/test/browser-webview.test.ts
@@ -37,12 +37,12 @@ class FakeWebView {
 
   async evaluate(script): Promise<any> {
     this.calls.push(['evaluate', script]);
-    if (script.includes('querySelectorAll')) {
+    if (script.includes('elements: []')) {
       return {
         title: 'Example',
         url: 'https://example.com',
         bodyText: 'hello '.repeat(100),
-        elements: Array.from({ length: 10 }, (_, index) => ({ id: String(index + 1), text: `Element ${index + 1}` })),
+        elements: [],
       };
     }
     if (script.includes('document.title')) {
@@ -161,14 +161,14 @@ describe('Bun.WebView browser session adapter', () => {
 });
 
 describe('Bun.WebView browser observation', () => {
-  it('captures page metadata and summarizes visible elements', async () => {
+  it('captures read-only page metadata without exposing interactive elements', async () => {
     const view = new FakeWebView();
     const observation = await captureBrowserObservation(view);
     const summary = summarizeBrowserObservation(observation);
 
     expect(observation.title).toBe('Example');
-    expect(observation.elements).toHaveLength(10);
-    expect(summary.elements).toHaveLength(8);
+    expect(observation.elements).toEqual([]);
+    expect(summary.elements).toEqual([]);
     expect(summary.text.length).toBeLessThanOrEqual(323);
   });
 });
@@ -204,24 +204,24 @@ describe('Bun.WebView browser actions', () => {
     ]));
   });
 
-  it('executes navigation, click, typing, scroll, content, and search actions through WebView', async () => {
+  it('executes read-only actions and rejects legacy interaction actions', async () => {
     const view = new FakeWebView();
 
     await expect(executeBrowserAction(view, { type: 'navigate', url: 'https://example.com' }))
       .resolves.toContain('已打开 https://example.com');
     await expect(executeBrowserAction(view, { type: 'click', elementId: '2' }))
-      .resolves.toContain('已点击元素 2');
+      .resolves.toMatchObject({ resultStatus: 'failed', resultError: '内置浏览器不支持交互操作' });
     await expect(executeBrowserAction(view, { type: 'type', elementId: '3', text: 'hello', submit: true }))
-      .resolves.toContain('已在元素 3 输入内容');
+      .resolves.toMatchObject({ resultStatus: 'failed', resultError: '内置浏览器不支持交互操作' });
     await expect(executeBrowserAction(view, { type: 'scroll', direction: 'down', amount: 2 }))
       .resolves.toContain('已向下滚动 2 步');
     await expect(executeBrowserAction(view, { type: 'get_page_content' }))
       .resolves.toBe('页面正文');
 
     expect(view.calls).toContainEqual(['navigate', 'https://example.com']);
-    expect(view.calls).toContainEqual(['click', '[data-agent-node-id="2"]', { timeout: 10000 }]);
-    expect(view.calls).toContainEqual(['type', '[data-agent-node-id="3"]', 'hello']);
-    expect(view.calls).toContainEqual(['press', 'Enter']);
+    expect(view.calls.some(call => call[0] === 'click')).toBe(false);
+    expect(view.calls.some(call => call[0] === 'type')).toBe(false);
+    expect(view.calls.some(call => call[0] === 'press')).toBe(false);
   });
 
   it('marks unavailable http_fetch pages as structured failures', async () => {

--- a/test/prompts.test.ts
+++ b/test/prompts.test.ts
@@ -99,6 +99,20 @@ describe('agent prompts', () => {
     expect(conditional.some(line => line.includes('chrome_call_tool'))).toBe(true);
   });
 
+  it('keeps built-in browser tools read-only', () => {
+    const names = createModelTools({ includeChromeMcp: false }).map(tool => tool.name);
+
+    expect(names).toEqual(expect.arrayContaining([
+      'navigate',
+      'wait',
+      'scroll',
+      'get_page_content',
+      'http_fetch',
+    ]));
+    expect(names).not.toContain('click');
+    expect(names).not.toContain('type');
+  });
+
   it('gives NVIDIA models an explicit single-action JSON output contract', () => {
     const messages = buildNvidiaTaskMessages({
       task: '打开示例网页',
@@ -114,7 +128,9 @@ describe('agent prompts', () => {
     expect(systemPrompt).toContain('rationale 只说明当前动作的直接目的');
     expect(systemPrompt).toContain('finish 固定使用 {"tool":"core","type":"finish","answer":"最终结果"}');
     expect(systemPrompt).toContain('每次只能选择一个已启用动作');
-    expect(systemPrompt).toContain('type(elementId,text,submit?)');
+    expect(systemPrompt).not.toContain('type(elementId,text,submit?)');
+    expect(systemPrompt).not.toContain('click(elementId)');
+    expect(systemPrompt).toContain('内置 browser 是只读信息浏览器');
     expect(systemPrompt).toContain('scroll(direction,amount?)');
   });
 
@@ -215,14 +231,14 @@ describe('agent prompts', () => {
     })[0].content;
 
     expect(casual).not.toContain('文件写入和终端确认命令');
-    expect(casual).not.toContain('browser.click/type');
+    expect(casual).not.toContain('内置 browser 是只读信息浏览器');
     expect(casual).not.toContain('图片任务必须使用 image_analyze');
     expect(casual).not.toContain('酒店、机票、电商');
-    expect(web).toContain('browser.click/type');
+    expect(web).toContain('内置 browser 是只读信息浏览器');
     expect(web).toContain('web_search 只用于发现来源');
     expect(web).not.toContain('图片任务必须使用 image_analyze');
     expect(image).toContain('图片任务必须使用 image_analyze');
-    expect(image).not.toContain('browser.click/type');
+    expect(image).not.toContain('内置 browser 是只读信息浏览器');
   });
 
   it('keeps NVIDIA action examples scoped to the current task', () => {
@@ -332,6 +348,69 @@ describe('agent prompts', () => {
     expect(payload.systemInstruction).toContain('Chrome DevTools 工具可用于');
     expect(toolNames).toContain('chrome_list_tools');
     expect(toolNames).toContain('chrome_call_tool');
+  });
+
+  it('routes ordinary web interaction tasks to Chrome MCP', () => {
+    vi.stubEnv('CHROME_MCP_ENABLED', 'true');
+    const payload = buildGeminiAgentPromptPayload({
+      task: '登录网站并填写表单后提交',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+    const toolNames = payload.tools[0].functionDeclarations.map(tool => tool.name);
+
+    expect(payload.systemInstruction).toContain('网页交互以及 CAPTCHA');
+    expect(toolNames).toContain('chrome_call_tool');
+    expect(toolNames).not.toContain('click');
+    expect(toolNames).not.toContain('type');
+  });
+
+  it('reports unavailable Chrome MCP instead of advertising missing interaction tools', () => {
+    vi.stubEnv('CHROME_MCP_ENABLED', 'false');
+    const payload = buildGeminiAgentPromptPayload({
+      task: '登录网站并提交表单',
+      step: 1,
+      history: [],
+      observation: {},
+    });
+    const toolNames = payload.tools[0].functionDeclarations.map(tool => tool.name);
+
+    expect(payload.systemInstruction).toContain('当前未启用 Chrome MCP');
+    expect(toolNames).not.toContain('chrome_list_tools');
+    expect(toolNames).not.toContain('chrome_call_tool');
+  });
+
+  it('keeps Chrome interaction tools in compact prompts when Chrome MCP is available', () => {
+    vi.stubEnv('CHROME_MCP_ENABLED', 'true');
+    const messages = buildNvidiaTaskMessages({
+      task: '登录网站并填写表单后提交',
+      step: 1,
+      history: [],
+      observation: {},
+      compact: true,
+    });
+
+    expect(messages[0].content).toContain('chrome_list_tools(refresh?)');
+    expect(messages[0].content).toContain('chrome_call_tool(toolName,arguments?,refreshTools?)');
+    expect(messages[0].content).not.toContain('browser: click');
+    expect(messages[0].content).not.toContain('browser: type');
+  });
+
+  it('reports unavailable Chrome MCP in compact interaction prompts', () => {
+    vi.stubEnv('CHROME_MCP_ENABLED', 'false');
+    const messages = buildNvidiaTaskMessages({
+      task: '登录网站并提交表单',
+      step: 1,
+      history: [],
+      observation: {},
+      compact: true,
+    });
+
+    expect(messages[0].content).toContain('当前未启用 Chrome MCP');
+    expect(messages[0].content).not.toContain('chrome_call_tool(');
+    expect(messages[0].content).not.toContain('browser: click');
+    expect(messages[0].content).not.toContain('browser: type');
   });
 
   it('keeps shared Gemini and NVIDIA agent rules semantically identical', () => {


### PR DESCRIPTION
## Summary
- remove built-in browser click and type tools
- route interactive web tasks to Chrome MCP, including compact prompts
- keep legacy browser interaction actions as explicit runtime failures
- stop exposing interactive elements from browser observations
- document the browser and Chrome MCP responsibility split

## Verification
- npm test -- --run (52 files, 335 tests passed)
- npm run typecheck
- git diff --check