### PR TITLE
feat(eval): trace 回放回归评测 CLI(离线四维度 + --live 决策回放)

### DIFF
--- a/agent/core/trace-replay.ts
+++ b/agent/core/trace-replay.ts
@@ -1,0 +1,249 @@
+/**
+ * Trace 回放重建 — 把 data/traces/<runId>.jsonl 的事件流还原成可离线评测的 ReplayRun。
+ *
+ * 纯数据变换：不触网、不读写磁盘，供 scripts/trace-eval.ts 与测试复用。
+ * 对旧 trace 宽松容错：坏行跳过、缺字段按 undefined 处理；rollback 重放的
+ * 同号步骤以后到的事件为准。
+ *
+ * 与 runtime 的对应关系（重建必须与 runtime.ts 组装 history 的口径一致，
+ * 否则离线重跑 assessResultQuality 会与录制结果偏离）：
+ *   - 每个已执行动作：step/observe + step/action + step/result 三类事件按 step 号合并；
+ *   - finish 步只有 action 事件、没有 result 事件（runtime.ts 对 finish 跳过 result）；
+ *   - 审批被拒的步只有 result(rejected) 事件、没有 action 事件；
+ *   - history 条目的 url/title 不落 trace，按 runtime 同样规则从 action/observation 推导。
+ */
+
+import type { AgentAction, AgentEvent, AgentStep, JsonObject, ResultQuality } from './contracts.ts';
+
+export interface ReplayParseFailure {
+  step?: number;
+  model?: string;
+  rawOutput: string;
+  error: string;
+}
+
+export interface ReplayRun {
+  runId: string;
+  task: string;
+  agentModels: string[];
+  strategy: string;
+  steps: AgentStep[];
+  /** run 结束前已 observe 但未执行动作的尾步（如解析失败中断时），用于补一个 prompt 构建点。 */
+  pendingObservation: { step: number; observation: JsonObject } | null;
+  answer: string;
+  recordedQuality: ResultQuality | null;
+  endedWith: 'done' | 'error' | 'incomplete';
+  parseFailures: ReplayParseFailure[];
+}
+
+export interface StepPromptContext {
+  task: string;
+  step: number;
+  history: AgentStep[];
+  observation: JsonObject;
+}
+
+/** 宽松逐行解析 JSONL，坏行跳过（与 trace-store 读取语义一致）。 */
+export function parseTraceLines(raw: string): AgentEvent[] {
+  const events: AgentEvent[] = [];
+  for (const line of String(raw ?? '').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // 跳过坏行
+    }
+  }
+  return events;
+}
+
+const RAW_OUTPUT_MARKER = '原始输出=';
+
+/** 从 planner 抛错文本（`…; 原始输出=<json 字符串>`）还原模型原文，供解析器语料回归使用。 */
+export function extractRawOutputFromError(errorText: unknown): string | null {
+  const text = typeof errorText === 'string' ? errorText : '';
+  const idx = text.indexOf(RAW_OUTPUT_MARKER);
+  if (idx < 0) return null;
+  const tail = text.slice(idx + RAW_OUTPUT_MARKER.length).trim();
+  if (!tail) return null;
+  try {
+    const decoded = JSON.parse(tail);
+    return typeof decoded === 'string' ? decoded : tail;
+  } catch {
+    return tail;
+  }
+}
+
+// 镜像 runtime.ts 的私有 actionTargetUrl / observationText。
+function actionTargetUrl(action: any): string | null {
+  if (typeof action?.url === 'string' && action.url) return action.url;
+  if (typeof action?.arguments?.url === 'string' && action.arguments.url) return action.arguments.url;
+  return null;
+}
+
+function observationText(observation: unknown, key: 'url' | 'title'): string | undefined {
+  if (!observation || typeof observation !== 'object') return undefined;
+  const value = (observation as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+interface StepDraft {
+  step: number;
+  rationale?: string;
+  action?: AgentAction;
+  result?: unknown;
+  resultStatus?: AgentStep['resultStatus'];
+  resultError?: string | null;
+  observation?: JsonObject;
+}
+
+export function reconstructRunFromTrace(events: AgentEvent[]): ReplayRun {
+  let runId = '';
+  let task = '';
+  let agentModels: string[] = [];
+  let strategy = '';
+  let answer = '';
+  let recordedQuality: ResultQuality | null = null;
+  let endedWith: ReplayRun['endedWith'] = 'incomplete';
+  const parseFailures: ReplayParseFailure[] = [];
+  const stepMap = new Map<number, StepDraft>();
+
+  for (const event of events as any[]) {
+    if (!event || typeof event !== 'object') continue;
+    if (!runId && typeof event.runId === 'string') runId = event.runId;
+
+    switch (event.type) {
+      case 'run_meta': {
+        if (typeof event.task === 'string' && event.task) task = event.task;
+        if (Array.isArray(event.agentModels)) {
+          const models = event.agentModels.filter((m: unknown) => typeof m === 'string' && m);
+          if (models.length) agentModels = models;
+        }
+        if (typeof event.strategy === 'string' && event.strategy) strategy = event.strategy;
+        break;
+      }
+      case 'step': {
+        const stepNo = Number(event.step);
+        if (!Number.isInteger(stepNo) || stepNo <= 0) break;
+        const entry = stepMap.get(stepNo) || { step: stepNo };
+        if (event.stage === 'observe') {
+          entry.observation = event.observation && typeof event.observation === 'object' ? event.observation : {};
+        } else if (event.stage === 'action') {
+          entry.rationale = typeof event.rationale === 'string' ? event.rationale : '';
+          if (event.action && typeof event.action === 'object') entry.action = event.action;
+        } else if (event.stage === 'result') {
+          entry.result = event.result;
+          entry.resultStatus = ['success', 'failed', 'rejected'].includes(event.resultStatus)
+            ? event.resultStatus
+            : undefined;
+          entry.resultError = typeof event.resultError === 'string' ? event.resultError : null;
+        }
+        stepMap.set(stepNo, entry);
+        break;
+      }
+      case 'model_plan': {
+        if (event.stage !== 'failed') break;
+        const rawOutput = extractRawOutputFromError(event.error);
+        if (rawOutput) {
+          parseFailures.push({
+            step: Number.isInteger(event.step) ? event.step : undefined,
+            model: typeof event.model === 'string' ? event.model : undefined,
+            rawOutput,
+            error: String(event.error ?? ''),
+          });
+        }
+        break;
+      }
+      case 'done': {
+        endedWith = 'done';
+        answer = typeof event.answer === 'string' ? event.answer : '';
+        recordedQuality = event.quality && typeof event.quality === 'object' ? event.quality : null;
+        break;
+      }
+      case 'error': {
+        endedWith = 'error';
+        const rawOutput = extractRawOutputFromError(event.error);
+        if (rawOutput) {
+          parseFailures.push({ rawOutput, error: String(event.error ?? '') });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  // run 结尾的 error 事件会复读最后一次 model_plan failed 的原文，按原文去重。
+  const seenRawOutputs = new Set<string>();
+  const dedupedFailures = parseFailures.filter(failure => {
+    if (seenRawOutputs.has(failure.rawOutput)) return false;
+    seenRawOutputs.add(failure.rawOutput);
+    return true;
+  });
+
+  const drafts = [...stepMap.values()].sort((a, b) => a.step - b.step);
+  const executed = drafts.filter(entry => entry.action !== undefined || entry.result !== undefined);
+  const steps: AgentStep[] = executed.map(entry => ({
+    step: entry.step,
+    rationale: entry.rationale ?? '',
+    action: entry.action as AgentAction,
+    result: entry.result,
+    ...(entry.resultStatus ? { resultStatus: entry.resultStatus } : {}),
+    resultError: entry.resultError ?? null,
+    url: actionTargetUrl(entry.action) || observationText(entry.observation, 'url'),
+    title: observationText(entry.observation, 'title'),
+    ...(entry.observation ? { observation: entry.observation } : {}),
+  }));
+
+  const executedNos = new Set(executed.map(entry => entry.step));
+  const tail = drafts.filter(entry => !executedNos.has(entry.step) && entry.observation).pop();
+  const pendingObservation = tail ? { step: tail.step, observation: tail.observation as JsonObject } : null;
+
+  return {
+    runId,
+    task,
+    agentModels,
+    strategy,
+    steps,
+    pendingObservation,
+    answer,
+    recordedQuality,
+    endedWith,
+    parseFailures: dedupedFailures,
+  };
+}
+
+function observationForIndex(run: ReplayRun, index: number): JsonObject {
+  // 个别步骤可能没有 observe 事件（runtime 的 shouldObserve 跳过时复用上一次观察），向前回退。
+  for (let i = index; i >= 0; i -= 1) {
+    const observation = run.steps[i]?.observation;
+    if (observation && typeof observation === 'object') return observation;
+  }
+  return {};
+}
+
+/** 还原第 index 个已执行步骤在 decide 时刻的 prompt 上下文。 */
+export function buildStepPromptContext(run: ReplayRun, index: number): StepPromptContext {
+  const target = run.steps[index];
+  if (!target) throw new Error(`步骤索引越界: ${index}（共 ${run.steps.length} 步）`);
+  return {
+    task: run.task,
+    step: target.step,
+    history: run.steps.slice(0, index),
+    observation: observationForIndex(run, index),
+  };
+}
+
+/** 列出该 run 全部可用的 prompt 构建点：每个已执行步骤 + 未执行的尾步观察（若有）。 */
+export function listPromptContexts(run: ReplayRun): StepPromptContext[] {
+  const contexts = run.steps.map((_, index) => buildStepPromptContext(run, index));
+  if (run.pendingObservation) {
+    contexts.push({
+      task: run.task,
+      step: run.pendingObservation.step,
+      history: run.steps.slice(),
+      observation: run.pendingObservation.observation,
+    });
+  }
+  return contexts;
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "stop": "node scripts/stop.js",
     "smoke": "node scripts/smoke-test.mjs",
     "test": "vitest run",
-    "prompt:bench": "bun scripts/prompt-benchmark.ts"
+    "prompt:bench": "bun scripts/prompt-benchmark.ts",
+    "eval": "bun scripts/trace-eval.ts",
+    "eval:capture": "bun scripts/trace-eval.ts capture",
+    "eval:live": "bun scripts/trace-eval.ts --live"
   },
   "dependencies": {
     "@google/genai": "^2.7.0",

--- a/scripts/trace-eval-live.ts
+++ b/scripts/trace-eval-live.ts
@@ -1,0 +1,164 @@
+/**
+ * trace-eval 决策回放（--live）— 用真实模型对录制步骤逐步重新决策，与录制动作对比。
+ *
+ * 每个回放点只发一次 agentPlan 请求：重建当时的 {task, step, history, observation}
+ * prompt 上下文 → provider.agentPlan（与 runtime 决策同一条代码路径）→ 与录制的
+ * action 比对。不执行任何工具、不写任何运行状态，唯一成本是模型 token。
+ *
+ * 单独成文件并由 trace-eval.ts 动态导入：纯离线评测路径不加载 OpenAI/Gemini SDK。
+ */
+
+import { createClients } from '../agent/core/ai-client.ts';
+import { createProviderRegistry } from '../agent/core/providers/registry.ts';
+import { buildStepPromptContext } from '../agent/core/trace-replay.ts';
+import type { FixtureCurrent } from './trace-eval.ts';
+
+interface LiveCliConfig {
+  liveModels: string[] | null;
+  maxLiveSteps: number;
+}
+
+export interface LiveStepRow {
+  fixture: string;
+  model: string;
+  step: number;
+  parsedOk: boolean;
+  toolMatch: boolean | null;
+  typeMatch: boolean | null;
+  recorded: string;
+  replayed: string;
+  error?: string;
+}
+
+export interface LiveModelSummary {
+  model: string;
+  steps: number;
+  parsedOk: number;
+  toolMatch: number;
+  typeMatch: number;
+  earlyFinish: number;
+  missedFinish: number;
+  promptTokens: number;
+  completionTokens: number;
+}
+
+function actionLabel(action: any): string {
+  if (!action || typeof action !== 'object') return '?';
+  return `${action.tool ?? '?'}.${action.type ?? '?'}`;
+}
+
+export async function runLiveEval(cfg: LiveCliConfig, currents: FixtureCurrent[]) {
+  const { openai_client, gemini_client } = createClients();
+  const registry = createProviderRegistry({ openai_client, gemini_client });
+  let modelConfig: any[] | undefined;
+  try {
+    modelConfig = await registry.loadModelConfig();
+  } catch (err: any) {
+    console.warn(`⚠️ 获取模型列表失败（继续，但 max_tokens/角色适配可能不精确）: ${err?.message || err}`);
+    modelConfig = undefined;
+  }
+
+  const rows: LiveStepRow[] = [];
+  const summaries = new Map<string, LiveModelSummary>();
+  let budget = cfg.maxLiveSteps;
+  let truncated = false;
+
+  console.log(`\n决策回放（--live，总请求预算 ${cfg.maxLiveSteps}）\n`);
+
+  outer:
+  for (const current of currents) {
+    const run = current.run;
+    if (!run.steps.length) continue;
+    const models = cfg.liveModels?.length ? cfg.liveModels : run.agentModels;
+    if (!models.length) {
+      console.warn(`⚠️ [${current.id}] 无可用模型（run_meta 无 agentModels 且未指定 --models），跳过`);
+      continue;
+    }
+
+    for (const model of models) {
+      const summary = summaries.get(model) || {
+        model, steps: 0, parsedOk: 0, toolMatch: 0, typeMatch: 0,
+        earlyFinish: 0, missedFinish: 0, promptTokens: 0, completionTokens: 0,
+      };
+      summaries.set(model, summary);
+
+      for (let index = 0; index < run.steps.length; index += 1) {
+        if (budget <= 0) { truncated = true; break outer; }
+        const recorded = run.steps[index];
+        if (!recorded.action) continue; // 审批被拒的步没有录制动作，无从比对
+
+        budget -= 1;
+        summary.steps += 1;
+        const context = buildStepPromptContext(run, index);
+        const row: LiveStepRow = {
+          fixture: current.id,
+          model,
+          step: recorded.step,
+          parsedOk: false,
+          toolMatch: null,
+          typeMatch: null,
+          recorded: actionLabel(recorded.action),
+          replayed: '-',
+        };
+
+        try {
+          const provider = registry.resolve(model, modelConfig as any);
+          const result = await provider.agentPlan({
+            model,
+            modelConfig: modelConfig as any,
+            task: context.task,
+            step: context.step,
+            history: context.history,
+            observation: context.observation,
+          });
+          row.parsedOk = true;
+          summary.parsedOk += 1;
+          row.replayed = actionLabel(result.action);
+          row.toolMatch = result.action?.tool === recorded.action.tool;
+          row.typeMatch = row.toolMatch && result.action?.type === recorded.action.type;
+          if (row.toolMatch) summary.toolMatch += 1;
+          if (row.typeMatch) summary.typeMatch += 1;
+
+          const recordedFinish = recorded.action.type === 'finish';
+          const replayedFinish = result.action?.type === 'finish';
+          if (replayedFinish && !recordedFinish) summary.earlyFinish += 1;
+          if (!replayedFinish && recordedFinish) summary.missedFinish += 1;
+
+          summary.promptTokens += Number(result.usage?.prompt_tokens) || 0;
+          summary.completionTokens += Number(result.usage?.completion_tokens ?? result.usage?.output_tokens) || 0;
+        } catch (err: any) {
+          row.error = String(err?.message || err).slice(0, 200);
+        }
+
+        rows.push(row);
+        console.log(
+          `  [${current.id}] step ${row.step} ${model}: 录制=${row.recorded} 回放=${row.replayed}` +
+          `${row.typeMatch ? ' ✅' : row.toolMatch ? ' ~tool' : row.parsedOk ? ' ✗' : ` ❌(${row.error})`}`,
+        );
+      }
+    }
+  }
+
+  if (truncated) {
+    console.warn(`⚠️ 已达 --max-steps 预算（${cfg.maxLiveSteps}），其余步骤未回放`);
+  }
+
+  const summaryRows = [...summaries.values()].map(summary => ({
+    model: summary.model,
+    steps: summary.steps,
+    'parse✓': summary.parsedOk,
+    'tool✓': summary.toolMatch,
+    'type✓': summary.typeMatch,
+    earlyFinish: summary.earlyFinish,
+    missedFinish: summary.missedFinish,
+    tokens: `${summary.promptTokens}+${summary.completionTokens}`,
+  }));
+  if (summaryRows.length) console.table(summaryRows);
+
+  return {
+    budget: cfg.maxLiveSteps,
+    truncated,
+    models: [...summaries.values()],
+    rows,
+  };
+}

--- a/scripts/trace-eval.ts
+++ b/scripts/trace-eval.ts
@@ -1,0 +1,617 @@
+/**
+ * trace-eval — 基于录制 trace 的离线回归评测 CLI。
+ *
+ * 用法：
+ *   bun scripts/trace-eval.ts                          # 离线评测全部夹具，与基线对比
+ *   bun scripts/trace-eval.ts capture <runId> [...]    # 把 data/traces 里的一个 run 脱敏后固化为夹具
+ *   bun scripts/trace-eval.ts --update-baseline        # 接受当前值，重写基线
+ *   bun scripts/trace-eval.ts --live --models m1,m2    # 决策回放：真实模型对录制步骤逐步重新决策（烧 token）
+ *
+ * 通用参数：
+ *   --data-dir <path>       运行时数据目录（默认 ./data；worktree 下可指向主仓库 data）
+ *   --fixtures-dir <path>   夹具目录（默认 <data-dir>/eval-fixtures）
+ *   --warn-drift <pct>      prompt token 漂移 warn 阈值（默认 10）
+ *   --fail-drift <pct>      prompt token 漂移 fail 阈值（默认 25）
+ *   --no-report             不写 JSON 报告（默认写到 <data-dir>/eval-reports/）
+ *   --fixtures fx1,fx2      只评测指定夹具
+ * capture 参数：
+ *   --id <fixtureId>        夹具 id（默认由 runId 派生）
+ *   --tags a,b              标签，写入 meta
+ * live 参数：
+ *   --models m1,m2          参与回放的模型（缺省用夹具 run_meta.agentModels）
+ *   --max-steps <n>         全部夹具累计的最大回放步数（默认 20）
+ *
+ * 退出码：0=全部 pass / 1=有 warn / 2=有 fail 或执行异常（与 smoke 一致）。
+ *
+ * 确定性：离线评测把 configStore.init 指向临时空目录，隔离本地 data/config.json
+ * 的工具开关对 prompt 构建的影响；因此重建 prompt 是「标准烛光」而非当时请求的
+ * 精确复刻，用于同口径下的 A/B 漂移对比。
+ */
+
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { readTraceEvents } from '../helpers/trace-store.ts';
+import { redactSensitiveData } from '../helpers/redact.ts';
+import { configStore } from '../agent/core/config-store.ts';
+import { assessResultQuality } from '../agent/core/result-quality.ts';
+import { buildGeminiAgentPromptPayload, buildNvidiaTaskMessages } from '../agent/core/prompts.ts';
+import { estimatePayloadTokens } from '../agent/core/context-estimate.ts';
+import { createModelResponseParser } from '../agent/core/nvidia-response-parsers.ts';
+import { normalizeDesktopAgentDecision } from '../agent/core/schemas.ts';
+import {
+  listPromptContexts,
+  parseTraceLines,
+  reconstructRunFromTrace,
+  type ReplayParseFailure,
+  type ReplayRun,
+} from '../agent/core/trace-replay.ts';
+
+// ── 类型 ──
+
+export interface FixtureMeta {
+  id: string;
+  sourceRunId: string;
+  capturedAt: string;
+  task: string;
+  tags: string[];
+  endedWith: ReplayRun['endedWith'];
+  stepCount: number;
+  agentModels: string[];
+  parseFailures: Array<Pick<ReplayParseFailure, 'step' | 'model' | 'rawOutput'>>;
+  notes: string;
+}
+
+export type ParserOutcome = 'parse_ok' | 'parse_fail' | 'normalize_fail';
+
+export interface PromptTokenTotals {
+  nvidia: number;
+  nvidiaCompact: number;
+  gemini: number;
+}
+
+export interface FixtureBaseline {
+  endedWith: ReplayRun['endedWith'];
+  qualityStatus: string;
+  promptContexts: number;
+  promptTokens: PromptTokenTotals;
+  parserOutcomes: ParserOutcome[];
+}
+
+export interface BaselineFile {
+  updatedAt: string;
+  fixtures: Record<string, FixtureBaseline>;
+}
+
+export interface FixtureCurrent {
+  id: string;
+  meta: FixtureMeta;
+  run: ReplayRun;
+  endedWith: ReplayRun['endedWith'];
+  qualityStatus: string;
+  qualityReasons: string[];
+  promptContexts: number;
+  promptTokens: PromptTokenTotals;
+  parserOutcomes: ParserOutcome[];
+}
+
+export type Severity = 'pass' | 'warn' | 'fail';
+
+export interface FixtureVerdict {
+  fixture: string;
+  severity: Severity;
+  notes: string[];
+  current: {
+    endedWith: string;
+    qualityStatus: string;
+    promptTokens: PromptTokenTotals;
+    promptContexts: number;
+    parserOutcomes: ParserOutcome[];
+  };
+  baseline: FixtureBaseline | null;
+  drift: Partial<Record<keyof PromptTokenTotals, number>>;
+}
+
+interface CliConfig {
+  command: 'eval' | 'capture';
+  runId?: string;
+  fixtureId?: string;
+  tags: string[];
+  dataDir: string;
+  fixturesDir: string;
+  onlyFixtures: string[] | null;
+  updateBaseline: boolean;
+  warnDrift: number;
+  failDrift: number;
+  writeReport: boolean;
+  live: boolean;
+  liveModels: string[] | null;
+  maxLiveSteps: number;
+}
+
+// ── 纯逻辑（供 vitest 导入）──
+
+export function severityMax(a: Severity, b: Severity): Severity {
+  const order: Severity[] = ['pass', 'warn', 'fail'];
+  return order[Math.max(order.indexOf(a), order.indexOf(b))];
+}
+
+export function driftPercent(current: number, baseline: number): number {
+  if (!Number.isFinite(baseline) || baseline <= 0) return current > 0 ? 100 : 0;
+  return Math.abs(current - baseline) / baseline * 100;
+}
+
+export function compareParserOutcomes(current: ParserOutcome[], baseline: ParserOutcome[]): { severity: Severity; notes: string[] } {
+  const notes: string[] = [];
+  let severity: Severity = 'pass';
+  if (current.length !== baseline.length) {
+    return { severity: 'fail', notes: [`解析器语料数量变化: ${baseline.length} -> ${current.length}（夹具应不可变，疑似提取逻辑变动）`] };
+  }
+  current.forEach((outcome, index) => {
+    const expected = baseline[index];
+    if (outcome === expected) return;
+    if (expected !== 'parse_ok' && outcome === 'parse_ok') {
+      notes.push(`语料 #${index + 1} 由 ${expected} 变为可解析（improved）`);
+      severity = severityMax(severity, 'warn');
+      return;
+    }
+    notes.push(`语料 #${index + 1} 回归: ${expected} -> ${outcome}`);
+    severity = 'fail';
+  });
+  return { severity, notes };
+}
+
+export function evaluateFixtureAgainstBaseline(
+  current: FixtureCurrent,
+  baseline: FixtureBaseline | null,
+  thresholds: { warnDrift: number; failDrift: number },
+): FixtureVerdict {
+  const notes: string[] = [];
+  let severity: Severity = 'pass';
+  const drift: FixtureVerdict['drift'] = {};
+
+  if (!baseline) {
+    return {
+      fixture: current.id,
+      severity: 'warn',
+      notes: ['基线中无此夹具，运行 --update-baseline 收录'],
+      current: currentSummary(current),
+      baseline: null,
+      drift,
+    };
+  }
+
+  if (current.endedWith !== baseline.endedWith) {
+    severity = 'fail';
+    notes.push(`endedWith 变化: ${baseline.endedWith} -> ${current.endedWith}（夹具不可变，疑似重建逻辑变动）`);
+  }
+
+  if (current.qualityStatus !== baseline.qualityStatus) {
+    severity = 'fail';
+    notes.push(`质量重打分变化: ${baseline.qualityStatus} -> ${current.qualityStatus}（当前 reasons: ${current.qualityReasons.join('；') || '无'}）`);
+  }
+
+  if (current.promptContexts !== baseline.promptContexts) {
+    severity = 'fail';
+    notes.push(`prompt 构建点数量变化: ${baseline.promptContexts} -> ${current.promptContexts}`);
+  } else {
+    for (const key of ['nvidia', 'nvidiaCompact', 'gemini'] as const) {
+      const pct = driftPercent(current.promptTokens[key], baseline.promptTokens[key]);
+      drift[key] = Math.round(pct * 10) / 10;
+      if (pct > thresholds.failDrift) {
+        severity = 'fail';
+        notes.push(`${key} prompt token 漂移 ${drift[key]}%（${baseline.promptTokens[key]} -> ${current.promptTokens[key]}）超过 fail 阈值 ${thresholds.failDrift}%`);
+      } else if (pct > thresholds.warnDrift) {
+        severity = severityMax(severity, 'warn');
+        notes.push(`${key} prompt token 漂移 ${drift[key]}%（${baseline.promptTokens[key]} -> ${current.promptTokens[key]}）超过 warn 阈值 ${thresholds.warnDrift}%`);
+      }
+    }
+  }
+
+  const parser = compareParserOutcomes(current.parserOutcomes, baseline.parserOutcomes);
+  severity = severityMax(severity, parser.severity);
+  notes.push(...parser.notes);
+
+  return { fixture: current.id, severity, notes, current: currentSummary(current), baseline, drift };
+}
+
+function currentSummary(current: FixtureCurrent) {
+  return {
+    endedWith: current.endedWith,
+    qualityStatus: current.qualityStatus,
+    promptTokens: current.promptTokens,
+    promptContexts: current.promptContexts,
+    parserOutcomes: current.parserOutcomes,
+  };
+}
+
+export function replayParserCorpus(entries: Array<{ model?: string; rawOutput: string }>): ParserOutcome[] {
+  return entries.map(entry => {
+    const parser = createModelResponseParser(entry.model || 'unknown/model');
+    const parsed = parser({ choices: [{ message: { content: entry.rawOutput } }] });
+    if (parsed.parseFailed) return 'parse_fail';
+    try {
+      normalizeDesktopAgentDecision(parsed);
+      return 'parse_ok';
+    } catch {
+      return 'normalize_fail';
+    }
+  });
+}
+
+export function computePromptTokenTotals(run: ReplayRun): { totals: PromptTokenTotals; contexts: number } {
+  const contexts = listPromptContexts(run);
+  const totals: PromptTokenTotals = { nvidia: 0, nvidiaCompact: 0, gemini: 0 };
+  for (const context of contexts) {
+    totals.nvidia += estimatePayloadTokens(buildNvidiaTaskMessages(context));
+    totals.nvidiaCompact += estimatePayloadTokens(buildNvidiaTaskMessages({ ...context, compact: true }));
+    totals.gemini += estimatePayloadTokens(buildGeminiAgentPromptPayload(context));
+  }
+  return { totals, contexts: contexts.length };
+}
+
+export function computeFixtureCurrent(id: string, meta: FixtureMeta, run: ReplayRun): FixtureCurrent {
+  const quality = assessResultQuality({ task: run.task, steps: run.steps, answer: run.answer });
+  const { totals, contexts } = computePromptTokenTotals(run);
+  return {
+    id,
+    meta,
+    run,
+    endedWith: run.endedWith,
+    qualityStatus: quality.status,
+    qualityReasons: quality.reasons,
+    promptContexts: contexts,
+    promptTokens: totals,
+    parserOutcomes: replayParserCorpus(meta.parseFailures),
+  };
+}
+
+export function baselineEntryFromCurrent(current: FixtureCurrent): FixtureBaseline {
+  return {
+    endedWith: current.endedWith,
+    qualityStatus: current.qualityStatus,
+    promptContexts: current.promptContexts,
+    promptTokens: current.promptTokens,
+    parserOutcomes: current.parserOutcomes,
+  };
+}
+
+// ── IO ──
+
+function fixtureTracePath(fixturesDir: string, id: string) {
+  return join(fixturesDir, 'traces', `${id}.jsonl`);
+}
+
+function fixtureMetaPath(fixturesDir: string, id: string) {
+  return join(fixturesDir, 'traces', `${id}.meta.json`);
+}
+
+function baselinePath(fixturesDir: string) {
+  return join(fixturesDir, 'baseline.json');
+}
+
+export async function loadBaseline(fixturesDir: string): Promise<BaselineFile> {
+  try {
+    const raw = await readFile(baselinePath(fixturesDir), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && parsed.fixtures && typeof parsed.fixtures === 'object') {
+      return parsed;
+    }
+  } catch {
+    // 基线不存在或损坏都按空基线处理
+  }
+  return { updatedAt: '', fixtures: {} };
+}
+
+async function saveBaseline(fixturesDir: string, baseline: BaselineFile) {
+  await mkdir(fixturesDir, { recursive: true });
+  await writeFile(baselinePath(fixturesDir), `${JSON.stringify(baseline, null, 2)}\n`, 'utf8');
+}
+
+async function listFixtureIds(fixturesDir: string): Promise<string[]> {
+  try {
+    const files = await readdir(join(fixturesDir, 'traces'));
+    return files
+      .filter(file => file.endsWith('.jsonl'))
+      .map(file => file.slice(0, -'.jsonl'.length))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+async function loadFixture(fixturesDir: string, id: string): Promise<{ meta: FixtureMeta; run: ReplayRun }> {
+  const raw = await readFile(fixtureTracePath(fixturesDir, id), 'utf8');
+  const run = reconstructRunFromTrace(parseTraceLines(raw));
+  let meta: FixtureMeta | null = null;
+  try {
+    meta = JSON.parse(await readFile(fixtureMetaPath(fixturesDir, id), 'utf8'));
+  } catch {
+    meta = null;
+  }
+  if (!meta || typeof meta !== 'object') {
+    throw new Error(`夹具 ${id} 缺少 meta 文件（${fixtureMetaPath(fixturesDir, id)}）`);
+  }
+  return { meta, run };
+}
+
+// ── capture ──
+
+function defaultFixtureId(runId: string) {
+  return `fx-${runId.replace(/^run_/, '').replace(/_/g, '-')}`;
+}
+
+export async function captureFixture(cfg: CliConfig): Promise<{ id: string; run: ReplayRun }> {
+  const runId = cfg.runId!;
+  const events = await readTraceEvents(cfg.dataDir, runId);
+  if (!events.length) {
+    throw new Error(`在 ${join(cfg.dataDir, 'traces')} 下找不到 ${runId} 的 trace（或文件为空）`);
+  }
+
+  const run = reconstructRunFromTrace(events as any);
+  if (!run.task) throw new Error(`trace 缺少 run_meta.task，无法作为夹具（runId=${runId}）`);
+  if (!run.steps.length && !run.pendingObservation) {
+    throw new Error(`trace 未包含任何已执行步骤，无法作为夹具（runId=${runId}）`);
+  }
+  if (run.endedWith === 'incomplete') {
+    throw new Error(`run 未正常结束（无 done/error 事件，可能被取消或仍在运行），不适合作为夹具（runId=${runId}）`);
+  }
+
+  const id = cfg.fixtureId || defaultFixtureId(runId);
+  if (!/^[a-z0-9][a-z0-9-]*$/i.test(id)) {
+    throw new Error(`夹具 id 只允许字母数字与连字符: ${id}`);
+  }
+
+  const redactedEvents = (events as any[]).map(event => redactSensitiveData(event));
+  const redactedRun = reconstructRunFromTrace(redactedEvents as any);
+
+  const meta: FixtureMeta = {
+    id,
+    sourceRunId: runId,
+    capturedAt: new Date().toISOString(),
+    task: redactedRun.task,
+    tags: cfg.tags,
+    endedWith: redactedRun.endedWith,
+    stepCount: redactedRun.steps.length,
+    agentModels: redactedRun.agentModels,
+    parseFailures: redactedRun.parseFailures.map(({ step, model, rawOutput }) => ({ step, model, rawOutput })),
+    notes: '',
+  };
+
+  await mkdir(join(cfg.fixturesDir, 'traces'), { recursive: true });
+  const jsonl = redactedEvents.map(event => JSON.stringify(event)).join('\n');
+  await writeFile(fixtureTracePath(cfg.fixturesDir, id), `${jsonl}\n`, 'utf8');
+  await writeFile(fixtureMetaPath(cfg.fixturesDir, id), `${JSON.stringify(meta, null, 2)}\n`, 'utf8');
+
+  // 立即把该夹具的当前值写入基线，作为后续对比的锚点。
+  const current = computeFixtureCurrent(id, meta, redactedRun);
+  const baseline = await loadBaseline(cfg.fixturesDir);
+  baseline.fixtures[id] = baselineEntryFromCurrent(current);
+  baseline.updatedAt = new Date().toISOString();
+  await saveBaseline(cfg.fixturesDir, baseline);
+
+  return { id, run: redactedRun };
+}
+
+// ── 离线评测 ──
+
+interface OfflineEvalOutcome {
+  verdicts: FixtureVerdict[];
+  severity: Severity;
+  currents: FixtureCurrent[];
+}
+
+async function runOfflineEval(cfg: CliConfig): Promise<OfflineEvalOutcome> {
+  const ids = await listFixtureIds(cfg.fixturesDir);
+  const selected = cfg.onlyFixtures ? ids.filter(id => cfg.onlyFixtures!.includes(id)) : ids;
+  if (!selected.length) {
+    throw new Error(`夹具目录 ${join(cfg.fixturesDir, 'traces')} 为空，先用 capture 固化几个 run（bun scripts/trace-eval.ts capture <runId>）`);
+  }
+  if (cfg.onlyFixtures) {
+    const missing = cfg.onlyFixtures.filter(id => !ids.includes(id));
+    if (missing.length) throw new Error(`找不到指定夹具: ${missing.join(', ')}`);
+  }
+
+  const baseline = await loadBaseline(cfg.fixturesDir);
+  const verdicts: FixtureVerdict[] = [];
+  const currents: FixtureCurrent[] = [];
+  let severity: Severity = 'pass';
+
+  for (const id of selected) {
+    try {
+      const { meta, run } = await loadFixture(cfg.fixturesDir, id);
+      const current = computeFixtureCurrent(id, meta, run);
+      currents.push(current);
+      const verdict = evaluateFixtureAgainstBaseline(current, baseline.fixtures[id] ?? null, cfg);
+      verdicts.push(verdict);
+      severity = severityMax(severity, verdict.severity);
+    } catch (err: any) {
+      verdicts.push({
+        fixture: id,
+        severity: 'fail',
+        notes: [`评测异常: ${err?.message || err}`],
+        current: { endedWith: '?', qualityStatus: '?', promptTokens: { nvidia: 0, nvidiaCompact: 0, gemini: 0 }, promptContexts: 0, parserOutcomes: [] },
+        baseline: baseline.fixtures[id] ?? null,
+        drift: {},
+      });
+      severity = 'fail';
+    }
+  }
+
+  if (cfg.updateBaseline) {
+    const next: BaselineFile = { updatedAt: new Date().toISOString(), fixtures: { ...baseline.fixtures } };
+    for (const current of currents) {
+      next.fixtures[current.id] = baselineEntryFromCurrent(current);
+    }
+    await saveBaseline(cfg.fixturesDir, next);
+  }
+
+  return { verdicts, severity, currents };
+}
+
+// ── 报告与输出 ──
+
+const SEVERITY_ICON: Record<Severity, string> = { pass: '✅', warn: '⚠️', fail: '❌' };
+
+function printVerdicts(verdicts: FixtureVerdict[]) {
+  console.table(verdicts.map(verdict => ({
+    fixture: verdict.fixture,
+    verdict: `${SEVERITY_ICON[verdict.severity]} ${verdict.severity}`,
+    endedWith: verdict.current.endedWith,
+    quality: verdict.current.qualityStatus,
+    'nvidia tok': verdict.current.promptTokens.nvidia,
+    'Δnvidia%': verdict.drift.nvidia ?? '-',
+    'Δcompact%': verdict.drift.nvidiaCompact ?? '-',
+    'Δgemini%': verdict.drift.gemini ?? '-',
+    parser: verdict.current.parserOutcomes.join(',') || '-',
+  })));
+  for (const verdict of verdicts) {
+    for (const note of verdict.notes) {
+      console.log(`  ${SEVERITY_ICON[verdict.severity]} [${verdict.fixture}] ${note}`);
+    }
+  }
+}
+
+async function writeReportFile(cfg: CliConfig, payload: Record<string, unknown>): Promise<string> {
+  const dir = join(cfg.dataDir, 'eval-reports');
+  await mkdir(dir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const file = join(dir, `eval-${stamp}.json`);
+  await writeFile(file, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  return file;
+}
+
+// ── CLI ──
+
+export function parseArgs(argv: string[]): CliConfig {
+  const cfg: CliConfig = {
+    command: 'eval',
+    tags: [],
+    dataDir: './data',
+    fixturesDir: '',
+    onlyFixtures: null,
+    updateBaseline: false,
+    warnDrift: 10,
+    failDrift: 25,
+    writeReport: true,
+    live: false,
+    liveModels: null,
+    maxLiveSteps: 20,
+  };
+
+  const rest = [...argv];
+  if (rest[0] && !rest[0].startsWith('-')) {
+    const command = rest.shift()!;
+    if (command === 'capture') {
+      cfg.command = 'capture';
+      if (rest[0] && !rest[0].startsWith('-')) cfg.runId = rest.shift();
+      if (!cfg.runId) throw new Error('capture 需要 runId: bun scripts/trace-eval.ts capture <runId>');
+    } else {
+      throw new Error(`未知子命令: ${command}`);
+    }
+  }
+
+  while (rest.length) {
+    const arg = rest.shift()!;
+    switch (arg) {
+      case '--data-dir': cfg.dataDir = rest.shift() || cfg.dataDir; break;
+      case '--fixtures-dir': cfg.fixturesDir = rest.shift() || ''; break;
+      case '--fixtures': cfg.onlyFixtures = splitList(rest.shift()); break;
+      case '--id': cfg.fixtureId = rest.shift(); break;
+      case '--tags': cfg.tags = splitList(rest.shift()) || []; break;
+      case '--update-baseline': cfg.updateBaseline = true; break;
+      case '--warn-drift': cfg.warnDrift = numberArg(rest.shift(), '--warn-drift'); break;
+      case '--fail-drift': cfg.failDrift = numberArg(rest.shift(), '--fail-drift'); break;
+      case '--no-report': cfg.writeReport = false; break;
+      case '--live': cfg.live = true; break;
+      case '--models': cfg.liveModels = splitList(rest.shift()); break;
+      case '--max-steps': cfg.maxLiveSteps = numberArg(rest.shift(), '--max-steps'); break;
+      default: throw new Error(`未知参数: ${arg}`);
+    }
+  }
+
+  cfg.dataDir = resolve(cfg.dataDir);
+  cfg.fixturesDir = resolve(cfg.fixturesDir || join(cfg.dataDir, 'eval-fixtures'));
+  return cfg;
+}
+
+function splitList(value?: string): string[] | null {
+  if (!value) return null;
+  const items = value.split(',').map(item => item.trim()).filter(Boolean);
+  return items.length ? items : null;
+}
+
+function numberArg(value: string | undefined, flag: string): number {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0) throw new Error(`${flag} 需要一个非负数字，收到: ${value}`);
+  return num;
+}
+
+async function initDeterministicConfig() {
+  // 隔离本地 data/config.json：prompt 构建读 configStore（如 Chrome MCP/通用 MCP 开关），
+  // 指向临时空目录后仅剩 schema 默认值，保证跨机器、跨本地配置可复现。
+  const dir = await mkdtemp(join(tmpdir(), 'trace-eval-config-'));
+  await configStore.init(dir);
+}
+
+async function main() {
+  const cfg = parseArgs(process.argv.slice(2));
+
+  if (cfg.command === 'capture') {
+    const { id, run } = await captureFixture(cfg);
+    console.log(`✅ 已捕获夹具 ${id}`);
+    console.log(`   来源 run: ${cfg.runId}（${run.endedWith}，${run.steps.length} 步，解析失败语料 ${run.parseFailures.length} 条）`);
+    console.log(`   task: ${run.task}`);
+    console.log(`   文件: ${fixtureTracePath(cfg.fixturesDir, id)}`);
+    console.log(`   基线已更新: ${baselinePath(cfg.fixturesDir)}`);
+    console.log('   注意: 夹具含真实任务内容（已做密钥脱敏），保存在本地 data/ 下，不会进 git。');
+    return;
+  }
+
+  await initDeterministicConfig();
+
+  const offline = await runOfflineEval(cfg);
+  console.log(`\ntrace-eval 离线评测（${offline.verdicts.length} 个夹具，warn>${cfg.warnDrift}% fail>${cfg.failDrift}%）\n`);
+  printVerdicts(offline.verdicts);
+
+  let liveSection: Record<string, unknown> | null = null;
+  if (cfg.live) {
+    const { runLiveEval } = await import('./trace-eval-live.ts');
+    liveSection = await runLiveEval(cfg, offline.currents);
+  }
+
+  if (cfg.updateBaseline) {
+    console.log(`\n✅ 基线已更新: ${baselinePath(cfg.fixturesDir)}`);
+  }
+
+  const summary = {
+    pass: offline.verdicts.filter(v => v.severity === 'pass').length,
+    warn: offline.verdicts.filter(v => v.severity === 'warn').length,
+    fail: offline.verdicts.filter(v => v.severity === 'fail').length,
+    verdict: offline.severity,
+  };
+
+  if (cfg.writeReport) {
+    const file = await writeReportFile(cfg, {
+      mode: cfg.live ? 'offline+live' : 'offline',
+      finishedAt: new Date().toISOString(),
+      dataDir: cfg.dataDir,
+      fixturesDir: cfg.fixturesDir,
+      thresholds: { warnDrift: cfg.warnDrift, failDrift: cfg.failDrift },
+      summary,
+      rows: offline.verdicts,
+      ...(liveSection ? { live: liveSection } : {}),
+    });
+    console.log(`\n报告: ${file}`);
+  }
+
+  console.log(`\n${SEVERITY_ICON[offline.severity]} 总判定: ${offline.severity}（pass=${summary.pass} warn=${summary.warn} fail=${summary.fail}）`);
+  process.exitCode = offline.severity === 'fail' ? 2 : offline.severity === 'warn' ? 1 : 0;
+}
+
+if (import.meta.main) {
+  main().catch(err => {
+    console.error(`❌ trace-eval 执行异常: ${err?.message || err}`);
+    process.exitCode = 2;
+  });
+}

--- a/test/trace-eval.test.ts
+++ b/test/trace-eval.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareParserOutcomes,
+  driftPercent,
+  evaluateFixtureAgainstBaseline,
+  replayParserCorpus,
+  severityMax,
+  type FixtureBaseline,
+  type FixtureCurrent,
+} from '../scripts/trace-eval.ts';
+
+const THRESHOLDS = { warnDrift: 10, failDrift: 25 };
+
+function makeCurrent(overrides: Partial<FixtureCurrent> = {}): FixtureCurrent {
+  return {
+    id: 'fx-demo',
+    meta: {} as any,
+    run: {} as any,
+    endedWith: 'done',
+    qualityStatus: 'done',
+    qualityReasons: [],
+    promptContexts: 3,
+    promptTokens: { nvidia: 1000, nvidiaCompact: 500, gemini: 800 },
+    parserOutcomes: [],
+    ...overrides,
+  };
+}
+
+function makeBaseline(overrides: Partial<FixtureBaseline> = {}): FixtureBaseline {
+  return {
+    endedWith: 'done',
+    qualityStatus: 'done',
+    promptContexts: 3,
+    promptTokens: { nvidia: 1000, nvidiaCompact: 500, gemini: 800 },
+    parserOutcomes: [],
+    ...overrides,
+  };
+}
+
+describe('severityMax / driftPercent', () => {
+  it('orders severities pass < warn < fail', () => {
+    expect(severityMax('pass', 'warn')).toBe('warn');
+    expect(severityMax('fail', 'warn')).toBe('fail');
+    expect(severityMax('pass', 'pass')).toBe('pass');
+  });
+
+  it('computes symmetric percent drift against the baseline', () => {
+    expect(driftPercent(110, 100)).toBeCloseTo(10);
+    expect(driftPercent(90, 100)).toBeCloseTo(10);
+    expect(driftPercent(0, 0)).toBe(0);
+    expect(driftPercent(5, 0)).toBe(100);
+  });
+});
+
+describe('compareParserOutcomes', () => {
+  it('passes when outcomes are identical', () => {
+    const { severity, notes } = compareParserOutcomes(['parse_fail'], ['parse_fail']);
+    expect(severity).toBe('pass');
+    expect(notes).toEqual([]);
+  });
+
+  it('marks fail→ok transitions as improved (warn, not regression)', () => {
+    const { severity, notes } = compareParserOutcomes(['parse_ok'], ['parse_fail']);
+    expect(severity).toBe('warn');
+    expect(notes[0]).toContain('improved');
+  });
+
+  it('fails on ok→fail regressions', () => {
+    const { severity, notes } = compareParserOutcomes(['parse_fail'], ['parse_ok']);
+    expect(severity).toBe('fail');
+    expect(notes[0]).toContain('回归');
+  });
+
+  it('fails when the corpus length changed', () => {
+    const { severity } = compareParserOutcomes(['parse_ok'], []);
+    expect(severity).toBe('fail');
+  });
+});
+
+describe('evaluateFixtureAgainstBaseline', () => {
+  it('warns for fixtures missing from the baseline', () => {
+    const verdict = evaluateFixtureAgainstBaseline(makeCurrent(), null, THRESHOLDS);
+    expect(verdict.severity).toBe('warn');
+    expect(verdict.notes[0]).toContain('--update-baseline');
+  });
+
+  it('passes when everything matches', () => {
+    const verdict = evaluateFixtureAgainstBaseline(makeCurrent(), makeBaseline(), THRESHOLDS);
+    expect(verdict.severity).toBe('pass');
+    expect(verdict.notes).toEqual([]);
+    expect(verdict.drift.nvidia).toBe(0);
+  });
+
+  it('fails when the re-scored quality status changed', () => {
+    const verdict = evaluateFixtureAgainstBaseline(
+      makeCurrent({ qualityStatus: 'done_degraded', qualityReasons: ['有失败步骤'] }),
+      makeBaseline(),
+      THRESHOLDS,
+    );
+    expect(verdict.severity).toBe('fail');
+    expect(verdict.notes.some(note => note.includes('质量重打分变化'))).toBe(true);
+  });
+
+  it('fails when endedWith changed (reconstruction drift)', () => {
+    const verdict = evaluateFixtureAgainstBaseline(makeCurrent({ endedWith: 'error' }), makeBaseline(), THRESHOLDS);
+    expect(verdict.severity).toBe('fail');
+  });
+
+  it('warns between warn and fail drift thresholds, fails beyond', () => {
+    const warned = evaluateFixtureAgainstBaseline(
+      makeCurrent({ promptTokens: { nvidia: 1150, nvidiaCompact: 500, gemini: 800 } }),
+      makeBaseline(),
+      THRESHOLDS,
+    );
+    expect(warned.severity).toBe('warn');
+    expect(warned.drift.nvidia).toBeCloseTo(15);
+
+    const failed = evaluateFixtureAgainstBaseline(
+      makeCurrent({ promptTokens: { nvidia: 1300, nvidiaCompact: 500, gemini: 800 } }),
+      makeBaseline(),
+      THRESHOLDS,
+    );
+    expect(failed.severity).toBe('fail');
+  });
+
+  it('fails when the number of prompt contexts changed', () => {
+    const verdict = evaluateFixtureAgainstBaseline(makeCurrent({ promptContexts: 4 }), makeBaseline(), THRESHOLDS);
+    expect(verdict.severity).toBe('fail');
+    expect(verdict.notes.some(note => note.includes('构建点数量'))).toBe(true);
+  });
+});
+
+describe('replayParserCorpus', () => {
+  it('classifies a valid decision as parse_ok', () => {
+    const raw = JSON.stringify({
+      rationale: '搜索',
+      action: { tool: 'search', type: 'web_search', query: '天气', maxResults: 5 },
+    });
+    expect(replayParserCorpus([{ model: 'nvidia/test', rawOutput: raw }])).toEqual(['parse_ok']);
+  });
+
+  it('classifies truncated JSON as parse_fail', () => {
+    const raw = '{"rationale":"r","action":{"tool":"core","type":"finish"';
+    expect(replayParserCorpus([{ rawOutput: raw }])).toEqual(['parse_fail']);
+  });
+
+  it('classifies parseable-but-invalid actions as normalize_fail', () => {
+    const raw = JSON.stringify({ rationale: 'r', action: { tool: 'no-such-tool', type: 'nope' } });
+    const [outcome] = replayParserCorpus([{ rawOutput: raw }]);
+    expect(['normalize_fail', 'parse_fail']).toContain(outcome);
+    expect(outcome).not.toBe('parse_ok');
+  });
+});

--- a/test/trace-replay.test.ts
+++ b/test/trace-replay.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStepPromptContext,
+  extractRawOutputFromError,
+  listPromptContexts,
+  parseTraceLines,
+  reconstructRunFromTrace,
+} from '../agent/core/trace-replay.ts';
+
+function line(event: Record<string, unknown>) {
+  return JSON.stringify(event);
+}
+
+const RUN_META = {
+  type: 'run_meta',
+  runId: 'run_test1_aaaa',
+  startedAt: 1000,
+  task: '查询今天苏州天气',
+  agentModels: ['nvidia/test-model'],
+  strategy: 'race',
+};
+
+function doneRunLines() {
+  return [
+    line(RUN_META),
+    line({ type: 'step', step: 1, stage: 'observe', observation: { title: 'Desktop', url: '' } }),
+    line({
+      type: 'model_plan', stage: 'success', step: 1, model: 'nvidia/test-model',
+      rationale: '搜索天气', action: { tool: 'search', type: 'web_search', query: '苏州天气', maxResults: 10 },
+    }),
+    line({
+      type: 'step', step: 1, stage: 'action', rationale: '搜索天气',
+      action: { tool: 'search', type: 'web_search', query: '苏州天气', maxResults: 10 },
+    }),
+    line({ type: 'step', step: 1, stage: 'result', result: 'web_search 结果: 晴 30 度', resultStatus: 'success', resultError: null }),
+    line({ type: 'step', step: 2, stage: 'observe', observation: { title: '天气页', url: 'https://weather.example.com/suzhou' } }),
+    line({
+      type: 'step', step: 2, stage: 'action', rationale: '完成',
+      action: { tool: 'core', type: 'finish', answer: '今天苏州晴，30 度' },
+    }),
+    // finish 步没有 result 事件（与 runtime 行为一致）
+    line({ type: 'done', answer: '今天苏州晴，30 度', quality: { status: 'done', reasons: [] } }),
+  ].join('\n');
+}
+
+describe('parseTraceLines', () => {
+  it('skips blank and malformed lines', () => {
+    const events = parseTraceLines('\n{"type":"status","status":"ok"}\n{bad json}\n\n{"type":"error","error":"x"}\n');
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe('status');
+    expect(events[1].type).toBe('error');
+  });
+
+  it('tolerates empty input', () => {
+    expect(parseTraceLines('')).toEqual([]);
+  });
+});
+
+describe('extractRawOutputFromError', () => {
+  it('decodes the JSON-encoded raw output tail', () => {
+    const raw = '{"rationale":"r","action":{"tool":"core","type":"finish"';
+    const error = `模型动作解析失败: 解析失败; 原始输出=${JSON.stringify(raw)}`;
+    expect(extractRawOutputFromError(error)).toBe(raw);
+  });
+
+  it('returns the tail as-is when not valid JSON', () => {
+    expect(extractRawOutputFromError('解析失败; 原始输出=plain text')).toBe('plain text');
+  });
+
+  it('returns null when the marker is absent', () => {
+    expect(extractRawOutputFromError('模型上下文太小')).toBeNull();
+    expect(extractRawOutputFromError(undefined)).toBeNull();
+  });
+});
+
+describe('reconstructRunFromTrace', () => {
+  it('rebuilds a completed run with meta, steps, answer and recorded quality', () => {
+    const run = reconstructRunFromTrace(parseTraceLines(doneRunLines()));
+
+    expect(run.runId).toBe('run_test1_aaaa');
+    expect(run.task).toBe('查询今天苏州天气');
+    expect(run.agentModels).toEqual(['nvidia/test-model']);
+    expect(run.strategy).toBe('race');
+    expect(run.endedWith).toBe('done');
+    expect(run.answer).toBe('今天苏州晴，30 度');
+    expect(run.recordedQuality?.status).toBe('done');
+    expect(run.parseFailures).toEqual([]);
+    expect(run.pendingObservation).toBeNull();
+
+    expect(run.steps).toHaveLength(2);
+    expect(run.steps[0]).toMatchObject({
+      step: 1,
+      rationale: '搜索天气',
+      action: { tool: 'search', type: 'web_search' },
+      result: 'web_search 结果: 晴 30 度',
+      resultStatus: 'success',
+    });
+    expect(run.steps[0].observation).toMatchObject({ title: 'Desktop' });
+    // finish 步：有 action、无 result
+    expect(run.steps[1].action.type).toBe('finish');
+    expect(run.steps[1].result).toBeUndefined();
+    // url/title 按 runtime 口径从 observation 推导
+    expect(run.steps[1].url).toBe('https://weather.example.com/suzhou');
+    expect(run.steps[1].title).toBe('天气页');
+  });
+
+  it('rebuilds an error-terminated run and extracts the parse-failure corpus', () => {
+    const raw = '{"rationale":"回答","action":{"tool":"core","type":"finish","answer":"截断';
+    const plannerError = `解析失败; 原始输出=${JSON.stringify(raw)}`;
+    const lines = [
+      line(RUN_META),
+      line({ type: 'step', step: 1, stage: 'observe', observation: { title: 'Desktop' } }),
+      line({
+        type: 'step', step: 1, stage: 'action', rationale: '搜索',
+        action: { tool: 'search', type: 'web_search', query: 'x', maxResults: 5 },
+      }),
+      line({ type: 'step', step: 1, stage: 'result', result: '结果文本', resultStatus: 'success' }),
+      line({ type: 'step', step: 2, stage: 'observe', observation: { title: '页面', url: 'https://a.example.com' } }),
+      line({ type: 'model_plan', stage: 'failed', step: 2, model: 'nvidia/test-model', error: plannerError }),
+      // 结尾 error 事件复读同一段原文，应被去重
+      line({ type: 'error', error: `模型动作解析失败: ${plannerError}` }),
+    ].join('\n');
+
+    const run = reconstructRunFromTrace(parseTraceLines(lines));
+
+    expect(run.endedWith).toBe('error');
+    expect(run.answer).toBe('');
+    expect(run.steps).toHaveLength(1);
+    // 已 observe 未执行的尾步保留为 pendingObservation，供 prompt 构建
+    expect(run.pendingObservation).toMatchObject({ step: 2, observation: { title: '页面' } });
+    expect(run.parseFailures).toHaveLength(1);
+    expect(run.parseFailures[0]).toMatchObject({ step: 2, model: 'nvidia/test-model', rawOutput: raw });
+  });
+
+  it('keeps rejected steps that carry a result but no action event', () => {
+    const lines = [
+      line(RUN_META),
+      line({ type: 'step', step: 1, stage: 'observe', observation: {} }),
+      line({ type: 'step', step: 1, stage: 'result', result: '操作未获批准', resultStatus: 'rejected', resultError: '操作未获批准' }),
+    ].join('\n');
+
+    const run = reconstructRunFromTrace(parseTraceLines(lines));
+
+    expect(run.endedWith).toBe('incomplete');
+    expect(run.steps).toHaveLength(1);
+    expect(run.steps[0].resultStatus).toBe('rejected');
+    expect(run.steps[0].action).toBeUndefined();
+  });
+
+  it('lets later events win for the same step number after a rollback replay', () => {
+    const lines = [
+      line(RUN_META),
+      line({ type: 'step', step: 1, stage: 'observe', observation: { title: '旧观察' } }),
+      line({ type: 'step', step: 1, stage: 'action', rationale: '旧动作', action: { tool: 'browser', type: 'get_page_content' } }),
+      line({ type: 'step', step: 1, stage: 'result', result: '旧结果', resultStatus: 'failed' }),
+      line({ type: 'rollback', targetStep: 1, message: '回滚' }),
+      line({ type: 'step', step: 1, stage: 'observe', observation: { title: '新观察' } }),
+      line({ type: 'step', step: 1, stage: 'action', rationale: '新动作', action: { tool: 'browser', type: 'navigate', url: 'https://b.example.com' } }),
+      line({ type: 'step', step: 1, stage: 'result', result: '新结果', resultStatus: 'success' }),
+    ].join('\n');
+
+    const run = reconstructRunFromTrace(parseTraceLines(lines));
+
+    expect(run.steps).toHaveLength(1);
+    expect(run.steps[0]).toMatchObject({ rationale: '新动作', result: '新结果', resultStatus: 'success' });
+    expect(run.steps[0].url).toBe('https://b.example.com');
+  });
+});
+
+describe('buildStepPromptContext / listPromptContexts', () => {
+  it('rebuilds the decide-time context for each executed step', () => {
+    const run = reconstructRunFromTrace(parseTraceLines(doneRunLines()));
+
+    const first = buildStepPromptContext(run, 0);
+    expect(first).toMatchObject({ task: '查询今天苏州天气', step: 1, history: [] });
+    expect(first.observation).toMatchObject({ title: 'Desktop' });
+
+    const second = buildStepPromptContext(run, 1);
+    expect(second.step).toBe(2);
+    expect(second.history).toHaveLength(1);
+    expect(second.history[0].action.tool).toBe('search');
+    expect(second.observation).toMatchObject({ title: '天气页' });
+  });
+
+  it('falls back to the previous observation when a step skipped observe', () => {
+    const lines = [
+      line(RUN_META),
+      line({ type: 'step', step: 1, stage: 'observe', observation: { title: '第一步观察' } }),
+      line({ type: 'step', step: 1, stage: 'action', rationale: 'a', action: { tool: 'browser', type: 'get_page_content' } }),
+      line({ type: 'step', step: 1, stage: 'result', result: 'r1', resultStatus: 'success' }),
+      // 第 2 步没有 observe 事件
+      line({ type: 'step', step: 2, stage: 'action', rationale: 'b', action: { tool: 'core', type: 'finish', answer: 'ok' } }),
+    ].join('\n');
+
+    const run = reconstructRunFromTrace(parseTraceLines(lines));
+    const context = buildStepPromptContext(run, 1);
+    expect(context.observation).toMatchObject({ title: '第一步观察' });
+  });
+
+  it('appends the pending tail observation as an extra prompt context', () => {
+    const lines = [
+      line(RUN_META),
+      line({ type: 'step', step: 1, stage: 'observe', observation: { title: 'o1' } }),
+      line({ type: 'step', step: 1, stage: 'action', rationale: 'a', action: { tool: 'browser', type: 'get_page_content' } }),
+      line({ type: 'step', step: 1, stage: 'result', result: 'r', resultStatus: 'success' }),
+      line({ type: 'step', step: 2, stage: 'observe', observation: { title: 'o2' } }),
+      line({ type: 'error', error: '模型动作解析失败' }),
+    ].join('\n');
+
+    const run = reconstructRunFromTrace(parseTraceLines(lines));
+    const contexts = listPromptContexts(run);
+    expect(contexts).toHaveLength(2);
+    expect(contexts[1]).toMatchObject({ step: 2 });
+    expect(contexts[1].history).toHaveLength(1);
+    expect(contexts[1].observation).toMatchObject({ title: 'o2' });
+  });
+
+  it('throws on an out-of-range step index', () => {
+    const run = reconstructRunFromTrace(parseTraceLines(doneRunLines()));
+    expect(() => buildStepPromptContext(run, 99)).toThrow(/越界/);
+  });
+});


### PR DESCRIPTION
## 动机

改 prompt(`agent/core/prompts.ts`)、调打分规则或换模型后,此前只能靠 smoke(真实跑 Agent,烧 API、慢、不可复现)判断“变好还是变坏”。仓库已有录制 trace、纯函数打分器 `assessResultQuality`、可离线调用的 prompt 构建函数——本 PR 补上“回放夹具 + 打分对比”的评测装置,让 prompt/planner 迭代能零成本量化,smoke 退居上线前验证。

## 改动

- **`agent/core/trace-replay.ts`**(新,纯函数库):把 `data/traces/<runId>.jsonl` 事件流重建为 `ReplayRun`(任务 / 步骤 / 答案 / 录制质量 / 解析失败语料)。重建口径与 `runtime.ts` 组装 history 严格一致:finish 步无 result、被拒步无 action、url/title 同规则推导、rollback 后到者胜。
- **`scripts/trace-eval.ts`**(新,CLI):
  - `capture <runId>`:读 trace → 校验可重建 → `redactSensitiveData` 脱敏 → 固化为夹具 + 写基线。
  - 默认离线评测(零 API):四维度——重建完整性 / 质量重打分 / 三套 prompt token 漂移(nvidia / compact / gemini)/ 解析器语料回归;与 `baseline.json` 对比,`console.table` + JSON 报告,退出码 0/1/2(同 smoke)。
  - flags:`--update-baseline` / `--warn-drift` / `--fail-drift` / `--fixtures` / `--no-report`。
- **`scripts/trace-eval-live.ts`**(新):`--live` 决策回放——用真实模型对录制步骤逐步重新决策(走 `provider.agentPlan`,与 runtime 同路径),与录制动作对比(解析成功率 / tool / type 匹配 / finish 时机 / token 用量),**不执行任何工具、不写任何状态**,`--max-steps` 护栏。
- 新增 28 个单测(`test/trace-replay.test.ts` / `test/trace-eval.test.ts`)。
- npm scripts:`eval` / `eval:capture` / `eval:live`;`CLAUDE.md` 补命令与说明。

## 设计要点

- 夹具与基线存本地 `data/eval-fixtures/`(gitignored,真实任务内容不入库);报告落 `data/eval-reports/`。
- 离线评测把 `configStore` 钉到临时空目录,隔离本地 `data/config.json` 对 prompt 构建的影响,保证跨机器可复现。
- 日常工作流:改代码前 `npm run eval` 确认全绿 → 改代码 → 再跑看 delta → 接受则 `npm run eval -- --update-baseline`。

## 验证

- `npm run build`(tsc 全量 + client 构建)、`npm test`(**363 passed**)、`npm run lint` 全绿。
- 回归检出演练:临时改 prompt 历史截断 → 多步夹具 33–64% token 漂移标 fail;临时改打分阈值 → `done -> done_unverified` 被精准检出。两处改动均已还原。
- `--live` 小样真实回放通过(nemotron-3-ultra-550b,6 步)。

## 已知限制

- 5 月前的旧 trace 无 `run_meta`,不能作夹具;trace 未录会话上下文,夹具宜选单轮任务。
- 解析器语料只覆盖历史解析失败样本(成功原文未落 trace)。
- live 回放每步喂录制 history,衡量的是“同起点单步决策”,非自由重跑。
