### PR TITLE
feat(browser): http_fetch 抓取即提炼(per-fetch distill)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ LOG_LEVEL=info
 # AGENT_MACOS_HELPER_PATH=/absolute/path/to/helper
 # SAGENT_SHELL=/bin/zsh
 
+# Optional: distill http_fetch page text with a cheap OpenAI-compatible model before it
+# enters agent history — cuts prompt-token growth on multi-source browsing tasks.
+# Empty/unset = disabled (no behavior change).
+# DISTILL_MODEL=
+
 # Agent behavior, profiles, tools and MCP servers are stored in data/config.json
 # and managed from the Settings UI. Legacy AGENT_* / CHROME_MCP_*
 # variables are still read for compatibility and emit a migration warning.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -60,6 +60,7 @@ Non-loopback `HOST` values require a token of at least 16 characters.
 | `SAGENT_SHELL` | Shell used by confirmed terminal actions |
 | `BUN_BIN` | Bun executable used by workers |
 | `SANDBOX_EXEC` | macOS sandbox executable override |
+| `DISTILL_MODEL` | Cheap OpenAI-compatible model that distills `http_fetch` page text before it enters agent history; cuts prompt-token growth on multi-source browsing. Empty/unset = disabled |
 
 ## Structured configuration
 

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -31,6 +31,7 @@ import { createActionRouter } from '../core/router.ts';
 import { runAgentRuntime } from '../core/runtime.ts';
 import { createAgentAuthorizer } from '../policy/approvals.ts';
 import { executeBrowserAction } from '../tools/browser/execute.ts';
+import { distillFetchContent } from '../tools/browser/distill.ts';
 import { executeFsAction } from '../tools/fs/execute.ts';
 import { executeSearchAction } from '../tools/search/execute.ts';
 import { executeVisionAction } from '../tools/vision/execute.ts';
@@ -63,6 +64,7 @@ interface DesktopAgentRunnerConfig {
   approvalStore: Pick<ApprovalStore, 'request'>;
   checkpointDir?: string;
   visionModel: string;
+  distillModel?: string;
   modelTimeoutMs?: number;
   staggerDelayMs?: number;
   batchSize?: number;
@@ -79,6 +81,7 @@ export function createDesktopAgentRunner({
   approvalStore,
   checkpointDir,
   visionModel,
+  distillModel = '',
   modelTimeoutMs = DEFAULT_MODEL_TIMEOUT_MS,
   staggerDelayMs = 0,
   batchSize = 1,
@@ -121,13 +124,26 @@ export function createDesktopAgentRunner({
         return action.answer || '任务已完成';
       },
       browser: async (state, action, context) => {
-        return withBrowserSessionRecovery(state, state.onEvent, (session, recoveryAttempt) => (
+        const result = await withBrowserSessionRecovery(state, state.onEvent, (session, recoveryAttempt) => (
           executeBrowserAction(session.view, action, { signal: state.cancelSignal, recoveryAttempt })
         ), {
           step: context?.step,
           actionType: action.type,
           url: 'url' in action ? action.url : ('urls' in action ? action.urls?.[0] : null),
         });
+        // http_fetch 抓取即提炼:长正文进 history 前用便宜模型以 task 为锚压缩(保留来源 URL),
+        // 避免后续每步 prompt 平方级膨胀。distillModel 未配置时 distill 内部直接原样返回。
+        if (action.type === 'http_fetch' && typeof result === 'string' && distillModel && openai_client) {
+          return distillFetchContent({
+            text: result,
+            url: action.url,
+            task: context?.task,
+            client: openai_client as never,
+            model: distillModel,
+            signal: state.cancelSignal,
+          });
+        }
+        return result;
       },
       fs: async (state, action) => executeFsAction(action, { cwd: state.projectRoot, dataDir: state.dataDir, signal: state.cancelSignal }),
       search: async (state, action) => executeSearchAction(action, { signal: state.cancelSignal }),

--- a/agent/tools/browser/distill.ts
+++ b/agent/tools/browser/distill.ts
@@ -1,0 +1,96 @@
+/**
+ * http_fetch 抓取即提炼(per-fetch distill)
+ *
+ * http_fetch 抓来的网页正文整段进 history,会让后续每步 prompt 平方级膨胀。
+ * 这里在正文进入 history 前,用一个便宜模型以 task 为锚提炼成要点,大幅压缩体积,
+ * 同时**强制保留来源 URL**——result-quality 的官方来源判定与 appendHttpFetchReferences
+ * 都从 result 文本里提 URL,丢了会破坏打分与引用。
+ *
+ * 纯增量、默认关闭:未配置 distillModel(client/model 为空)或正文短于阈值时原样返回;
+ * 提炼失败/超时回退原文,绝不抛错阻断主流程(取消信号例外,需向上传播)。
+ */
+
+import { log } from '../../../helpers/logger.ts';
+
+export const DEFAULT_DISTILL_MODEL = ''; // 默认空 = 关闭提炼
+
+// 与 result-quality.ts 的 urlsFromText 同口径,避免把中文标点/右括号吞进 URL。
+const URL_RE = /https?:\/\/[^\s)\]"'，。]+/g;
+
+interface ChatCompletionClient {
+  chat: { completions: { create: (body: any, options?: any) => Promise<any> } };
+}
+
+export interface DistillOptions {
+  text: string;
+  url?: string;
+  task?: string;
+  client?: ChatCompletionClient | null;
+  model?: string;
+  signal?: AbortSignal;
+  /** 正文短于此(字符)直接返回,不提炼。 */
+  threshold?: number;
+  /** 提炼输入正文的上限,过长先截断。 */
+  maxChars?: number;
+}
+
+export async function distillFetchContent({
+  text,
+  url,
+  task,
+  client,
+  model,
+  signal,
+  threshold = 1200,
+  maxChars = 24000,
+}: DistillOptions): Promise<string> {
+  const original = String(text ?? '');
+
+  // 未配置 / 短文 → 原样返回(纯增量,默认不改变行为)
+  if (!client || !model || original.length < threshold) return original;
+
+  // 收集必须保留的来源 URL:主 URL + 正文内所有 URL
+  const sourceUrls = new Set<string>();
+  if (url) sourceUrls.add(url);
+  for (const match of original.matchAll(URL_RE)) sourceUrls.add(match[0]);
+
+  try {
+    const response = await client.chat.completions.create(
+      {
+        model,
+        messages: [{ role: 'user', content: buildDistillPrompt(task, original, maxChars) }],
+        temperature: 0.1,
+        max_tokens: 600,
+      },
+      signal ? { signal } : undefined,
+    );
+    const distilled = response?.choices?.[0]?.message?.content?.trim();
+    if (!distilled) return original; // 空输出 → 回退原文
+    return ensureSourceUrls(distilled, sourceUrls);
+  } catch (err: any) {
+    // 取消信号必须向上传播,否则取消后仍返回原文让主循环继续
+    if (signal?.aborted) throw err;
+    log.warn(`[Distill] 提炼失败,回退原文: ${err?.message || err}`);
+    return original;
+  }
+}
+
+function buildDistillPrompt(task: string | undefined, text: string, maxChars: number): string {
+  const body = text.length > maxChars ? `${text.slice(0, maxChars)}\n...(正文过长已截断)` : text;
+  return [
+    task ? `任务:${task}` : '',
+    '从以下网页正文中提炼与任务直接相关的事实、数字、时间和结论,用简洁中文分条列出。',
+    '必须原样保留正文中出现的所有来源 URL(http/https 开头),不得改写或省略。',
+    '正文没有与任务相关的信息时,直接说明"正文无相关信息"。',
+    '',
+    body,
+  ].filter(Boolean).join('\n');
+}
+
+// 提炼可能丢弃 URL,补回缺失的来源,保证 result-quality 的官方来源判定与引用不失效。
+function ensureSourceUrls(distilled: string, sourceUrls: Set<string>): string {
+  const present = new Set(Array.from(distilled.matchAll(URL_RE)).map(match => match[0]));
+  const missing = [...sourceUrls].filter(sourceUrl => !present.has(sourceUrl));
+  if (!missing.length) return distilled;
+  return `${distilled}\n来源: ${missing.join(' ')}`;
+}

--- a/agent/worker/agent-worker.ts
+++ b/agent/worker/agent-worker.ts
@@ -108,6 +108,7 @@ async function main() {
   const { initLlmLogger, flushLlmLogs } = await import('../core/llm-logger.ts');
   const { configStore } = await import('../core/config-store.ts');
   const { DEFAULT_VISION_MODEL } = await import('../tools/vision/execute.ts');
+  const { DEFAULT_DISTILL_MODEL } = await import('../tools/browser/distill.ts');
   const { initWebViewDataStore } = await import('../tools/browser/webview-session.ts');
   flushLlmLogsBeforeExit = flushLlmLogs;
 
@@ -134,6 +135,7 @@ async function main() {
     approvalStore,
     checkpointDir: payload.checkpointDir || memoryDir,
     visionModel: payload.visionModel || process.env.VISION_MODEL || DEFAULT_VISION_MODEL,
+    distillModel: payload.distillModel || process.env.DISTILL_MODEL || DEFAULT_DISTILL_MODEL,
   });
 
   const checkpointWriter = {

--- a/agent/worker/runner.ts
+++ b/agent/worker/runner.ts
@@ -124,6 +124,7 @@ export function createSandboxedWorkerAgentRunner({
   approvalStore,
   runStore,
   visionModel,
+  distillModel = '',
   sandbox = true,
   sandboxFile = path.join(REPO_ROOT, 'sandbox.sb'),
   workerFile = path.join(REPO_ROOT, 'agent/worker/agent-worker.ts'),
@@ -134,6 +135,7 @@ export function createSandboxedWorkerAgentRunner({
   approvalStore: any;
   runStore?: any;
   visionModel: string;
+  distillModel?: string;
   sandbox?: boolean;
   sandboxFile?: string;
   workerFile?: string;
@@ -327,6 +329,7 @@ export function createSandboxedWorkerAgentRunner({
         checkpointDir: dataDir,
         modelConfig,
         visionModel,
+        distillModel,
       },
     });
 

--- a/server.ts
+++ b/server.ts
@@ -27,6 +27,7 @@ import { flushLlmLogs, initLlmLogger } from './agent/core/llm-logger.ts';
 import { createDesktopAgentRunner } from './agent/desktop/agent.ts';
 import { createSandboxedWorkerAgentRunner, getWorkerCancelDelays } from './agent/worker/runner.ts';
 import { DEFAULT_VISION_MODEL } from './agent/tools/vision/execute.ts';
+import { DEFAULT_DISTILL_MODEL } from './agent/tools/browser/distill.ts';
 import { createClients, deriveProviderName } from './agent/core/ai-client.ts';
 import { createProviderRegistry } from './agent/core/providers/registry.ts';
 import { initWebViewDataStore } from './agent/tools/browser/webview-session.ts';
@@ -82,6 +83,7 @@ const projectStore = createProjectStore(MEMORY_DIR);
 await projectStore.init();
 
 const VISION_MODEL = (configStore.tools().vision?.model || process.env.VISION_MODEL || DEFAULT_VISION_MODEL).trim();
+const DISTILL_MODEL = (process.env.DISTILL_MODEL || DEFAULT_DISTILL_MODEL).trim();
 const AGENT_SANDBOXED_WORKERS = executionConfig.sandboxedWorkers;
 const AGENT_WORKER_SANDBOX = executionConfig.workerSandbox;
 const agentRunStore = createAgentRunStore();
@@ -101,6 +103,7 @@ const directRunDesktopAgent = createDesktopAgentRunner({
   approvalStore,
   checkpointDir: CHECKPOINT_DIR,
   visionModel: VISION_MODEL,
+  distillModel: DISTILL_MODEL,
 });
 const runDesktopAgent = AGENT_SANDBOXED_WORKERS
   ? createSandboxedWorkerAgentRunner({
@@ -110,6 +113,7 @@ const runDesktopAgent = AGENT_SANDBOXED_WORKERS
       approvalStore,
       runStore: agentRunStore,
       visionModel: VISION_MODEL,
+      distillModel: DISTILL_MODEL,
       sandbox: AGENT_WORKER_SANDBOX,
     }) as any
   : directRunDesktopAgent;

--- a/test/distill.test.ts
+++ b/test/distill.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import { distillFetchContent } from '../agent/tools/browser/distill.ts';
+
+function mockClient(content: string) {
+  const create = vi.fn().mockResolvedValue({ choices: [{ message: { content } }] });
+  return { client: { chat: { completions: { create } } }, create };
+}
+
+const LONG = '相关正文。'.repeat(400); // ~2000 字符,超过默认阈值
+
+describe('distillFetchContent', () => {
+  it('提炼长正文:调用模型、返回更短文本', async () => {
+    const { client, create } = mockClient('要点:今日汇率 7.1。 https://www.pbc.gov.cn/rate');
+    const out = await distillFetchContent({
+      text: `${LONG}\n来源 https://www.pbc.gov.cn/rate`,
+      url: 'https://www.pbc.gov.cn/rate',
+      task: '查询今日汇率',
+      client,
+      model: 'nvidia/cheap',
+    });
+    expect(create).toHaveBeenCalledOnce();
+    expect(out.length).toBeLessThan(LONG.length);
+    expect(out).toContain('7.1');
+  });
+
+  it('把 task 注入进提炼 prompt', async () => {
+    const { client, create } = mockClient('要点');
+    await distillFetchContent({ text: LONG, task: '查询今日汇率', client, model: 'nvidia/cheap' });
+    const prompt = create.mock.calls[0][0].messages[0].content;
+    expect(prompt).toContain('任务:查询今日汇率');
+    expect(prompt).toContain(LONG.slice(0, 50));
+  });
+
+  it('保留所有来源 URL:提炼结果丢了 URL 时补回', async () => {
+    // 模型输出不含任何 URL
+    const { client } = mockClient('要点:汇率 7.1,无链接');
+    const out = await distillFetchContent({
+      text: `${LONG}\nhttps://www.pbc.gov.cn/rate 和 https://www.safe.gov.cn/data`,
+      url: 'https://www.pbc.gov.cn/rate',
+      client,
+      model: 'nvidia/cheap',
+    });
+    expect(out).toContain('https://www.pbc.gov.cn/rate');
+    expect(out).toContain('https://www.safe.gov.cn/data');
+  });
+
+  it('提炼结果已含 URL 时不重复补', async () => {
+    const { client } = mockClient('要点 https://www.pbc.gov.cn/rate');
+    const out = await distillFetchContent({
+      text: `${LONG}\nhttps://www.pbc.gov.cn/rate`,
+      url: 'https://www.pbc.gov.cn/rate',
+      client,
+      model: 'nvidia/cheap',
+    });
+    expect(out).not.toContain('来源:');
+    expect((out.match(/pbc\.gov\.cn/g) || []).length).toBe(1);
+  });
+
+  it('短正文直接返回,不调用模型', async () => {
+    const { client, create } = mockClient('不该被调用');
+    const short = '很短的正文';
+    const out = await distillFetchContent({ text: short, client, model: 'nvidia/cheap' });
+    expect(out).toBe(short);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('未配置 client/model 时原样返回', async () => {
+    expect(await distillFetchContent({ text: LONG, model: 'nvidia/cheap' })).toBe(LONG);
+    const { client } = mockClient('x');
+    expect(await distillFetchContent({ text: LONG, client })).toBe(LONG);
+  });
+
+  it('模型抛错时回退原文,不抛出', async () => {
+    const create = vi.fn().mockRejectedValue(new Error('502 upstream'));
+    const client = { chat: { completions: { create } } };
+    const out = await distillFetchContent({ text: LONG, client, model: 'nvidia/cheap' });
+    expect(out).toBe(LONG);
+  });
+
+  it('空输出回退原文', async () => {
+    const { client } = mockClient('   ');
+    const out = await distillFetchContent({ text: LONG, client, model: 'nvidia/cheap' });
+    expect(out).toBe(LONG);
+  });
+
+  it('取消信号向上传播(不静默回退)', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const create = vi.fn().mockRejectedValue(new Error('The operation was aborted'));
+    const client = { chat: { completions: { create } } };
+    await expect(
+      distillFetchContent({ text: LONG, client, model: 'nvidia/cheap', signal: ac.signal }),
+    ).rejects.toThrow();
+  });
+
+  it('signal 透传给 create 的第二参数', async () => {
+    const ac = new AbortController();
+    const { client, create } = mockClient('要点');
+    await distillFetchContent({ text: LONG, client, model: 'nvidia/cheap', signal: ac.signal });
+    expect(create.mock.calls[0][1]).toEqual({ signal: ac.signal });
+  });
+});


### PR DESCRIPTION
## 动机

承接 #339(trace 回归评测)的实测:浏览类任务里 `http_fetch` 抓来的网页正文整段累积进 history,导致后续每步 prompt token **平方级膨胀**(fx-agent-news trace 实测 step1→step6 从 2496 涨到 8105,六步累计 30968)。当前唯一手段是字符截断(`maxResultChars=4000`/步 × 最近 6 步),粗暴且到 finish 时早期来源已被挤出窗口。

## 改动

`http_fetch` 拿到正文后,用一个**便宜模型(`distillModel`)以 task 为锚提炼成要点、强制保留来源 URL** 再进 history。history 不再累积全文,后续每步 prompt 大幅缩小,同时**保留串行 ReAct 的决策连贯性**(比 map-reduce 侵入小得多)。

- **`agent/tools/browser/distill.ts`**(新):`distillFetchContent` 纯函数——短文/未配置直接返回;自建 task 锚点 + “保留所有来源 URL”的提炼 prompt;**失败/取消回退原文,绝不阻断主流程**;输出前校验来源 URL 仍在,缺失则补回(`result-quality` 的官方来源判定与 `appendHttpFetchReferences` 都依赖 result 文本里的 URL)。
- **`agent/desktop/agent.ts`** browser handler:`http_fetch` 成功返回的长正文经 `distillFetchContent` 再进 history;其余动作不变。
- **`distillModel` 照 `visionModel` 范式全链路接线**:`server.ts` + `agent/worker/runner.ts` + `agent/worker/agent-worker.ts`(sandbox 模式也生效)。`DISTILL_MODEL` env,**默认空 = 关闭**(纯增量,显式配置便宜模型才启用)。
- 10 个单测;`.env.example` / `CONFIGURATION.md` 文档。

## 关系

#339 已合并入 main。本 PR 把 per-fetch distill 单独 cherry-pick 到 **main** 上(来自 #341 的 squash commit `6c111a8`),base = `main`,独立可合。原 #341(base 为 `feat/trace-eval`)与 `revert-341-*` 分支可关闭/删除。

## 验证

- `npm run typecheck` + `npm test`(**374 passed**,含新增 10 distill 单测)在最新 main(含 #338/#339)基础上全绿。
- distill 逻辑被单测覆盖:长文变短、URL 全保留、task 注入、短文跳过、抛错回退、取消传播、signal 透传。
- **端到端真实收益待补**:配 `DISTILL_MODEL=<便宜模型>` 重跑一个多源浏览任务,对比新旧 trace 的 step5/6 `usage.prompt_tokens`(方法同 #339 的 usage 对比)。

## 已知限制(follow-up)

- v1 仅 `http_fetch` + openai-compatible 模型;`get_page_content` / `web_search`、gemini distill 列 follow-up。
- trace 的 result 事件将存提炼后文本,原始全文不落 trace(可选 `onEvent` 另发原文)。
- 每次提炼加一次便宜模型往返(仅超阈值触发;`DISTILL_MODEL` 空则整体关闭)。
