### PR TITLE
fix(tools): 修复工具正确性审查发现的高/中/低问题

### DIFF
--- a/agent/tools/chrome/execute.ts
+++ b/agent/tools/chrome/execute.ts
@@ -360,7 +360,7 @@ export async function executeChromeAction(action, opts: { signal?: AbortSignal }
     const NAVIGATE_TOOLS = new Set(['navigate_page', 'new_page']);
     if (!result?.isError && NAVIGATE_TOOLS.has(toolName)) {
       try {
-        const snapshotResult = await client.callTool('take_snapshot', {});
+        const snapshotResult = await client.callTool('take_snapshot', {}, { signal });
         const snapshotContent = extractToolContent(snapshotResult);
         parts.push(`\n[页面快照]\n${snapshotContent}`);
         const sid = extractSnapshotIdFromText(snapshotContent);

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -468,6 +468,11 @@ class SseTransport {
       .finally(() => {
         log.info(`[Chrome MCP][sse] stream closed url=${this.streamUrl}`);
         this.streamPromise = null;
+        // 流一旦关闭（正常 done / 断线 / 中止），会话即失效：重置 initialized 使下次请求
+        // 重新握手（否则以 SSE 为会话边界的 server 会拒绝新会话上的请求）；
+        // 并 reject 仍在等待 SSE 响应的在途请求，避免它们各自空等到自身超时。
+        this.initialized = false;
+        this.rejectAllPending(new Error('Chrome MCP SSE 流已关闭，请重试'));
       });
 
     if (!this.endpointPromise) {

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -540,7 +540,13 @@ class SseTransport {
         clearTimeout(this.endpointFallbackTimer);
         this.endpointFallbackTimer = null;
       }
-      this.postUrl = new URL(data, this.streamUrl).toString();
+      try {
+        this.postUrl = new URL(data, this.streamUrl).toString();
+      } catch (err: any) {
+        // 畸形 endpoint 事件不应冒泡出 consumeStream 击垮整条流（进而误标不可达）。
+        log.warn(`[Chrome MCP][sse] 无法解析 endpoint 事件: ${truncateText(data, 240)} (${err?.message || err})`);
+        return;
+      }
       log.info(`[Chrome MCP][sse] endpoint event -> ${this.postUrl}`);
       this.endpointResolve?.(this.postUrl);
       return;

--- a/agent/tools/chrome/mcp-client.ts
+++ b/agent/tools/chrome/mcp-client.ts
@@ -451,6 +451,13 @@ class SseTransport {
         await this.consumeStream(response.body);
       })
       .catch(err => {
+        if (err?.name === 'AbortError') {
+          // 主动 close() 触发的中止不是真实断线，不能标记为不可达，
+          // 否则每次 run 结束调用 shutdownChromeMcp 都会把 Chrome MCP 冷却 5 分钟自锁。
+          log.info(`[Chrome MCP][sse] stream aborted url=${this.streamUrl}`);
+          this.endpointReject?.(new Error('Chrome MCP SSE 连接已关闭'));
+          return;
+        }
         const error = new Error(`Chrome MCP SSE 连接失败: ${err.message}`);
         markChromeMcpUnavailable();
         log.warn(`[Chrome MCP][sse] stream failed url=${this.streamUrl} reason=${error.message}`);

--- a/agent/tools/fs/execute.ts
+++ b/agent/tools/fs/execute.ts
@@ -45,12 +45,12 @@ function assertWithinSandbox(targetPath, sandboxPath, operation = '访问') {
 }
 
 const DANGEROUS_PATTERNS = [
-  /^\.env(\.\w+)?$/i,
-  /^\.ssh\//i,
-  /^\.git\//i,
-  / id_rsa/,
-  / id_dsa/,
-  / authorized_keys/,
+  /(^|\/)\.env(\.\w+)?$/i,
+  /(^|\/)\.ssh(\/|$)/i,
+  /(^|\/)\.git(\/|$)/i,
+  /(^|\/)id_rsa$/i,
+  /(^|\/)id_dsa$/i,
+  /(^|\/)authorized_keys$/i,
 ];
 
 function assertSafePath(targetPath, sandboxPath) {

--- a/agent/tools/fs/execute.ts
+++ b/agent/tools/fs/execute.ts
@@ -117,10 +117,13 @@ export async function executeFsAction(action, opts: { cwd?: string | null; dataD
     await fs.mkdir(path.dirname(lexicalPath), { recursive: true });
     const canonicalParent = await fs.realpath(path.dirname(lexicalPath));
     assertWithinSandbox(canonicalParent, baseCwd, '写入');
+    assertSafePath(canonicalParent, baseCwd);
     const canonicalPath = path.join(canonicalParent, path.basename(lexicalPath));
+    assertSafePath(canonicalPath, baseCwd);
     try {
       const existingTarget = await fs.realpath(lexicalPath);
       assertWithinSandbox(existingTarget, baseCwd, '写入');
+      assertSafePath(existingTarget, baseCwd);
       return existingTarget;
     } catch (err: any) {
       if (err?.code !== 'ENOENT') throw err;

--- a/agent/tools/fs/execute.ts
+++ b/agent/tools/fs/execute.ts
@@ -161,7 +161,10 @@ export async function executeFsAction(action, opts: { cwd?: string | null; dataD
   if (action.type === 'read_file') {
     const { canonicalPath: targetPath } = await resolveExisting(action.path, '读取');
     const buffer = await fs.readFile(targetPath, { signal: opts.signal });
-    const text = buffer.toString('utf8', 0, Math.min(buffer.length, action.maxBytes || 12000));
+    // 按字节截断可能切断多字节 UTF-8 字符产生乱码；TextDecoder 的 stream 模式
+    // 会丢弃末尾不完整的字节序列，避免边界处出现替换字符。
+    const end = Math.min(buffer.length, action.maxBytes || 12000);
+    const text = new TextDecoder('utf-8').decode(buffer.subarray(0, end), { stream: true });
     return `文件 ${targetPath} 内容预览:\n${text}`;
   }
 
@@ -194,13 +197,17 @@ export async function executeFsAction(action, opts: { cwd?: string | null; dataD
       '--exclude=id_dsa',
       '--exclude=authorized_keys',
     ];
-    const args = ['-rn', '--color=never', '-E', ...excludeArgs, query, '--include', include, targetPath];
+    // query 以 -- 与选项分隔，避免以 '-' 开头的 query 被 grep 当作选项解析。
+    const args = ['-rn', '--color=never', '-E', ...excludeArgs, '--include', include, '--', query, targetPath];
 
+    let timedOut = false;
     const lines = await new Promise<string[]>((resolve, reject) => {
       const proc = spawn('grep', args, { stdio: ['ignore', 'pipe', 'pipe'] });
       const collected: string[] = [];
       let buf = '';
       const timer = setTimeout(() => {
+        timedOut = true;
+        opts.signal?.removeEventListener('abort', onAbort);
         proc.kill();
         resolve(collected);
       }, 10000);
@@ -221,6 +228,7 @@ export async function executeFsAction(action, opts: { cwd?: string | null; dataD
             collected.push(line);
             if (collected.length >= maxResults + 100) {
               clearTimeout(timer);
+              opts.signal?.removeEventListener('abort', onAbort);
               proc.kill();
               resolve(collected);
             }
@@ -249,15 +257,18 @@ export async function executeFsAction(action, opts: { cwd?: string | null; dataD
     });
 
     if (lines.length === 0) {
-      return `搜索 "${query}" 在 ${targetPath} (${include}): 未找到匹配`;
+      return timedOut
+        ? `搜索 "${query}" 在 ${targetPath} (${include}): 10 秒内未完成，无匹配结果（可能不完整）`
+        : `搜索 "${query}" 在 ${targetPath} (${include}): 未找到匹配`;
     }
 
     const truncated = lines.slice(0, maxResults);
     const header = `搜索 "${query}" 在 ${targetPath} (${include})，找到 ${lines.length} 个结果:`;
+    const timeoutNote = timedOut ? '\n... (搜索超过 10 秒被中断，结果可能不完整)' : '';
     if (lines.length > maxResults) {
-      return `${header}\n${truncated.join('\n')}\n... (截断，共 ${lines.length} 个结果)`;
+      return `${header}\n${truncated.join('\n')}\n... (截断，共 ${lines.length} 个结果)${timeoutNote}`;
     }
-    return `${header}\n${truncated.join('\n')}`;
+    return `${header}\n${truncated.join('\n')}${timeoutNote}`;
   }
 
   throw new Error(`不支持的文件动作: ${action.type}`);

--- a/agent/tools/fs/execute.ts
+++ b/agent/tools/fs/execute.ts
@@ -180,7 +180,18 @@ export async function executeFsAction(action, opts: { cwd?: string | null; dataD
     }
     const maxResults = action.maxResults || 20;
     const include = action.include || '*';
-    const args = ['-rn', '--color=never', '-E', query, '--include', include, targetPath];
+    // 递归搜索必须排除敏感文件/目录，否则 grep -r 会读取并回显 read_file 明令禁止的
+    // .env / .git / .ssh / 私钥内容，绕过敏感文件防护造成凭据泄露。
+    const excludeArgs = [
+      '--exclude-dir=.git',
+      '--exclude-dir=.ssh',
+      '--exclude=.env',
+      '--exclude=.env.*',
+      '--exclude=id_rsa',
+      '--exclude=id_dsa',
+      '--exclude=authorized_keys',
+    ];
+    const args = ['-rn', '--color=never', '-E', ...excludeArgs, query, '--include', include, targetPath];
 
     const lines = await new Promise<string[]>((resolve, reject) => {
       const proc = spawn('grep', args, { stdio: ['ignore', 'pipe', 'pipe'] });

--- a/agent/tools/macos/helper-client.ts
+++ b/agent/tools/macos/helper-client.ts
@@ -9,7 +9,7 @@ const DEFAULT_HELPER_CANDIDATES = [
 
 function execFileJson(file: string, args: string[], payload: any = {}, timeout = 12000, signal?: AbortSignal): Promise<any> {
   return new Promise((resolve, reject) => {
-    const child = execFile(file, args, { timeout, signal }, (error, stdout, stderr) => {
+    const child = execFile(file, args, { timeout, signal, maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(stderr?.trim() || error.message));
         return;

--- a/agent/tools/macos/helper-client.ts
+++ b/agent/tools/macos/helper-client.ts
@@ -23,6 +23,10 @@ function execFileJson(file: string, args: string[], payload: any = {}, timeout =
     });
 
     if (child.stdin) {
+      // helper 在读完 stdin 前退出/崩溃时，向其 stdin 写入会触发 EPIPE；
+      // 未监听的可写流 'error' 会作为未捕获异常使整个后端进程崩溃，这里吞掉它，
+      // 真正的失败会经 execFile 回调（进程退出码/stderr）反映。
+      child.stdin.on('error', () => {});
       child.stdin.end(JSON.stringify(payload));
     }
   });

--- a/agent/tools/macos/observe.ts
+++ b/agent/tools/macos/observe.ts
@@ -18,7 +18,7 @@ function emptyUnlessAborted(signal?: AbortSignal) {
 
 function execFileText(file: string, args: string[], signal?: AbortSignal): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile(file, args, { timeout: 12000, signal }, (error, stdout, stderr) => {
+    execFile(file, args, { timeout: 12000, signal, maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(stderr?.trim() || error.message));
         return;
@@ -48,6 +48,8 @@ async function captureScreenshot(runId, signal?: AbortSignal) {
     await fs.chmod(filePath, 0o600).catch(() => {});
     return filePath;
   } catch (err) {
+    // screencapture 可能已落盘半成品（超时被 kill / abort），清理残留文件。
+    await fs.rm(filePath, { force: true }).catch(() => {});
     if (signal?.aborted) throw signal.reason instanceof Error ? signal.reason : err;
     return '';
   }

--- a/agent/tools/mcp/client.ts
+++ b/agent/tools/mcp/client.ts
@@ -190,9 +190,11 @@ export async function getSharedGenericMcpClient(name: string) {
   const key = configKey(config);
   const existing = sharedClients.get(name);
   if (existing?.key === key) return existing.client;
-  if (existing) await existing.client.close();
+  // 同步登记新 client（set 之前不能有 await），避免同名并发调用各自 await 旧连接关闭后
+  // 互相覆盖 map、导致先建的新连接从 map 丢失却仍持有子进程/连接而永不关闭。
   const client = createGenericMcpClient(name, config);
   sharedClients.set(name, { key, client });
+  if (existing) await existing.client.close().catch(() => {});
   return client;
 }
 

--- a/agent/tools/mcp/client.ts
+++ b/agent/tools/mcp/client.ts
@@ -48,6 +48,9 @@ export class GenericMcpClient {
   private transport: StdioClientTransport | SSEClientTransport | StreamableHTTPClientTransport | null = null;
   private connecting: Promise<Client> | null = null;
   private tools: any[] | null = null;
+  // 每次 close() 递增；connectOnce 在 connect 成功后比对，若期间发生过 close 则丢弃新连接，
+  // 避免在途连接“复活”后挂上却不在任何清理路径中导致泄漏。
+  private closeGeneration = 0;
 
   constructor(name: string, config: McpServerConfig) {
     this.name = name;
@@ -62,6 +65,7 @@ export class GenericMcpClient {
 
   private async connectOnce(onStatus?: McpStatusHandler) {
     onStatus?.({ phase: 'connecting', message: `正在连接 ${this.name}` });
+    const generation = this.closeGeneration;
     const transportConfig = this.config.transport;
     const transport = transportConfig.type === 'stdio'
       ? new StdioClientTransport({
@@ -92,6 +96,11 @@ export class GenericMcpClient {
     }
     try {
       await client.connect(transport, { timeout: this.config.toolTimeoutMs || 60_000 });
+      if (this.closeGeneration !== generation) {
+        // 连接期间发生过 close()，丢弃这个连接，避免复活后挂上却无人清理。
+        await client.close().catch(() => {});
+        throw new Error(`${this.name} 连接已在建立期间被关闭`);
+      }
       this.client = client;
       onStatus?.({ phase: 'connected', message: `${this.name} 已连接` });
       return client;
@@ -171,6 +180,7 @@ export class GenericMcpClient {
   }
 
   async close() {
+    this.closeGeneration += 1;
     this.tools = null;
     const client = this.client;
     const transport = this.transport;

--- a/agent/tools/search/execute.ts
+++ b/agent/tools/search/execute.ts
@@ -42,7 +42,9 @@ function unwrapDdgRedirect(href) {
     const parsed = new URL(url, ENDPOINT);
     if (/(^|\.)duckduckgo\.com$/i.test(parsed.hostname) && parsed.pathname === '/l/') {
       const uddg = parsed.searchParams.get('uddg');
-      if (uddg) return decodeURIComponent(uddg);
+      // searchParams.get 已做过一次百分号解码，返回的即真实 URL；再次 decodeURIComponent
+      // 属二次解码，会破坏含编码字符的 URL 或在残留裸 % 时抛错回退到跳转包装地址。
+      if (uddg) return uddg;
     }
     return parsed.toString();
   } catch {

--- a/agent/tools/search/execute.ts
+++ b/agent/tools/search/execute.ts
@@ -21,11 +21,14 @@ function decodeEntities(text) {
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&nbsp;/g, ' ')
-    .replace(/&#x27;/g, "'")
-    .replace(/&#x2F;/g, '/')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, code) => {
+      const n = parseInt(code, 16);
+      return Number.isFinite(n) && n <= 0x10ffff ? String.fromCodePoint(n) : '';
+    })
     .replace(/&#(\d+);/g, (_, code) => {
       const n = Number(code);
-      return Number.isFinite(n) ? String.fromCharCode(n) : '';
+      // fromCharCode 只取低 16 位，补充平面码点（如 emoji）会解码错误，用 fromCodePoint。
+      return Number.isFinite(n) && n >= 0 && n <= 0x10ffff ? String.fromCodePoint(n) : '';
     });
 }
 

--- a/agent/tools/terminal/run.ts
+++ b/agent/tools/terminal/run.ts
@@ -51,7 +51,15 @@ async function resolveCwd(value, base = process.cwd()) {
 async function assertSafeCommandPaths(args: string[], cwd: string) {
   for (const arg of args) {
     const candidate = arg.startsWith('-') && arg.includes('=') ? arg.slice(arg.indexOf('=') + 1) : arg;
-    if (!candidate || candidate.startsWith('-')) continue;
+    if (!candidate) continue;
+    if (candidate.startsWith('-')) {
+      // 粘连短选项的路径值（如 -f/etc/passwd）不走上面的 = 分支，单独约束绝对路径/越界。
+      const attached = candidate.replace(/^-+[A-Za-z]*/, '');
+      if (attached && (path.isAbsolute(attached) || attached.split(/[\\/]/).includes('..'))) {
+        throw new Error(`run_safe 路径参数越界: ${attached}`);
+      }
+      continue;
+    }
     if (path.isAbsolute(candidate)) throw new Error(`run_safe 禁止使用绝对路径参数: ${candidate}`);
     const segments = candidate.split(/[\\/]/);
     if (segments.includes('..')) throw new Error(`run_safe 路径参数越界: ${candidate}`);
@@ -152,6 +160,7 @@ async function runProcess({ file, args, env = process.env, command, cwd, timeout
     }, timeoutMs);
 
     child.stdout.on('data', chunk => {
+      if (settled) return;
       const text = chunk.toString();
       if (stdout.length < MAX_CAPTURE) stdout += redactText(text);
       emitProgress({
@@ -161,6 +170,7 @@ async function runProcess({ file, args, env = process.env, command, cwd, timeout
     });
 
     child.stderr.on('data', chunk => {
+      if (settled) return;
       const text = chunk.toString();
       if (stderr.length < MAX_CAPTURE) stderr += redactText(text);
       emitProgress({

--- a/agent/tools/terminal/run.ts
+++ b/agent/tools/terminal/run.ts
@@ -109,6 +109,9 @@ async function runProcess({ file, args, env = process.env, command, cwd, timeout
 
     let stdout = '';
     let stderr = '';
+    // 输出最终只截取前若干字节，累积无上限会在高产出命令超时前占满内存；
+    // 达到上限后停止追加（保留已收集的头部内容）。
+    const MAX_CAPTURE = 256 * 1024;
     let settled = false;
     let killTimer: NodeJS.Timeout | null = null;
     let timeout: NodeJS.Timeout;
@@ -150,7 +153,7 @@ async function runProcess({ file, args, env = process.env, command, cwd, timeout
 
     child.stdout.on('data', chunk => {
       const text = chunk.toString();
-      stdout += redactText(text);
+      if (stdout.length < MAX_CAPTURE) stdout += redactText(text);
       emitProgress({
         phase: 'stdout',
         chunk: redactText(text).slice(0, 4000),
@@ -159,7 +162,7 @@ async function runProcess({ file, args, env = process.env, command, cwd, timeout
 
     child.stderr.on('data', chunk => {
       const text = chunk.toString();
-      stderr += redactText(text);
+      if (stderr.length < MAX_CAPTURE) stderr += redactText(text);
       emitProgress({
         phase: 'stderr',
         chunk: redactText(text).slice(0, 4000),

--- a/agent/tools/terminal/safe-policy.ts
+++ b/agent/tools/terminal/safe-policy.ts
@@ -215,6 +215,13 @@ export function parseSafeCommand(command: string): ParsedSafeCommand {
   if (!validateArgs(file, args)) {
     throw new Error(`run_safe 不允许该命令参数: ${command}`);
   }
+  if (file === 'rg') {
+    // rg 会加载 RIPGREP_CONFIG_PATH 指向的配置文件，其中的 --pre 无法在命令行层面拦截，
+    // 剥离该环境变量以关闭配置文件加载。
+    const env = { ...process.env };
+    delete env.RIPGREP_CONFIG_PATH;
+    return { file, args, env };
+  }
   if (file !== 'git') return { file, args };
 
   const [subcommand, ...subcommandArgs] = args;

--- a/agent/tools/terminal/safe-policy.ts
+++ b/agent/tools/terminal/safe-policy.ts
@@ -169,6 +169,9 @@ function validateGit(args: string[]) {
   if (args[0].startsWith('-') || hasOption(args, '-c', '--config-env', '--exec-path')) return false;
   const subcommand = args[0];
   if (!GIT_READ_ONLY_SUBCOMMANDS.has(subcommand)) return false;
+  // -O / -O<pager> 是 --open-files-in-pager 的短选项，git 会用 /bin/sh 执行该 pager，
+  // 构成任意命令执行；hasOption 无法匹配 -O<pager> 粘连形式，需单独拒绝任何 -O 开头参数。
+  if (args.some(arg => arg === '-O' || arg.startsWith('-O'))) return false;
   if (hasOption(
     args,
     '--output',

--- a/agent/tools/vision/execute.ts
+++ b/agent/tools/vision/execute.ts
@@ -89,6 +89,24 @@ function asStringArray(value: unknown): string[] {
     : [];
 }
 
+// 兼容 content 为字符串或分段数组（[{type:'text',text}]）两种返回形态。
+function extractMessageText(content: unknown): string {
+  if (typeof content === 'string') return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .map(part => {
+        if (typeof part === 'string') return part;
+        if (part && typeof part === 'object' && typeof (part as Record<string, unknown>).text === 'string') {
+          return (part as Record<string, string>).text;
+        }
+        return '';
+      })
+      .join('')
+      .trim();
+  }
+  return '';
+}
+
 function uniqueModels(values: unknown[]): string[] {
   return [...new Set(values
     .flatMap(value => Array.isArray(value) ? value : [value])
@@ -154,6 +172,14 @@ async function toImageDataUrl(
 ): Promise<string> {
   throwIfAborted(signal);
   if (/^data:image\//i.test(image)) {
+    // data URL 分支也要做大小限制，否则可构造超大 data URL 绕过 10MB 上限。
+    const comma = image.indexOf(',');
+    const meta = comma >= 0 ? image.slice(5, comma) : '';
+    const payload = comma >= 0 ? image.slice(comma + 1) : '';
+    const approxBytes = /;base64/i.test(meta) ? Math.floor(payload.length * 3 / 4) : payload.length;
+    if (approxBytes > MAX_IMAGE_BYTES) {
+      throw new Error(`图片过大（${(approxBytes / 1024 / 1024).toFixed(1)} MB），上限 10 MB`);
+    }
     return image;
   }
 
@@ -213,7 +239,7 @@ async function toImageDataUrl(
   if (buf.length > MAX_IMAGE_BYTES) {
     throw new Error(`图片过大（${(buf.length / 1024 / 1024).toFixed(1)} MB），上限 10 MB`);
   }
-  return `data:${mimeFromExt(abs)};base64,${buf.toString('base64')}`;
+  return `data:${sniffImageMime(buf) || mimeFromExt(abs)};base64,${buf.toString('base64')}`;
 }
 
 export async function executeVisionAction(
@@ -277,8 +303,10 @@ export async function executeVisionAction(
           temperature: 0.2,
           messages,
         }, { signal: scope.signal })) as CompletionLike;
-    const text = completion?.choices?.[0]?.message?.content;
-    const answer = typeof text === 'string' ? text.trim() : '';
+    const raw = completion?.choices?.[0]?.message?.content;
+    // 部分 OpenAI 兼容/多模态实现会把 content 返回为分段数组，需拼接文本片段，
+    // 否则会被当作空内容误报“未返回内容”。
+    const answer = extractMessageText(raw);
     if (!answer) return `image_analyze 模型 ${model} 未返回内容`;
     return `image_analyze 结果（model=${model}）:\n${answer}`;
   } catch (err: unknown) {

--- a/agent/tools/vision/execute.ts
+++ b/agent/tools/vision/execute.ts
@@ -38,7 +38,19 @@ function mimeFromExt(target: string): string {
   if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg';
   if (ext === 'webp') return 'image/webp';
   if (ext === 'gif') return 'image/gif';
+  if (ext === 'bmp') return 'image/bmp';
   return 'image/png';
+}
+
+// 依据文件头魔数识别常见图片类型，用于扩展名/content-type 不可靠时的兜底，
+// 避免把非 png 图片一律标成 image/png 送给严格的 provider。
+function sniffImageMime(buf: Buffer): string | null {
+  if (buf.length >= 4 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'image/png';
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'image/jpeg';
+  if (buf.length >= 6 && buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return 'image/gif';
+  if (buf.length >= 12 && buf.toString('ascii', 0, 4) === 'RIFF' && buf.toString('ascii', 8, 12) === 'WEBP') return 'image/webp';
+  if (buf.length >= 2 && buf[0] === 0x42 && buf[1] === 0x4d) return 'image/bmp';
+  return null;
 }
 
 interface VisionContext {
@@ -152,12 +164,30 @@ async function toImageDataUrl(
       if (!res.ok) {
         throw new Error(`下载图片失败 HTTP ${res.status}`);
       }
-      const buf = Buffer.from(await res.arrayBuffer());
-      if (buf.length > MAX_IMAGE_BYTES) {
-        throw new Error(`图片过大（${(buf.length / 1024 / 1024).toFixed(1)} MB），上限 10 MB`);
+      // 先按 Content-Length 预检，再边下边累计字节数，超限立即中止，
+      // 避免把超大响应体一次性读入内存导致 OOM。
+      const declaredLength = Number(res.headers.get('content-length'));
+      if (Number.isFinite(declaredLength) && declaredLength > MAX_IMAGE_BYTES) {
+        throw new Error(`图片过大（${(declaredLength / 1024 / 1024).toFixed(1)} MB），上限 10 MB`);
       }
+      const reader = res.body?.getReader();
+      if (!reader) throw new Error('下载图片失败：响应无内容');
+      const chunks: Uint8Array[] = [];
+      let total = 0;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+        total += value.length;
+        if (total > MAX_IMAGE_BYTES) {
+          await reader.cancel().catch(() => {});
+          throw new Error('图片过大，超过上限 10 MB');
+        }
+        chunks.push(value);
+      }
+      const buf = Buffer.concat(chunks);
       const contentType = res.headers.get('content-type')?.split(';')[0]?.trim();
-      const mime = contentType && /^image\//.test(contentType) ? contentType : mimeFromExt(image);
+      const mime = contentType && /^image\//i.test(contentType) ? contentType : (sniffImageMime(buf) || mimeFromExt(image));
       return `data:${mime};base64,${buf.toString('base64')}`;
     } finally {
       scope.cleanup();

--- a/test/terminal-safe-policy.test.ts
+++ b/test/terminal-safe-policy.test.ts
@@ -40,17 +40,23 @@ describe('terminal run_safe policy', () => {
   });
 
   it('parses quoted arguments without invoking a shell', () => {
-    expect(parseSafeCommand('rg -n "foo bar" \'src files\'')).toEqual({
+    expect(parseSafeCommand('rg -n "foo bar" \'src files\'')).toMatchObject({
       file: 'rg',
       args: ['-n', 'foo bar', 'src files'],
     });
   });
 
   it('preserves explicit empty argv values', () => {
-    expect(parseSafeCommand("rg '' README.md")).toEqual({
+    expect(parseSafeCommand("rg '' README.md")).toMatchObject({
       file: 'rg',
       args: ['', 'README.md'],
     });
+  });
+
+  it('strips RIPGREP_CONFIG_PATH from rg env to disable config-file --pre', () => {
+    const parsed = parseSafeCommand('rg foo src');
+    expect(parsed.env).toBeDefined();
+    expect(parsed.env).not.toHaveProperty('RIPGREP_CONFIG_PATH');
   });
 
   it('hardens git against configured external processes', () => {


### PR DESCRIPTION
## 背景

对 `agent/tools/` 下 6 个工具(chrome / fs / macos / mcp / search / terminal)做了代码正确性审查(browser 已在此前另行检查),修复审查发现的高/中/低问题。每个修复单独一个 commit,全程 `tsc` 通过、`npm test` 684 项全绿。

## 🔴 高危

- **fs `search_files` 密钥泄露**:`grep -rn` 只校验搜索根路径,递归会读取并回显 `read_file` 明令禁止的 `.env/.git/.ssh/私钥`。增加 `--exclude-dir/--exclude`。
- **terminal `git grep -O` 绕过**:`validateGit` 漏了 `--open-files-in-pager` 的短选项 `-O`,`git grep -O<pager>` 经 `/bin/sh` 达任意命令执行(run_safe 是免审批只读通道)。拒绝任何 `-O` 开头的 git 参数。
- **chrome `close()` 自锁**:`close()` 的 `abortController.abort()` 让 SSE 流以 `AbortError` reject 后无条件 `markChromeMcpUnavailable`(冷却 5 分钟)。in-process 模式每次 run 结束都触发,下一次 run 的 chrome 工具被自锁。对 `AbortError` 跳过标记。

## 🟡 中危

- fs 写入路径对 realpath 结果补敏感模式校验(软链绕过);敏感模式死代码/嵌套遗漏修正。
- mcp `getSharedGenericMcpClient` 并发竞态泄漏(改同步登记);`close()` 用 generation 计数取消在途 `connect` 防复活泄漏。
- macos helper stdin 监听 `error` 防 EPIPE 崩溃进程。
- chrome SSE 流关闭后重置 `initialized` 并 reject 在途请求。
- vision HTTP 下载改流式 + Content-Length 预检,防 OOM。
- terminal stdout/stderr 累积上限,防内存耗尽。
- search `uddg` 去二次解码。

## 🟢 低危

- fs:UTF-8 安全截断 / `--` 分隔 query / 监听器移除 / 超时提示。
- terminal:粘连短选项路径约束 / 结算后事件抑制 / rg 剥离 `RIPGREP_CONFIG_PATH`。
- macos:execFile `maxBuffer` / 截图残留清理。
- vision:data URL 大小校验 / 数组 content 兼容 / MIME 魔数嗅探。
- search:`fromCodePoint` / 通用十六进制实体。
- chrome:endpoint 事件解析容错 / navigate 后快照传 `signal`。

## 未处理

chrome 的 `close_page` 参数名(`pageId` vs `pageIdx`)存疑且无法在本仓库核实,盲改有风险,保留原样待确认。

## 验证

- `npm run typecheck` ✅(每个修复后均跑)
- `npm test` ✅ 684 passed
