### PR TITLE
feat(agent): 支持浏览器无痕/隐私模式

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ The project is designed for local use: you choose a project workspace, start an 
 
 ## Highlights
 
-- Multi-model chat and Agent mode with race or vote strategies.
+- Multi-model chat and Agent mode with race, vote, or progressive strategies.
 - macOS desktop observation, screenshots, browser automation, and optional Chrome DevTools MCP integration.
 - File, terminal, search, vision, MCP, and browser tools behind an approval-aware runtime.
-- Sandboxed Agent workers when launched with `npm run sandbox`.
+- Configurable short-lived Agent workers, with optional macOS sandboxing.
 - Project-scoped memory, traces, uploads, checkpoints, and run recovery.
 - Mobile-friendly progress view for devices on the same LAN.
 - Smoke tests and trace files for validating Agent behavior after changes.
@@ -44,12 +44,12 @@ cd sagent
 cp .env.example .env
 npm install
 cd client && npm install && cd ..
-npm run sandbox
+npm run dev
 ```
 
 Edit `.env` before starting if you have not added an API key yet. Open http://localhost:5173 when the dev server is ready.
 
-`npm run sandbox` starts the UI/API server normally and runs each Agent task in a short-lived macOS sandboxed worker. Use `npm run dev` only when you intentionally want the non-sandboxed development mode.
+`npm run dev` starts the UI/API development servers. By default, each Agent task runs in a short-lived Worker; on macOS, the Worker Sandbox option additionally applies `sandbox.sb`. The Worker and Sandbox switches live under Settings → Agent → Advanced and take effect after restarting the backend.
 
 After startup, use Settings to choose an Agent profile, edit basic or advanced runtime limits, and manage Chrome or generic MCP connections. These values are stored locally in `data/config.json`; secrets remain in `.env`.
 
@@ -77,7 +77,7 @@ docker run --env-file .env -p 5173:5173 -v "$(pwd)/data-docker:/app/data" sagent
 
 When the Agent needs approval, sagent shows an in-app approval panel and a browser desktop notification. Chromium-based browsers support inline Allow/Reject buttons; Safari and Firefox still show the notification, and clicking it returns focus to sagent.
 
-Dangerous operations such as deleting files, installing packages, or executing terminal commands require explicit approval. The sandbox boundary is controlled by [sandbox.sb](sandbox.sb) when running with `npm run sandbox`.
+Dangerous operations such as deleting files, installing packages, or executing terminal commands require explicit approval. When Worker Sandbox is enabled on macOS, its boundary is controlled by [sandbox.sb](sandbox.sb).
 
 ## Multi-Device View
 
@@ -92,7 +92,7 @@ VITE_HOST=0.0.0.0 npm run sandbox
 Devices on the same LAN can then open `http://<Mac-IP>:5173`. The first protected request prompts for the token. For a separately hosted frontend, list its exact origin in `SAGENT_CORS_ORIGINS`.
 
 - While an Agent run is active, secondary devices show the execution flow and receive the final result when it completes.
-- Chat history is local to each browser/device.
+- Normal chat history is stored by the backend under the configured data directory and is visible to authenticated devices; Private mode conversations are not persisted.
 - Only one Agent run can execute at a time; additional requests receive a 409 response.
 - API, OpenAI-compatible `/v1`, and screenshot routes require authentication whenever `SAGENT_API_TOKEN` is configured. Non-loopback backend listeners refuse to start without one.
 
@@ -100,11 +100,11 @@ Devices on the same LAN can then open `http://<Mac-IP>:5173`. The first protecte
 
 ### Multi-Model Agent
 
-Agent mode can call multiple models for each step. In race mode, the first valid result wins and the remaining requests are cancelled. In vote mode, all selected models run and the result is aggregated. The UI lets you select models, reorder priority, and switch strategies per run.
+Agent mode can call multiple models for each step. In race mode, the first valid result wins and the remaining requests are cancelled. In vote mode, all selected models run and successful decisions are aggregated. Progressive mode starts with the primary model, then lets the remaining models join the race if it is slow or fails. The UI lets you select models, reorder priority, and switch strategies per run.
 
 ### Checkpoint Recovery
 
-Each completed Agent step is written to `data/checkpoints/`. If the backend restarts and recovery is enabled, sagent restores the last run state and continues from the next step. Completed runs clean up their checkpoints automatically.
+Each completed step of a normal Agent run is written under that run's data directory in `checkpoints/`. If the backend restarts and recovery is enabled, sagent restores the last run state and continues from the next step. Completed runs clean up their checkpoints automatically; Private mode creates no checkpoints, so recovery and rollback are unavailable for that run.
 
 ### Cross-Session Memory
 
@@ -112,13 +112,13 @@ sagent stores project experience under the configured data directory. Memory inc
 
 ### Browser And MCP Integrations
 
-The built-in Browser is read-only and is limited to navigation and content extraction. All interactive web operations—including clicking, typing, login, form submission, upload, and download—are delegated to Chrome DevTools MCP through `chrome_list_tools` and `chrome_call_tool`. Generic MCP servers (including `codex mcp-server`) are exposed through `mcp_list_servers`, `mcp_list_tools`, and `mcp_call_tool`. All integrations are optional and documented in [CONFIGURATION.md](CONFIGURATION.md).
+The built-in Browser is read-only and is limited to navigation and content extraction. The “Private mode” toggle in the composer gives the built-in Browser a disposable profile for each task and removes its cookies and LocalStorage during normal task cleanup; it also skips persistence of chat sessions, app/run logs, LLM logs, traces, checkpoints, Worker logs, and sagent-managed screenshots. This isolation does not extend to external Chrome MCP: its browser profile and session are neither isolated nor cleared by Private mode. All interactive web operations—including clicking, typing, login, form submission, upload, and download—are delegated to Chrome DevTools MCP through `chrome_list_tools` and `chrome_call_tool`. Generic MCP servers (including `codex mcp-server`) are exposed through `mcp_list_servers`, `mcp_list_tools`, and `mcp_call_tool`. All integrations are optional and documented in [CONFIGURATION.md](CONFIGURATION.md).
 
 ## Common Commands
 
 ```bash
-npm run sandbox      # Start server and client with sandboxed Agent workers
-npm run dev          # Start server and client without sandboxed workers
+npm run dev          # Start the API server and Vite client; runner mode comes from Settings/config
+npm run prod         # Start the API server (and serve client/dist when it exists)
 npm run build        # Type-check backend and build frontend
 npm run lint         # Run ESLint
 npm test             # Run Vitest tests

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -20,10 +20,10 @@ sagent 把 React Web UI、Bun/Express 后端和可调用工具的 Agent runtime 
 
 ## 核心特性
 
-- 多模型聊天和 Agent 模式，支持竞速与汇总策略。
+- 多模型聊天和 Agent 模式，支持竞速、投票汇总和渐进式竞速策略。
 - macOS 桌面观察、截图、浏览器自动化，以及可选的 Chrome DevTools MCP 集成。
 - 文件、终端、搜索、视觉、MCP、浏览器等工具统一接入 Agent runtime。
-- 使用 `npm run sandbox` 时，每次 Agent 任务都会进入短生命周期沙盒 worker。
+- 短生命周期 Agent Worker 可在设置中开关，macOS Sandbox 也可独立配置。
 - 项目级记忆、trace、上传文件、checkpoint 和中断恢复。
 - 局域网内手机、平板、电脑都能实时查看 Agent 进度。
 - 内置 smoke 测试和 trace 文件，方便功能开发后回归验证。
@@ -44,12 +44,12 @@ cd sagent
 cp .env.example .env
 npm install
 cd client && npm install && cd ..
-npm run sandbox
+npm run dev
 ```
 
 如果还没填 API Key，请先编辑 `.env`。开发服务启动后打开 http://localhost:5173。
 
-`npm run sandbox` 会正常启动 UI/API server，并让每次 Agent 任务在 macOS 沙盒 worker 中执行。只有明确需要无沙盒调试时，才使用 `npm run dev`。
+`npm run dev` 会启动 UI/API 开发服务。默认情况下，每次 Agent 任务都在短生命周期 Worker 中执行；在 macOS 上，开启 Worker Sandbox 后还会应用 `sandbox.sb`。这两个开关位于“设置 → Agent → 高级”，保存后需重启后端才生效。
 
 启动后可在设置页选择 Agent Profile、调整基础/高级运行参数，并管理 Chrome 或通用 MCP 连接。这些值保存在本地 `data/config.json`，密钥仍保留在 `.env`。
 
@@ -75,7 +75,7 @@ docker run --env-file .env -p 5173:5173 -v "$(pwd)/data-docker:/app/data" sagent
 
 Agent 等待审批时，sagent 会显示页面内审批面板，并发送浏览器桌面通知。Chromium 内核浏览器支持通知里的「允许 / 拒绝」按钮；Safari 和 Firefox 仍会弹出通知，点击后回到 sagent 页面处理审批。
 
-删除文件、安装依赖、执行终端命令等危险操作都需要显式确认。通过 `npm run sandbox` 启动时，沙盒权限边界由 [sandbox.sb](sandbox.sb) 控制。
+删除文件、安装依赖、执行终端命令等危险操作都需要显式确认。在 macOS 上启用 Worker Sandbox 时，沙盒权限边界由 [sandbox.sb](sandbox.sb) 控制。
 
 ## 多设备查看
 
@@ -90,7 +90,7 @@ VITE_HOST=0.0.0.0 npm run sandbox
 局域网设备随后可打开 `http://<Mac-IP>:5173`，首次受保护请求会要求输入 Token。独立部署前端时，还需通过 `SAGENT_CORS_ORIGINS` 配置精确来源。
 
 - Agent 运行中，其他设备展示执行流程，并在完成后收到最终结果。
-- 聊天历史保存在各自浏览器里，不跨设备共享。
+- 普通聊天历史由后端保存在配置的数据目录中，认证后的设备可以读取；隐私模式会话不会持久化。
 - 同一时间只能运行一个 Agent，新的任务请求会收到 409。
 - 配置 Token 后，API、OpenAI 兼容 `/v1` 和截图接口都需要认证；后端监听非 loopback 地址时，没有合规 Token 将拒绝启动。
 
@@ -98,11 +98,11 @@ VITE_HOST=0.0.0.0 npm run sandbox
 
 ### 多模型 Agent
 
-Agent 模式下，每一步都可以同时调用多个模型。竞速模式采用第一个有效结果并取消其余请求；汇总模式会等待所有选中模型并聚合结果。前端支持选择模型、调整优先级、切换策略。
+Agent 模式下，每一步都可以调用多个模型。竞速模式采用第一个有效结果并取消其余请求；投票模式会等待所有活动模型并聚合成功决策；渐进式模式先运行主模型，主模型过慢或失败时再让其余模型加入竞速。前端支持选择模型、调整优先级、切换策略。
 
 ### Checkpoint 恢复
 
-Agent 每完成一步都会写入 `data/checkpoints/`。如果后端重启且恢复已启用，sagent 会还原上次运行状态，并从下一步继续执行。正常完成的任务会自动清理 checkpoint。
+普通 Agent 每完成一步，都会在本次运行的数据目录下写入 `checkpoints/`。如果后端重启且恢复已启用，sagent 会还原上次运行状态，并从下一步继续执行。正常完成的任务会自动清理 checkpoint；隐私模式不会创建 checkpoint，因此该模式下不支持断点恢复和回滚。
 
 ### 跨会话记忆
 
@@ -110,13 +110,13 @@ sagent 会在配置的数据目录下保存项目经验，包括近期任务摘�
 
 ### 浏览器与 MCP 集成
 
-内置 Browser 仅用于只读信息浏览和正文提取；点击、输入、登录、提交、上传、下载等网页交互统一由 Chrome DevTools MCP 负责。Chrome MCP 会增加 `chrome_list_tools` 和 `chrome_call_tool`。包括 `codex mcp-server` 在内的通用 MCP server 会通过 `mcp_list_servers`、`mcp_list_tools` 和 `mcp_call_tool` 接入。所有集成都是可选能力，配置方式见 [CONFIGURATION.md](CONFIGURATION.md)。
+内置 Browser 仅用于只读信息浏览和正文提取；点击、输入、登录、提交、上传、下载等网页交互统一由 Chrome DevTools MCP 负责。输入框工具栏中的“隐私模式”会让本次任务使用一次性 Browser profile，并在任务正常收尾时删除 Cookie 和 LocalStorage；同时跳过聊天会话、应用/运行日志、LLM 日志、trace、checkpoint、Worker 日志和 sagent 自己管理的截图持久化。该隔离不覆盖外部 Chrome MCP：隐私模式既不会隔离它的浏览器 profile，也不会清除它的现有会话。Chrome MCP 会增加 `chrome_list_tools` 和 `chrome_call_tool`。包括 `codex mcp-server` 在内的通用 MCP server 会通过 `mcp_list_servers`、`mcp_list_tools` 和 `mcp_call_tool` 接入。所有集成都是可选能力，配置方式见 [CONFIGURATION.md](CONFIGURATION.md)。
 
 ## 常用命令
 
 ```bash
-npm run sandbox      # 沙盒 worker 模式启动 server 和 client
-npm run dev          # 无沙盒 worker 模式启动 server 和 client
+npm run dev          # 启动 API server 和 Vite client；运行器模式由设置/配置决定
+npm run prod         # 启动 API server（存在 client/dist 时同时提供前端）
 npm run build        # 后端类型检查 + 前端构建
 npm run lint         # 运行 ESLint
 npm test             # 运行 Vitest 测试

--- a/agent/core/checkpoint.ts
+++ b/agent/core/checkpoint.ts
@@ -9,12 +9,15 @@
  *   Step 级：{dir}/checkpoints/{runId}.json          （单文件，覆盖写入）
  *   Session 级：{dir}/session-checkpoints/{runId}/session-healthy-{step}.json
  *
- * 所有写入使用原子操作（先写 .tmp 再 rename）防崩溃损坏。
+ * 隐私 run 在已建立的异步上下文中跳过 Step checkpoint 和 Session 快照写入。
+ * 普通 run 的写入优先采用“先写 .tmp 再 rename”的原子替换；底层替换失败时
+ * 才回退为直接写目标文件，因此不能把所有路径都描述成严格原子写入。
  */
 
 import { mkdir, writeFile, readFile, unlink, readdir, rename, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { log } from '../../helpers/logger.ts';
+import { isPrivateRun } from '../../helpers/private-run.ts';
 import type { ActionResultStatus, AgentRuntimeState, AgentStep, JsonObject, TokenUsage } from './contracts.ts';
 
 export type StepCheckpoint = { runId: string; [key: string]: unknown };
@@ -57,6 +60,8 @@ function tmpPath(dir: string, runId: string) {
 }
 
 export async function saveCheckpoint(dir: string, data: StepCheckpoint): Promise<void> {
+  // 先在这里拦截，避免隐私任务连 checkpoints 目录都创建出来。
+  if (isPrivateRun()) return;
   const cpDir = join(dir, 'checkpoints');
   await mkdir(cpDir, { recursive: true });
   const tmp = tmpPath(dir, data.runId);
@@ -204,6 +209,8 @@ export async function saveHealthySnapshot({
   resultError?: string | null;
   usage?: Partial<TokenUsage> | JsonObject;
 }): Promise<void> {
+  // 与 Step checkpoint 共用同一条隐私防线；回滚所需的快照也不能落盘。
+  if (isPrivateRun()) return;
   const cpDir = sessionDir(dir, runId);
   await mkdir(cpDir, { recursive: true });
 
@@ -300,7 +307,7 @@ export async function listSessionCheckpoints(dir: string, runId: string) {
 
 export { HEALTH_CHECKPOINT_INTERVAL, KEEP_HEALTHY, KEEP_FAILED };
 
-// ─── Session 快照清理（运行结束后调用）────────────────────────
+// ─── Session 快照清理（启动前、取消或运行结束时调用）──────────────
 
 export async function removeSessionCheckpoints(dir: string, runId: string) {
   const cpDir = sessionDir(dir, runId);

--- a/agent/core/config-store.ts
+++ b/agent/core/config-store.ts
@@ -5,10 +5,12 @@
  * 冻结的 Agent 行为参数收敛到这里。消费点改为每次读 get()，因此前台改完
  * 下次 agent 任务即自动生效，无需重启进程。
  *
- * 数据来源优先级：data/config.json（前台覆盖） > 内置 schema 默认值。
- *   - configDefaults() 返回内置默认值；Agent 运行时参数不再读取环境变量
- *   - config.json 保存 profile、Agent 覆盖、工具和 MCP server
- *   - reset() 清空覆盖，回到内置默认
+ * 两类配置的来源不同：
+ *   - 热生效 Agent 参数：data/config.json 的 agent 覆盖 > schema 内置默认值，
+ *     这些字段不再从环境变量读取。
+ *   - 启动期 execution 参数：同一 config.json 的 execution 段保存 Worker 部署选择；
+ *     resume 与 workerSandbox 仍可被对应环境变量覆盖，sandboxedWorkers 只取存储值。
+ *   - config.json 还保存 profile、tools、MCP server；reset() 只清空 Agent 覆盖。
  *
  * get() 是同步的（compressHistory 等热路径是同步函数）；current 在模块加载时
  * 即初始化为默认值，init() 再叠加 json，故任何时刻 get() 都安全。
@@ -33,6 +35,45 @@ import {
 
 export type { RuntimeConfig } from './config-schema.ts';
 
+export type ExecutionConfig = {
+  resume: boolean;
+  sandboxedWorkers: boolean;
+  workerSandbox: boolean;
+};
+
+export type ExecutionConfigSource = 'default' | 'user' | 'env';
+
+const EXECUTION_UPDATE_KEYS = ['sandboxedWorkers', 'workerSandbox'] as const;
+
+type ExecutionUpdate = Partial<Pick<ExecutionConfig, typeof EXECUTION_UPDATE_KEYS[number]>>;
+
+function envBool(env: Record<string, string | undefined>, name: string, fallback: boolean) {
+  const raw = env[name];
+  if (raw == null || String(raw).trim() === '') return fallback;
+  return ['1', 'true', 'yes', 'on'].includes(String(raw).trim().toLowerCase());
+}
+
+function hasEnvValue(env: Record<string, string | undefined>, name: string) {
+  return env[name] != null && String(env[name]).trim() !== '';
+}
+
+function validateExecution(patch: any): { clean: ExecutionUpdate; errors: string[] } {
+  const clean: ExecutionUpdate = {};
+  const errors: string[] = [];
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    return { clean, errors: ['启动配置必须是对象'] };
+  }
+  for (const key of EXECUTION_UPDATE_KEYS) {
+    if (!(key in patch)) continue;
+    if (typeof patch[key] !== 'boolean') {
+      errors.push(`${key} 必须是布尔值`);
+      continue;
+    }
+    clean[key] = patch[key];
+  }
+  return { clean, errors };
+}
+
 /** 纯函数：返回内置默认值。 */
 export function computeDefaults(): RuntimeConfig {
   return configDefaults().values;
@@ -40,7 +81,7 @@ export function computeDefaults(): RuntimeConfig {
 
 /**
  * 纯函数：校验前台传来的 patch，返回 { clean, errors }。
- * - 只认识 FIELD_SPEC 里的键，未知键忽略
+ * - 只认识 AGENT_CONFIG_SCHEMA 里的键，未知键忽略
  * - int 字段必须是有限整数且在 [min,max]；bool 字段必须是布尔
  * - 任一字段非法记入 errors，且不进入 clean
  */
@@ -80,7 +121,7 @@ export function validateConfig(patch: any): { clean: Partial<RuntimeConfig>; err
   return { clean, errors };
 }
 
-/** 纯函数：默认值 + 覆盖项合并（覆盖项只取已知且非空的键）。 */
+/** 纯函数：默认值 + 覆盖项合并（覆盖项只取已知且非 null/undefined 的键）。 */
 export function mergeConfig(defaults: RuntimeConfig, overrides: Partial<RuntimeConfig> | null | undefined): RuntimeConfig {
   const merged = { ...defaults };
   if (overrides && typeof overrides === 'object') {
@@ -283,19 +324,40 @@ export const configStore = {
     return JSON.parse(JSON.stringify(document.tools || {}));
   },
 
-  execution(env: Record<string, string | undefined> = process.env) {
+  execution(env: Record<string, string | undefined> = process.env): ExecutionConfig {
     const stored = document.execution || {};
-    const envBool = (name: string, fallback: boolean) => {
-      const raw = env[name];
-      if (raw == null || String(raw).trim() === '') return fallback;
-      return ['1', 'true', 'yes', 'on'].includes(String(raw).trim().toLowerCase());
-    };
     return {
-      resume: envBool('AGENT_RESUME', stored.resume ?? true),
+      resume: envBool(env, 'AGENT_RESUME', stored.resume ?? true),
       // execution 是启动期部署选择。sandboxedWorkers 只由存储配置决定（默认沙箱），不再接受环境变量覆盖。
       sandboxedWorkers: stored.sandboxedWorkers ?? true,
-      workerSandbox: envBool('AGENT_WORKER_SANDBOX', stored.workerSandbox ?? true),
+      workerSandbox: envBool(env, 'AGENT_WORKER_SANDBOX', stored.workerSandbox ?? true),
     };
+  },
+
+  executionSources(env: Record<string, string | undefined> = process.env): Record<keyof ExecutionConfig, ExecutionConfigSource> {
+    const stored = document.execution || {};
+    return {
+      resume: hasEnvValue(env, 'AGENT_RESUME') ? 'env' : stored.resume != null ? 'user' : 'default',
+      sandboxedWorkers: stored.sandboxedWorkers != null ? 'user' : 'default',
+      workerSandbox: hasEnvValue(env, 'AGENT_WORKER_SANDBOX')
+        ? 'env'
+        : stored.workerSandbox != null
+          ? 'user'
+          : 'default',
+    };
+  },
+
+  /** 更新需要重启后端才能生效的 Worker 部署选项；Agent 与 execution 段共用同一个 config.json。 */
+  async updateExecution(patch: any): Promise<ExecutionConfig> {
+    const { clean, errors } = validateExecution(patch);
+    if (errors.length) throw new Error(errors.join('；'));
+    document = {
+      ...document,
+      execution: { ...(document.execution || {}), ...clean },
+    };
+    saveChain = saveChain.then(persist).catch(err => log.error('[Config] 保存启动配置失败:', err?.message || err));
+    await saveChain;
+    return this.execution();
   },
 
   async updateMcpServer(name: string, server: McpServerConfig | null): Promise<Record<string, McpServerConfig>> {
@@ -315,7 +377,7 @@ export const configStore = {
     return { ...next };
   },
 
-  /** 更新全局 tools.model 配置(vision/distill),sanitize 后落盘。 */
+  /** 更新全局 tools 配置（vision/distill/screenshots），sanitize 后落盘。 */
   async updateTools(tools: SagentConfigDocument['tools']): Promise<SagentConfigDocument['tools']> {
     const sanitized = normalizeConfigDocument({
       ...document,
@@ -352,7 +414,7 @@ export const configStore = {
     return current;
   },
 
-  /** 清空 Agent 覆盖，回到 env 默认；MCP 等其它配置保持不变。 */
+  /** 清空 Agent 覆盖，回到 schema 内置默认；MCP、tools、execution 等其它配置保持不变。 */
   async reset(): Promise<RuntimeConfig> {
     overrides = {};
     document = { ...document, profile: 'custom' };

--- a/agent/core/contracts.ts
+++ b/agent/core/contracts.ts
@@ -111,7 +111,7 @@ interface EventTraceFields {
 
 export type AgentEvent = EventTraceFields & (
   | { type: 'status'; status: string; message?: string }
-  | { type: 'run_meta'; startedAt: number; model?: string; agentModels?: string[]; task?: string; sessionId?: string; projectId?: string | null; strategy?: string }
+  | { type: 'run_meta'; startedAt: number; model?: string; agentModels?: string[]; task?: string; sessionId?: string; projectId?: string | null; strategy?: string; privateMode?: boolean }
   | { type: 'step'; step: number; stage: 'observe'; observation: unknown }
   | { type: 'step'; step: number; stage: 'action'; rationale?: string; action: AgentAction; usage?: TokenUsage | null }
   | { type: 'step'; step: number; stage: 'result'; result: unknown; resultStatus?: ActionResultStatus; resultError?: string | null }
@@ -164,6 +164,7 @@ export interface RunMeta {
   agentModels?: string[];
   task?: string;
   attempt?: number;
+  privateMode?: boolean;
   projectId?: string | null;
   dataDir?: string;
   projectRoot?: string | null;
@@ -233,6 +234,7 @@ export interface AgentRuntimeState {
   runId?: string;
   onEvent?: AgentEventWriter;
   headless?: boolean;
+  privateMode?: boolean;
   browserSession?: {
     view?: { navigate(url: string): Promise<unknown>; [key: string]: unknown };
     [key: string]: unknown;
@@ -325,6 +327,7 @@ export interface DesktopAgentRunOptions {
   strategy?: string;
   systemPrompt?: string | null;
   headless?: boolean;
+  privateMode?: boolean;
   onEvent?: AgentEventWriter;
   cancelSignal?: AbortSignal;
   runId: string;

--- a/agent/core/llm-logger.ts
+++ b/agent/core/llm-logger.ts
@@ -1,12 +1,14 @@
 /**
  * LLM Logger — 将 LLM 请求/响应日志按模型、按日期写入文件
  *
- * 文件结构：data/llm-logs/2026-04-24/minimaxai_minimax-m2.7.jsonl
+ * 文件结构：<baseDir>/llm-logs/<date>/<model>.jsonl
  * 每行一个 JSON 对象：{ time, type, model, ... }
  *
  * 调用场景：
- *   - planner.js 发送 NVIDIA API 请求前后
- *   - provider 调用模型 API 前后
+ *   - planner.ts / provider 在调用模型 API 前后
+ *
+ * 隐私 run 仍会返回脱敏后的请求数据给调用方，并保留控制台诊断；只是不把
+ * request/response/error 行加入 JSONL 写队列。
  */
 
 import { mkdir, appendFile } from 'node:fs/promises';
@@ -15,6 +17,7 @@ import { log } from '../../helpers/logger.ts';
 import { extractErrorDiagnostics, formatErrorDiagnostics } from '../../helpers/retry.ts';
 import { getLogPolicy, pruneLogTreeSync, rotateLogFileSync } from '../../helpers/log-policy.ts';
 import { redactSensitiveData } from '../../helpers/redact.ts';
+import { isPrivateRun } from '../../helpers/private-run.ts';
 
 let logDir = 'data/llm-logs';
 
@@ -98,22 +101,28 @@ export function logLlmRequest(model, messages, tools = null) {
   // 让文件日志与前端 trace 用同一套 messages 展示（与 gemini provider 一致）。
   const combined = hasTools ? [...messages, { role: 'tools', content: tools }] : messages;
   const safeMessages = redactSensitiveData(combined);
-  const line = JSON.stringify({ time: timeStr(), type: 'request', model, messages: safeMessages });
-  enqueueLog(join(todayDir(), modelFileName(model)), line);
+  if (!isPrivateRun()) {
+    const line = JSON.stringify({ time: timeStr(), type: 'request', model, messages: safeMessages });
+    enqueueLog(join(todayDir(), modelFileName(model)), line);
+  }
   log.debug(`[LLM] → ${model} messages=${messages.length}${hasTools ? ` tools=${tools.length}` : ''}`);
   return safeMessages;
 }
 
 export function logLlmResponse(model, response) {
   const usage = response.usage || {};
-  const line = JSON.stringify(redactSensitiveData({ time: timeStr(), type: 'response', model, usage, response }));
-  enqueueLog(join(todayDir(), modelFileName(model)), line);
+  if (!isPrivateRun()) {
+    const line = JSON.stringify(redactSensitiveData({ time: timeStr(), type: 'response', model, usage, response }));
+    enqueueLog(join(todayDir(), modelFileName(model)), line);
+  }
   const tokens = (usage.prompt_tokens || 0) + (usage.completion_tokens || usage.output_tokens || 0);
   log.debug(`[LLM] ← ${model} tokens=${tokens}`);
 }
 
 export function logLlmError(model, err, context = {}) {
-  const line = JSON.stringify(redactSensitiveData({ time: timeStr(), type: 'error', model, context, error: extractErrorDiagnostics(err) }));
-  enqueueLog(join(todayDir(), modelFileName(model)), line);
+  if (!isPrivateRun()) {
+    const line = JSON.stringify(redactSensitiveData({ time: timeStr(), type: 'error', model, context, error: extractErrorDiagnostics(err) }));
+    enqueueLog(join(todayDir(), modelFileName(model)), line);
+  }
   log.warn(`[LLM] ✕ ${model} ${formatErrorDiagnostics(err)}`);
 }

--- a/agent/core/session-store.ts
+++ b/agent/core/session-store.ts
@@ -1,7 +1,16 @@
+/**
+ * Chat session store — 按全局/项目 scope 保存聊天会话与 Agent 运行摘要。
+ *
+ * loadAll() 会读取 trace 恢复缺失会话；每个 dataDir 使用独立串行队列，避免
+ * 多个标签页并发更新互相覆盖。隐私模式仍可读现有文件，但 trace 恢复和
+ * activeSessionId 修正只体现在返回值中；upsert、删除和 run 摘要更新会直接跳过。
+ */
+
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createPersistenceQueue } from '../../helpers/persistence-queue.ts';
 import { listTraceRuns, readTraceEvents } from '../../helpers/trace-store.ts';
+import { isPrivateRun } from '../../helpers/private-run.ts';
 import { projectDataDir, type ProjectStore } from './project-store.ts';
 
 const SESSIONS_FILE = 'chat-sessions.json';
@@ -285,7 +294,12 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
     return { projectId, dataDir: projectDataDir(memoryDir, projectId) };
   };
 
-  async function loadScope(projectId: string | null, dataDir: string, logIndex: Map<string, RunLogEntry>) {
+  async function loadScope(
+    projectId: string | null,
+    dataDir: string,
+    logIndex: Map<string, RunLogEntry>,
+    { persist = true }: { persist?: boolean } = {},
+  ) {
     return queueFor(dataDir).enqueue(async () => {
       const state = await readScopeState(dataDir, projectId);
       const represented = new Set(state.sessions.flatMap(sessionRunIds));
@@ -307,14 +321,17 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
         state.activeSessionId = state.sessions.find(isActiveSession)?.id || null;
         changed = true;
       }
-      if (changed) await writeScopeState(dataDir, state);
+      // 隐私模式仍可读取现有会话供页面显示，但不能因为 trace 恢复或
+      // activeSessionId 修正而反向写入 chat-sessions.json。
+      if (changed && persist) await writeScopeState(dataDir, state);
       return state;
     });
   }
 
-  async function loadAll() {
+  async function loadAll({ persist = !isPrivateRun() }: { persist?: boolean } = {}) {
+    // persist=false 只禁止 loadScope 的恢复/active 修正写回，不影响页面读取现有会话。
     const logIndex = await loadRunLogIndex(memoryDir);
-    const loaded = await Promise.all(scopes().map(scope => loadScope(scope.projectId, scope.dataDir, logIndex)));
+    const loaded = await Promise.all(scopes().map(scope => loadScope(scope.projectId, scope.dataDir, logIndex, { persist })));
     const sessions = loaded.flatMap(state => state.sessions).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
     const activeProjectId = projectStore.list().activeProjectId ?? null;
     const activeScopeIndex = scopes().findIndex(scope => scope.projectId === activeProjectId);
@@ -325,8 +342,11 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
   // 单条 upsert：客户端只同步“发生变化的那一条”会话，绝不推整份列表，
   // 因此不存在“列表里缺失即删除”的推断——过期客户端最多回退它见过的某条,
   // 无法删除它从未见过的会话。删除必须走显式 deleteSession。
-  async function upsertSession(rawSession: unknown) {
+  async function upsertSession(rawSession: unknown, { persist = !isPrivateRun() }: { persist?: boolean } = {}) {
     if (!rawSession || typeof rawSession !== 'object') throw new Error('session 必须是对象');
+    // 三层防线：调用方显式 persist=false、当前 AsyncLocalStorage 隐私上下文，
+    // 以及 payload 自带 privateMode，任一命中都只返回只读快照，不进入写队列。
+    if (!persist || isPrivateRun() || (rawSession as any).privateMode === true) return loadAll({ persist: false });
     const requestedProjectId = typeof (rawSession as any).projectId === 'string' && (rawSession as any).projectId
       ? (rawSession as any).projectId
       : null;
@@ -353,8 +373,13 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
 
   // 显式删除：从存量移除会话,并把它的 runId 加进 dismissedTraceRunIds
   // (阻止 trace 恢复复活它)。这是 dismissedTraceRunIds 唯一的写入点。
-  async function deleteSession(projectId: string | null, sessionId: string) {
+  async function deleteSession(
+    projectId: string | null,
+    sessionId: string,
+    { persist = !isPrivateRun() }: { persist?: boolean } = {},
+  ) {
     if (typeof sessionId !== 'string' || !sessionId) throw new Error('sessionId 不能为空');
+    if (!persist || isPrivateRun()) return loadAll({ persist: false });
     const scope = resolveScope(projectId);
     await queueFor(scope.dataDir).enqueue(async () => {
       const state = await readScopeState(scope.dataDir, scope.projectId);
@@ -388,7 +413,7 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
   }
 
   async function recordRunStart({
-    projectId, sessionId, runId, task, model, models, startedAt, retry,
+    projectId, sessionId, runId, task, model, models, startedAt, retry, privateMode,
   }: {
     projectId: string | null;
     sessionId: string | null;
@@ -398,7 +423,10 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
     models: string[];
     startedAt: number;
     retry?: boolean;
+    privateMode?: boolean;
   }) {
+    // 隐私 run 的过程和结果只在当前页面临时展示，不能创建/更新聊天会话。
+    if (privateMode === true || isPrivateRun()) return;
     const id = sessionId || `session_trace_${runId.slice(4)}`;
     await mutateScope(projectId, state => {
       let session = state.sessions.find(item => item.id === id);
@@ -421,7 +449,7 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
   }
 
   async function recordRunTerminal({
-    projectId, sessionId, runId, task, answer, error, models, status, startedAt, endedAt, meta,
+    projectId, sessionId, runId, task, answer, error, models, status, startedAt, endedAt, meta, privateMode,
   }: {
     projectId: string | null;
     sessionId: string | null;
@@ -434,7 +462,10 @@ export function createSessionStore({ memoryDir, projectStore }: { memoryDir: str
     startedAt: number;
     endedAt: number;
     meta?: Record<string, any>;
+    privateMode?: boolean;
   }) {
+    // 与 recordRunStart 保持相同的双重防线：显式标记或 AsyncLocalStorage 任一命中即跳过。
+    if (privateMode === true || isPrivateRun()) return;
     const id = sessionId || `session_trace_${runId.slice(4)}`;
     await mutateScope(projectId, state => {
       let session = state.sessions.find(item => item.id === id);

--- a/agent/desktop/agent.ts
+++ b/agent/desktop/agent.ts
@@ -4,27 +4,33 @@
  *
  * 核心流程 / Core loop:
  *   initialize → (observe → decide → authorize → execute) × N → cleanup
- *   由 agent/core/runtime.js 驱动单步循环，本文件提供各阶段的实现。
+ *   由 agent/core/runtime.ts 的 runAgentRuntime() 驱动通用循环；
+ *   本文件负责注入桌面 Agent 的状态、规划、审批、工具路由和清理实现。
  *
- * 多模型竞速 / Multi-model race:
- *   buildDesktopPlanner() 支持 race / vote 两种策略：
+ * 多模型规划 / Multi-model planning:
+ *   createDesktopPlanner() 支持三种策略：
  *   - race: 批量错峰启动，首个有效结果胜出，其余取消
- *   - vote: 等待全部完成，多数投票选最优决策
- *   超时模型自动加入黑名单，批次全部失败时触发下一批。
+ *   - vote: 等待所有活动模型结束后汇总成功结果；任一模型返回 finish 时立即结束
+ *   - progressive: 先运行主模型，超过等待阈值或失败后再让其余模型加入竞速
+ *   模型超时会在本次 run 内加入黑名单；“整批失败后启动下一批”仅适用于 race。
  *
  * 观测 / Observation:
- *   observeDesktopAgent() 同时采集桌面（AppleScript）和浏览器（Playwright）状态，
- *   合并为统一的 observation 对象供 LLM 决策。
+ *   observeDesktopAgent() 并行采集已启用的桌面状态和已建立的内置浏览器状态：
+ *   - 启用桌面观测时优先使用 macOS 原生 helper，helper 失败时回退 AppleScript
+ *     窗口采集；截图统一由 screencapture 完成
+ *   - 浏览器通过 Bun.WebView（Windows 为 Edge CDP 适配器）执行页面求值
+ *   两类结果会合并为统一 observation，供 planner 决策。
  *
  * 调用场景 / Callers:
- *   - server.js 启动时: createDesktopAgentRunner() 工厂创建 runDesktopAgent 函数
- *   - routes/agent.js POST /api/agent: runDesktopAgent() 执行任务
- *   - server.js resumeFromCheckpoint(): 恢复断点继续执行
+ *   - server.ts 与 agent/worker/agent-worker.ts 创建 runDesktopAgent 函数
+ *   - routes/agent-run-start.ts 接收 POST /api/agent，agent-run-execution.ts 调用 runner
+ *   - server.ts 的 resumeFromCheckpoint() 从断点恢复任务
  *
- * TODO / 拆分建议 Refactor suggestions:
- *   - 将 multi-model 竞速逻辑（buildDesktopPlanner / aggregateResults）拆到 agent/core/multi-model.js
- *   - 将 message 构建（buildGeminiTaskMessages / buildNvidiaTaskMessages）拆到 agent/core/prompts.js
- *   - 将 observation 采集逻辑拆到 agent/desktop/observer.js
+ * 主要职责边界 / Module boundaries:
+ *   - planner.ts: 模型路由及 race / vote / progressive 调度
+ *   - core/multi-model.ts: 多模型结果聚合
+ *   - core/prompts.ts: 各 provider 的消息构建
+ *   - observer.ts: 桌面与浏览器 observation 采集
  */
 
 import { createActionRouter } from '../core/router.ts';
@@ -44,6 +50,7 @@ import { observeDesktopAgent } from './observer.ts';
 import { createDesktopPlanner, DEFAULT_MODEL_TIMEOUT_MS } from './planner.ts';
 import { saveCheckpoint, saveHealthySnapshot } from '../core/checkpoint.ts';
 import { log } from '../../helpers/logger.ts';
+import { isPrivateRun, withPrivateRun } from '../../helpers/private-run.ts';
 import { configStore } from '../core/config-store.ts';
 import type { ProviderRegistry } from '../core/providers/registry.ts';
 import type { ModelInfo } from '../core/providers/types.ts';
@@ -87,14 +94,17 @@ export function createDesktopAgentRunner({
   staggerDelayMs = 0,
   batchSize = 1,
 }: DesktopAgentRunnerConfig): DesktopAgentRunner {
+  // 所有内置浏览器操作共享受管会话：串行执行，并在 WebView 失效时统一恢复。
   const {
     cleanupBrowserSession,
     serializeBrowserOperation,
     withBrowserSessionRecovery,
   } = createSharedBrowserSessionManager();
 
-  // Agent 行为参数每次 run 实时读取（前台改完无需重启即生效）；
-  // 构造参数（maxSteps 等）保留为兜底，运行时优先用 configStore。
+  // 每次 run 都从 configStore 读取行为参数，前台修改后无需重启即可生效。
+  // 因此工厂入参 maxSteps/modelTimeoutMs/staggerDelayMs/batchSize/observeDesktop
+  // 目前不参与运行时兜底。
+  // visionModel/distillModel 也不在这里直接读取；两个工具在 action 执行时动态解析模型。
   function liveConfig() {
     const c = configStore.get();
     return {
@@ -107,6 +117,7 @@ export function createDesktopAgentRunner({
     };
   }
 
+  // 将 runtime 产生的统一 action 分发到具体工具；审批在路由执行前由 runtime 完成。
   const routeAction = createActionRouter(
     {
       core: async (state, action, context) => {
@@ -125,6 +136,7 @@ export function createDesktopAgentRunner({
         return action.answer || '任务已完成';
       },
       browser: async (state, action, context) => {
+        // 浏览器动作在共享会话队列中执行；会话失效时由管理器重建后重试一次。
         const result = await withBrowserSessionRecovery(state, state.onEvent, (session, recoveryAttempt) => (
           executeBrowserAction(session.view, action, { signal: state.cancelSignal, recoveryAttempt })
         ), {
@@ -132,10 +144,10 @@ export function createDesktopAgentRunner({
           actionType: action.type,
           url: 'url' in action ? action.url : ('urls' in action ? action.urls?.[0] : null),
         });
-        // http_fetch 提炼成功后只返回 task 锚定的 Distill 摘要(保留来源 URL)，
-        // 面板、trace 和后续 prompt 均不再携带网页原文；提炼失败仍安全回退原文。
-        // model 三层解析:项目→全局→env→主模型(默认回退主模型)。
+        // http_fetch 在客户端、模型均可用且正文足够长时进行 task 锚定提炼，并保留来源 URL。
+        // 条件不满足时直接保留原文；空输出或提炼失败时 distillFetchContent() 回退原文。
         if (action.type === 'http_fetch' && typeof result === 'string' && openai_client) {
+          // Distill 模型四级解析：项目覆盖 → 全局配置 → 环境变量 → 当前主模型。
           const projectTools = await readProjectToolsOverride(state.dataDir);
           const model = resolveToolModel('distill', {
             projectTools,
@@ -159,7 +171,9 @@ export function createDesktopAgentRunner({
       fs: async (state, action) => executeFsAction(action, { cwd: state.projectRoot, dataDir: state.dataDir, signal: state.cancelSignal }),
       search: async (state, action) => executeSearchAction(action, { signal: state.cancelSignal }),
       vision: async (state, action) => {
-        // vision model 三层解析:项目→全局→env→主模型;未设回退主模型(用户已确认接受主模型可能非多模态)。
+        // Vision 兜底模型按四级解析：项目覆盖 → 全局配置 → 环境变量 → 当前主模型。
+        // vision 工具仍会优先选择本次 run 中明确具备图片输入能力的候选模型；
+        // 若最终兜底模型不支持多模态，由工具返回实际调用错误。
         const projectTools = await readProjectToolsOverride(state.dataDir);
         const resolvedVisionModel = resolveToolModel('vision', {
           projectTools,
@@ -214,6 +228,7 @@ export function createDesktopAgentRunner({
     strategy = 'progressive',
     systemPrompt = null,
     headless = defaultHeadless,
+    privateMode = false,
     onEvent,
     cancelSignal,
     runId,
@@ -227,11 +242,17 @@ export function createDesktopAgentRunner({
     dataDir = null,
     checkpointWriter = null,
   }: DesktopAgentRunOptions) {
+    // 未显式提供候选列表时只使用主模型；黑名单仅在当前 run 内生效。
     agentModels = agentModels || [model];
+    // 显式参数与外层 AsyncLocalStorage 任一为 true 都按隐私 run 处理，
+    // 防止路由/Worker 的嵌套调用意外把外层隐私标记降级。
+    const effectivePrivateMode = privateMode === true || isPrivateRun();
     const { maxSteps, modelTimeoutMs, staggerDelayMs, batchSize, observeDesktop, autoModelRouting } = liveConfig();
     const blacklistedModels = new Set();
+    // planner 封装模型自动路由、超时、限流以及三种多模型调度策略。
     const plan = createDesktopPlanner({ registry, modelConfig, blacklistedModels, modelTimeoutMs, staggerDelayMs, batchSize, autoModelRouting });
 
+    // 所有工具动作在执行前统一经过策略审批；ask_user 也复用同一等待机制。
     const authorize = createAgentAuthorizer({
       runId,
       approvalStore,
@@ -239,23 +260,27 @@ export function createDesktopAgentRunner({
       runStore,
     });
 
-    // 本次 run 的落盘目录：命中项目用项目目录，否则回退工厂注入的全局 checkpointDir。
-    const runCheckpointDir = dataDir || checkpointDir;
+    // 本次 run 的 checkpoint/回滚目录：命中项目用项目目录，否则回退工厂注入的全局目录。
+    // 隐私模式不创建 step checkpoint 或 session snapshot，避免任务上下文通过
+    // 恢复/回滚文件留下副本。
+    const runCheckpointDir = effectivePrivateMode ? null : (dataDir || checkpointDir);
 
-    return runAgentRuntime({
+    // 通用 runtime 只控制循环；下面注入桌面 Agent 各阶段的具体实现。
+    return withPrivateRun(effectivePrivateMode, () => runAgentRuntime({
       task,
       maxSteps,
       onEvent,
       cancelSignal,
       initialStep,
       initialHistory,
-      // v2: 会话级健康检查点支持
+      // 会话级健康快照与手动回滚都使用本次 run 的隔离落盘目录；隐私模式为 null。
       sessionCheckpointDir: runCheckpointDir,
       runRecord,
       onCheckpoint: runCheckpointDir
         ? (history, step) => {
+            // 保存恢复循环所需的完整上下文。
             const checkpoint = {
-              runId, task, model, systemPrompt, headless,
+              runId, task, model, systemPrompt, headless, privateMode: effectivePrivateMode,
               history, step, maxSteps, startedAt,
               agentModels, strategy, conversationHistory, memory,
               projectRoot, dataDir,
@@ -266,17 +291,22 @@ export function createDesktopAgentRunner({
             return runRecord?.persistence ? runRecord.persistence.enqueue(persist) : persist();
           }
         : null,
-      saveSessionSnapshot: checkpointWriter?.saveHealthySnapshot
-        ? data => runRecord?.persistence
-          ? runRecord.persistence.enqueue(() => checkpointWriter.saveHealthySnapshot(data))
-          : checkpointWriter.saveHealthySnapshot(data)
-        : runRecord?.persistence
-          ? data => runRecord.persistence!.enqueue(() => saveHealthySnapshot(data as any))
-          : undefined,
+      // 存在 run 持久化队列时，健康快照也进入该队列，避免并发写入导致次序错乱。
+      saveSessionSnapshot: effectivePrivateMode
+        ? undefined
+        : checkpointWriter?.saveHealthySnapshot
+          ? data => runRecord?.persistence
+            ? runRecord.persistence.enqueue(() => checkpointWriter.saveHealthySnapshot(data))
+            : checkpointWriter.saveHealthySnapshot(data)
+          : runRecord?.persistence
+            ? data => runRecord.persistence!.enqueue(() => saveHealthySnapshot(data as any))
+            : undefined,
+      // initialize 返回的可变 state 会贯穿整个 observe/decide/execute 循环。
       initialize: async () => ({
         runId,
         onEvent,
         headless,
+        privateMode: effectivePrivateMode,
         browserSession: null,
         observeDesktop,
         model,
@@ -287,7 +317,9 @@ export function createDesktopAgentRunner({
         projectRoot,
         dataDir,
       }),
+      // 观察与浏览器执行共用串行队列，避免读取到页面切换过程中的中间状态。
       observe: state => serializeBrowserOperation(() => observeDesktopAgent(state)),
+      // runtime 已压缩 history；planner 只负责选择模型并生成下一步 action。
       decide: async ({ task: currentTask, step, history, observation, finalOnly }) =>
         plan({
           model,
@@ -307,14 +339,17 @@ export function createDesktopAgentRunner({
       shouldObserve: (lastAction) => {
         if (!lastAction) return false;
         const tool = lastAction.tool || '';
-        // chrome 是浏览器类工具，状态变化必须观察；fs/terminal 多为本地无副作用操作可跳过
+        // fs/terminal 的执行结果已直接进入 history，额外桌面/浏览器观察通常没有新信息；
+        // 若继续下一步，browser、chrome、search、vision、MCP 和 core 动作后均重新观察环境。
         return tool !== 'fs' && tool !== 'terminal';
       },
+      // 工具执行仍通过统一路由，以保持取消信号、事件和审批上下文一致。
       execute: async (state, action, context) => routeAction(state, action, context),
       cleanup: async state => {
+        // 普通会话复位后可复用；隐私会话会由管理器关闭并清除一次性 profile。
         await cleanupBrowserSession(state);
       },
-    });
+    }));
   }
 
   return runDesktopAgent as DesktopAgentRunner;

--- a/agent/desktop/browser-session-manager.ts
+++ b/agent/desktop/browser-session-manager.ts
@@ -1,3 +1,12 @@
+/**
+ * Shared built-in browser session manager.
+ *
+ * Sessions are matched by headless + privateMode, all operations pass through one
+ * serial queue, and an invalid WebView is recreated once before a per-run circuit
+ * breaker stops further built-in-browser calls. Normal sessions are reset to about:blank
+ * for reuse; private sessions are closed so their temporary profile can be deleted.
+ */
+
 import { captureBrowserPreview, closeBrowserSession, createBrowserSession } from '../tools/browser/webview-session.ts';
 
 type BrowserLifecycle = 'starting' | 'ready' | 'busy' | 'broken' | 'closing' | 'closed';
@@ -5,6 +14,8 @@ type BrowserLifecycle = 'starting' | 'ready' | 'busy' | 'broken' | 'closing' | '
 type ManagedBrowserSession = {
   view: any;
   page: any;
+  privateMode?: boolean;
+  privateProfileDir?: string | null;
   sessionId: number;
   generation: number;
   lifecycle: BrowserLifecycle;
@@ -21,6 +32,7 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
   const MAX_RECOVERY_FAILURES_PER_RUN = 2;
   let sharedBrowserSession: ManagedBrowserSession | null = null;
   let sharedBrowserHeadless: boolean | null = null;
+  let sharedBrowserPrivateMode: boolean | null = null;
   let nextSessionId = 1;
   let nextGeneration = 1;
   let operationQueue: Promise<unknown> = Promise.resolve();
@@ -32,6 +44,7 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
       sessionId: session?.sessionId || null,
       generation: session?.generation || null,
       lifecycle: session?.lifecycle || 'closed',
+      privateMode: Boolean(session?.privateMode),
       timestamp: Date.now(),
       ...extra,
     });
@@ -81,10 +94,12 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
     await session.closePromise;
   }
 
-  async function getSharedBrowserSessionInternal(headless: boolean, onEvent?: (payload: any) => void) {
+  async function getSharedBrowserSessionInternal(headless: boolean, privateMode: boolean, onEvent?: (payload: any) => void) {
+    // headless/privateMode 属于会话隔离条件；任一变化都不能复用旧 WebView。
     if (
       sharedBrowserSession
       && sharedBrowserHeadless === headless
+      && sharedBrowserPrivateMode === privateMode
       && sharedBrowserSession.lifecycle !== 'broken'
       && sharedBrowserSession.lifecycle !== 'closing'
       && sharedBrowserSession.lifecycle !== 'closed'
@@ -95,11 +110,12 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
       const previous = sharedBrowserSession;
       sharedBrowserSession = null;
       sharedBrowserHeadless = null;
+      sharedBrowserPrivateMode = null;
       await closeSessionBounded(previous);
     }
 
     const session: ManagedBrowserSession = {
-      ...createBrowserSession(),
+      ...createBrowserSession({ privateMode }),
       sessionId: nextSessionId++,
       generation: nextGeneration++,
       lifecycle: 'starting',
@@ -107,17 +123,23 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
     };
     sharedBrowserSession = session;
     sharedBrowserHeadless = headless;
+    sharedBrowserPrivateMode = privateMode;
     emit(onEvent, 'starting', session);
     return session;
   }
 
   async function ensureBrowserSessionInternal(state: any, onEvent?: (payload: any) => void) {
-    if (state.browserSession && isCurrentSession(state.browserSession)) {
+    const privateMode = state.privateMode === true;
+    if (
+      state.browserSession
+      && isCurrentSession(state.browserSession)
+      && Boolean(state.browserSession.privateMode) === privateMode
+    ) {
       return state.browserSession as ManagedBrowserSession;
     }
     state.browserSession = null;
 
-    const session = await getSharedBrowserSessionInternal(state.headless, onEvent);
+    const session = await getSharedBrowserSessionInternal(state.headless === true, privateMode, onEvent);
     const generation = session.generation;
     try {
       session.lifecycle = 'busy';
@@ -130,6 +152,7 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
       if (session === sharedBrowserSession) {
         sharedBrowserSession = null;
         sharedBrowserHeadless = null;
+        sharedBrowserPrivateMode = null;
       }
       await closeSessionBounded(session);
       const detail = String(err?.message || err);
@@ -146,6 +169,7 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
         : 'Bun.WebView 浏览器已启动并通过健康检查',
       sessionId: session.sessionId,
       generation: session.generation,
+      privateMode: Boolean(session.privateMode),
     });
     emit(onEvent, 'ready', session, { url: 'about:blank', healthChecked: true });
     return session;
@@ -158,6 +182,7 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
     if (session && session === sharedBrowserSession) {
       sharedBrowserSession = null;
       sharedBrowserHeadless = null;
+      sharedBrowserPrivateMode = null;
     }
     if (session) {
       if (session.lifecycle !== 'broken') session.lifecycle = 'closing';
@@ -168,6 +193,11 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
   async function cleanupBrowserSessionInternal(state?: any) {
     const session = (state?.browserSession || sharedBrowserSession) as ManagedBrowserSession | null;
     if (!session?.view || !isCurrentSession(session)) return;
+    if (session.privateMode) {
+      // 隐私会话不能跨任务复用：关闭 WebView 才会删除一次性 profile。
+      await resetBrowserSessionInternal(state);
+      return;
+    }
     const generation = session.generation;
     try {
       session.lifecycle = 'busy';
@@ -187,6 +217,8 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
     operation: (session: ManagedBrowserSession, recoveryAttempt: number) => Promise<any>,
     context: any = {},
   ) {
+    // 每个动作最多经历一次重建重试；连续两次恢复失败后打开本 run 熔断，
+    // 避免 planner 在坏会话上无限循环并持续产生副作用。
     if (state.browserCircuitOpen) {
       emit(onEvent, 'degraded', state.browserSession, { ...context, reason: 'circuit_open', recoveryFailures: state.browserRecoveryFailures || 0 });
       return circuitOpenResult();
@@ -199,8 +231,11 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
     try {
       const result = await operation(session, 0);
       assertCurrentSession(session, generation);
-      const preview = state.runId
-        ? await captureBrowserPreview(session.view, { runId: state.runId }).catch(() => null)
+      const preview = state.runId && state.privateMode !== true
+        ? await captureBrowserPreview(session.view, {
+            runId: state.runId,
+            privateMode: state.privateMode === true,
+          }).catch(() => null)
         : null;
       assertCurrentSession(session, generation);
       session.lifecycle = 'ready';
@@ -224,8 +259,11 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
       try {
         const result = await operation(session, 1);
         assertCurrentSession(session, generation);
-        const preview = state.runId
-          ? await captureBrowserPreview(session.view, { runId: state.runId }).catch(() => null)
+        const preview = state.runId && state.privateMode !== true
+          ? await captureBrowserPreview(session.view, {
+              runId: state.runId,
+              privateMode: state.privateMode === true,
+            }).catch(() => null)
           : null;
         assertCurrentSession(session, generation);
         session.lifecycle = 'ready';
@@ -252,8 +290,8 @@ export function createSharedBrowserSessionManager({ closeTimeoutMs = 3_000 } = {
 
   return {
     serializeBrowserOperation: <T>(operation: () => Promise<T>) => enqueue(operation),
-    getSharedBrowserSession: (headless: boolean, onEvent?: (payload: any) => void) => (
-      enqueue(() => getSharedBrowserSessionInternal(headless, onEvent))
+    getSharedBrowserSession: (headless: boolean, onEvent?: (payload: any) => void, privateMode = false) => (
+      enqueue(() => getSharedBrowserSessionInternal(headless === true, privateMode === true, onEvent))
     ),
     ensureBrowserSession: (state: any, onEvent?: (payload: any) => void) => (
       enqueue(() => ensureBrowserSessionInternal(state, onEvent))

--- a/agent/desktop/observer.ts
+++ b/agent/desktop/observer.ts
@@ -1,16 +1,25 @@
+/** 将桌面 helper/AppleScript 与内置浏览器状态合并成 planner 使用的 observation。 */
+
 import { captureBrowserObservation, summarizeBrowserObservation } from '../tools/browser/observe.ts';
 import { observeMacOSDesktop } from '../tools/macos/observe.ts';
 
 export async function observeDesktopAgent(state: {
   observeDesktop?: boolean;
   runId?: string;
+  privateMode?: boolean;
   browserSession?: any;
   projectRoot?: string | null;
   cancelSignal?: AbortSignal;
 }) {
+  // 两类观测并行执行；未启用桌面观测或尚未建立浏览器会话时返回空占位，
+  // 让 planner 始终收到稳定的 observation 结构。
   const [desktop, browserRaw] = await Promise.all([
     state.observeDesktop
-      ? observeMacOSDesktop({ runId: state.runId || 'unknown', signal: state.cancelSignal })
+      ? observeMacOSDesktop({
+          runId: state.runId || 'unknown',
+          signal: state.cancelSignal,
+          privateMode: state.privateMode === true,
+        })
       : Promise.resolve({ frontmostApp: '', frontmostWindowTitle: '', windows: [] }),
     state.browserSession
       ? captureBrowserObservation(state.browserSession.view)

--- a/agent/tools/browser/edge-cdp-webview.ts
+++ b/agent/tools/browser/edge-cdp-webview.ts
@@ -1,3 +1,10 @@
+/**
+ * Windows built-in browser adapter: launch a dedicated Edge process and expose the
+ * small read-only WebView surface used by the Agent through CDP WebSocket commands.
+ * A temporary profile is used for the launched process; privateMode additionally
+ * requests an Edge InPrivate context. close() then performs bounded profile cleanup.
+ */
+
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { createServer } from 'node:net';
@@ -8,6 +15,35 @@ type PendingCommand = {
   resolve: (value: any) => void;
   reject: (reason?: any) => void;
 };
+
+export function buildEdgeLaunchArgs({
+  port,
+  profileDir,
+  width = 1440,
+  height = 960,
+  privateMode = false,
+}: {
+  port: number;
+  profileDir: string;
+  width?: number;
+  height?: number;
+  privateMode?: boolean;
+}) {
+  return [
+    '--headless=new',
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${profileDir}`,
+    `--window-size=${width},${height}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    '--disable-background-networking',
+    '--disable-component-update',
+    '--disable-extensions',
+    '--disable-features=msEdgeFirstRunExperience',
+    ...(privateMode ? ['--inprivate'] : []),
+    'about:blank',
+  ];
+}
 
 export class EdgeCdpWebView {
   // 该适配器刻意保持只读：只实现导航、页面求值和截图，不提供 CDP 输入事件。
@@ -21,7 +57,7 @@ export class EdgeCdpWebView {
   private profileDir: string | null = null;
   private ready: Promise<void>;
 
-  constructor(private options: { width?: number; height?: number } = {}) {
+  constructor(private options: { width?: number; height?: number; privateMode?: boolean } = {}) {
     this.ready = this.start();
   }
 
@@ -48,19 +84,15 @@ export class EdgeCdpWebView {
     if (this.closed) throw new Error('Invalid state: WebView is closed');
 
     this.profileDir = mkdtempSync(path.join(os.tmpdir(), 'sagent-edge-'));
-    this.child = spawn(edgePath, [
-      '--headless=new',
-      `--remote-debugging-port=${port}`,
-      `--user-data-dir=${this.profileDir}`,
-      `--window-size=${this.options.width || 1440},${this.options.height || 960}`,
-      '--no-first-run',
-      '--no-default-browser-check',
-      '--disable-background-networking',
-      '--disable-component-update',
-      '--disable-extensions',
-      '--disable-features=msEdgeFirstRunExperience',
-      'about:blank',
-    ], {
+    // Each adapter owns its profile directory; close() validates the temp prefix
+    // before recursively deleting it, so a malformed path can never widen cleanup.
+    this.child = spawn(edgePath, buildEdgeLaunchArgs({
+      port,
+      profileDir: this.profileDir,
+      width: this.options.width || 1440,
+      height: this.options.height || 960,
+      privateMode: this.options.privateMode,
+    }), {
       stdio: 'ignore',
       windowsHide: true,
     });
@@ -198,6 +230,8 @@ export class EdgeCdpWebView {
     try { this.socket?.close(); } catch {}
     try { this.child?.kill(); } catch {}
     if (this.profileDir) {
+      // Edge may keep files briefly after Browser.close; retry bounded cleanup only
+      // inside the OS temp root and only for our generated sagent-edge-* directory.
       const tempRoot = path.resolve(os.tmpdir());
       const resolvedProfile = path.resolve(this.profileDir);
       if (resolvedProfile.startsWith(`${tempRoot}${path.sep}`) && path.basename(resolvedProfile).startsWith('sagent-edge-')) {

--- a/agent/tools/browser/webview-session.ts
+++ b/agent/tools/browser/webview-session.ts
@@ -1,7 +1,19 @@
-import { mkdirSync } from 'node:fs';
-import { chmod, mkdir, readdir, unlink, writeFile } from 'node:fs/promises';
+/**
+ * Built-in browser session/profile adapter.
+ *
+ * On Bun.WebView platforms normal runs use the configured persistent browser-profile;
+ * private runs get a random temporary dataStore that close() removes on a best-effort basis. On Windows the
+ * Edge CDP adapter owns a temporary process profile for every managed session, while
+ * privateMode also passes Edge's --inprivate flag. Browser preview screenshots are
+ * persisted only for non-private runs.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { chmod, mkdir, readdir, rm, unlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { EdgeCdpWebView } from './edge-cdp-webview.ts';
+import { isPrivateRun } from '../../../helpers/private-run.ts';
 
 let sharedSession = null;
 let webViewFactory = defaultWebViewFactory;
@@ -16,7 +28,9 @@ function defaultWebViewFactory(options) {
   if (!WebView) {
     throw new Error('Bun.WebView 不可用。请使用 Bun 1.3+ 运行 sagent，或升级到包含 Bun.WebView 的 Bun 版本。');
   }
-  return new WebView(options);
+  // privateMode 是 sagent 的内部标记，Bun.WebView 不需要也不认识它。
+  const { privateMode: _privateMode, ...webViewOptions } = options;
+  return new WebView(webViewOptions);
 }
 
 export function initWebViewDataStore(baseDir) {
@@ -39,7 +53,12 @@ async function removeOldBrowserPreviews(dirPath, keepFile) {
   await Promise.all(previews.slice(2).map(file => unlink(path.join(dirPath, file)).catch(() => {})));
 }
 
-export async function captureBrowserPreview(view, { runId }: { runId?: string } = {}) {
+export async function captureBrowserPreview(
+  view,
+  { runId, privateMode = false }: { runId?: string; privateMode?: boolean } = {},
+) {
+  // 隐私模式不调用 WebView 截图接口，也不创建截图目录/文件。
+  if (privateMode === true || isPrivateRun()) return null;
   if (!view || typeof view.screenshot !== 'function') return null;
 
   const page = await Promise.resolve(view.evaluate(`({
@@ -93,16 +112,50 @@ export function resetWebViewFactoryForTests() {
   sharedSession = null;
 }
 
-export function createBrowserSession({ width = 1440, height = 960 } = {}) {
+function isSafePrivateProfileDir(profileDir) {
+  if (!profileDir) return false;
+  const tempRoot = path.resolve(os.tmpdir());
+  const resolvedProfile = path.resolve(profileDir);
+  return path.dirname(resolvedProfile) === tempRoot
+    && path.basename(resolvedProfile).startsWith('sagent-private-browser-');
+}
+
+async function removePrivateProfileDir(profileDir) {
+  if (!isSafePrivateProfileDir(profileDir)) return;
+  await rm(profileDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }).catch(() => {});
+}
+
+export function createBrowserSession({ width = 1440, height = 960, privateMode = false } = {}) {
+  const normalizedPrivateMode = privateMode === true;
   const opts: any = { width, height };
-  if (dataStoreDir) {
+  let privateProfileDir = null;
+  if (normalizedPrivateMode) {
+    // Bun.WebView 的 dataStore 目录决定了 cookie/localStorage 等持久化边界；
+    // 随机临时目录 + 任务结束删除，确保隐私 run 不会污染全局 browser-profile。
+    privateProfileDir = mkdtempSync(path.join(os.tmpdir(), 'sagent-private-browser-'));
+    opts.privateMode = true;
+    opts.dataStore = { directory: privateProfileDir };
+  } else if (dataStoreDir) {
     opts.dataStore = { directory: dataStoreDir };
   }
-  const view = webViewFactory(opts);
-  return {
-    view,
-    page: view,
-  };
+  try {
+    const view = webViewFactory(opts);
+    const session: any = {
+      view,
+      page: view,
+    };
+    if (normalizedPrivateMode) {
+      session.privateMode = true;
+      session.privateProfileDir = privateProfileDir;
+    }
+    return session;
+  } catch (error) {
+    // WebView 构造失败时也不能遗留一次性 profile。
+    if (privateProfileDir && isSafePrivateProfileDir(privateProfileDir)) {
+      try { rmSync(privateProfileDir, { recursive: true, force: true }); } catch {}
+    }
+    throw error;
+  }
 }
 
 export function getSharedWebViewSession(options = {}) {
@@ -118,12 +171,14 @@ export function getWebView(options = {}) {
 
 export async function closeBrowserSession(session = sharedSession) {
   const view = session?.view || session?.page || session;
+  const privateProfileDir = session?.privateProfileDir;
   if (view && typeof view.close === 'function') {
     try {
       const result = view.close();
       if (result && typeof result.catch === 'function') await result;
     } catch {}
   }
+  await removePrivateProfileDir(privateProfileDir);
   if (session === sharedSession || session?.view === sharedSession?.view) {
     sharedSession = null;
   }

--- a/agent/tools/macos/observe.ts
+++ b/agent/tools/macos/observe.ts
@@ -1,3 +1,5 @@
+/** macOS 桌面 observation：优先调用原生 helper，失败时回退 AppleScript。 */
+
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -5,6 +7,7 @@ import { execFile } from 'node:child_process';
 import { getMacOSCapabilityReport } from './permissions.ts';
 import { invokeMacOSHelper, resolveMacOSBackend } from './helper-client.ts';
 import { configStore } from '../../core/config-store.ts';
+import { isPrivateRun } from '../../../helpers/private-run.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SCREENSHOT_DIR = path.resolve(__dirname, '../../../data/screenshots');
@@ -28,7 +31,9 @@ function execFileText(file: string, args: string[], signal?: AbortSignal): Promi
   });
 }
 
-async function captureScreenshot(runId, signal?: AbortSignal) {
+async function captureScreenshot(runId, signal?: AbortSignal, privateMode = false) {
+  // 截图包含完整桌面内容；隐私模式下连临时文件都不创建。
+  if (privateMode || isPrivateRun()) return '';
   const dirPath = path.join(SCREENSHOT_DIR, runId || 'default');
   await fs.mkdir(dirPath, { recursive: true });
   const filePath = path.join(dirPath, `screen-${Date.now()}.png`);
@@ -55,7 +60,7 @@ async function captureScreenshot(runId, signal?: AbortSignal) {
   }
 }
 
-async function observeWithShell(runId, signal?: AbortSignal) {
+async function observeWithShell(runId, signal?: AbortSignal, privateMode = false) {
   const frontmostApp = await execFileText('osascript', [
     '-e',
     'tell application "System Events" to name of first application process whose frontmost is true',
@@ -89,31 +94,33 @@ async function observeWithShell(runId, signal?: AbortSignal) {
     frontmostApp,
     frontmostWindowTitle,
     windows,
-    screenshotPath: await captureScreenshot(runId, signal),
+    screenshotPath: await captureScreenshot(runId, signal, privateMode),
   };
 }
 
-async function observeWithHelper(runId, signal?: AbortSignal) {
+async function observeWithHelper(runId, signal?: AbortSignal, privateMode = false) {
   const desktop = await invokeMacOSHelper('observe', { runId }, undefined, { signal });
   return {
     backend: 'helper',
     frontmostApp: desktop.frontmostApp || '',
     frontmostWindowTitle: desktop.frontmostWindowTitle || '',
     windows: Array.isArray(desktop.windows) ? desktop.windows.slice(0, 20) : [],
-    screenshotPath: await captureScreenshot(runId, signal),
+    screenshotPath: await captureScreenshot(runId, signal, privateMode),
   };
 }
 
-export async function observeMacOSDesktop({ runId, signal = undefined }) {
+export async function observeMacOSDesktop({ runId, signal = undefined, privateMode = false }) {
+  // 隐私模式仍采集窗口文本用于决策，但彻底跳过屏幕截图文件。
+  const skipScreenshot = privateMode === true || isPrivateRun();
   const capability = getMacOSCapabilityReport();
   const backend = resolveMacOSBackend();
   const desktop =
     backend.type === 'helper'
-      ? await observeWithHelper(runId, signal).catch(err => {
+      ? await observeWithHelper(runId, signal, skipScreenshot).catch(err => {
           if (signal?.aborted) throw signal.reason instanceof Error ? signal.reason : err;
-          return observeWithShell(runId, signal);
+          return observeWithShell(runId, signal, skipScreenshot);
         })
-      : await observeWithShell(runId, signal);
+      : await observeWithShell(runId, signal, skipScreenshot);
 
   return {
     ...desktop,

--- a/agent/worker/agent-worker.ts
+++ b/agent/worker/agent-worker.ts
@@ -1,3 +1,14 @@
+/**
+ * Child-side Agent Worker entry.
+ *
+ * stdout is reserved for the JSON-line protocol, so console.log/debug are redirected
+ * to stderr. The private AsyncLocalStorage context wraps dynamic imports and the full
+ * Agent execution chain, ensuring module-level log/checkpoint adapters see the flag.
+ */
+
+import { withPrivateRun } from '../../helpers/private-run.ts';
+
+// Capture the original stdout writer before redirecting console output away from the protocol.
 const protocolWrite = process.stdout.write.bind(process.stdout);
 console.log = (...args) => console.error(...args);
 console.debug = (...args) => console.error(...args);
@@ -102,74 +113,85 @@ async function main() {
   const payload = startMessage.payload || {};
   runRecord = { runId: payload.runId, pendingRollback: null };
 
-  const { createClients } = await import('../core/ai-client.ts');
-  const { createProviderRegistry } = await import('../core/providers/registry.ts');
-  const { createDesktopAgentRunner } = await import('../desktop/agent.ts');
-  const { initLlmLogger, flushLlmLogs } = await import('../core/llm-logger.ts');
-  const { configStore } = await import('../core/config-store.ts');
-  const { DEFAULT_VISION_MODEL } = await import('../tools/vision/execute.ts');
-  const { DEFAULT_DISTILL_MODEL } = await import('../tools/browser/distill.ts');
-  const { initWebViewDataStore } = await import('../tools/browser/webview-session.ts');
-  flushLlmLogsBeforeExit = flushLlmLogs;
+  // Keep dynamic imports inside the context too, so any import-time initialization and
+  // async work spawned by those modules inherit the same private-run marker.
+  return withPrivateRun(payload.privateMode === true, async () => {
+    const { createClients } = await import('../core/ai-client.ts');
+    const { createProviderRegistry } = await import('../core/providers/registry.ts');
+    const { createDesktopAgentRunner } = await import('../desktop/agent.ts');
+    const { initLlmLogger, flushLlmLogs } = await import('../core/llm-logger.ts');
+    const { configStore } = await import('../core/config-store.ts');
+    const { DEFAULT_VISION_MODEL } = await import('../tools/vision/execute.ts');
+    const { DEFAULT_DISTILL_MODEL } = await import('../tools/browser/distill.ts');
+    const { initWebViewDataStore } = await import('../tools/browser/webview-session.ts');
+    flushLlmLogsBeforeExit = flushLlmLogs;
 
-  const memoryDir = payload.memoryDir || process.env.MEMORY_DIR || 'data';
-  initWebViewDataStore(memoryDir);
-  await configStore.init(memoryDir);
-  initLlmLogger(memoryDir);
+    const memoryDir = payload.memoryDir || process.env.MEMORY_DIR || 'data';
+    initWebViewDataStore(memoryDir);
+    await configStore.init(memoryDir);
+    initLlmLogger(memoryDir);
 
-  const { openai_client, gemini_client } = createClients();
-  const registry = createProviderRegistry({ openai_client, gemini_client });
-  const modelConfig = Array.isArray(payload.modelConfig) ? payload.modelConfig : [];
-  const cfg = configStore.get();
-  const runDesktopAgent = createDesktopAgentRunner({
-    registry,
-    openai_client,
-    modelConfig,
-    maxSteps: cfg.maxSteps,
-    defaultHeadless: payload.headless === true,
-    observeDesktop: cfg.observeDesktop,
-    modelTimeoutMs: cfg.modelTimeoutSec * 1000,
-    staggerDelayMs: cfg.staggerDelaySec * 1000,
-    batchSize: cfg.batchSize,
-    runStore: null,
-    approvalStore,
-    checkpointDir: payload.checkpointDir || memoryDir,
-    visionModel: payload.visionModel || process.env.VISION_MODEL || DEFAULT_VISION_MODEL,
-    distillModel: payload.distillModel || process.env.DISTILL_MODEL || DEFAULT_DISTILL_MODEL,
+    const { openai_client, gemini_client } = createClients();
+    const registry = createProviderRegistry({ openai_client, gemini_client });
+    const modelConfig = Array.isArray(payload.modelConfig) ? payload.modelConfig : [];
+    const cfg = configStore.get();
+    const runDesktopAgent = createDesktopAgentRunner({
+      registry,
+      openai_client,
+      modelConfig,
+      maxSteps: cfg.maxSteps,
+      defaultHeadless: payload.headless === true,
+      observeDesktop: cfg.observeDesktop,
+      modelTimeoutMs: cfg.modelTimeoutSec * 1000,
+      staggerDelayMs: cfg.staggerDelaySec * 1000,
+      batchSize: cfg.batchSize,
+      runStore: null,
+      approvalStore,
+      checkpointDir: payload.checkpointDir || memoryDir,
+      visionModel: payload.visionModel || process.env.VISION_MODEL || DEFAULT_VISION_MODEL,
+      distillModel: payload.distillModel || process.env.DISTILL_MODEL || DEFAULT_DISTILL_MODEL,
+    });
+
+    const checkpointWriter = {
+      saveCheckpoint(data: any) {
+        // Child and parent both reject private checkpoints; the duplicate guard protects
+        // against future callers bypassing either side of the bridge.
+        if (payload.privateMode === true) return;
+        writeProtocol({ type: 'checkpoint', data });
+      },
+      saveHealthySnapshot(data: any) {
+        if (payload.privateMode === true) return;
+        writeProtocol({ type: 'session_checkpoint_snapshot', data });
+      },
+    };
+
+    const result = await runDesktopAgent({
+      task: payload.task,
+      model: payload.model,
+      models: Array.isArray(payload.models) ? payload.models : [],
+      strategy: payload.strategy || 'race',
+      systemPrompt: payload.systemPrompt || '',
+      headless: payload.headless === true,
+      privateMode: payload.privateMode === true,
+      runId: payload.runId,
+      runRecord,
+      startedAt: payload.startedAt,
+      initialStep: payload.initialStep || 1,
+      initialHistory: Array.isArray(payload.initialHistory) ? payload.initialHistory : [],
+      conversationHistory: Array.isArray(payload.conversationHistory) ? payload.conversationHistory : [],
+      memory: payload.memory !== false,
+      onEvent: (event: any) => writeProtocol({ type: 'event', payload: event }),
+      cancelSignal: cancelAc.signal,
+      projectRoot: payload.projectRoot || null,
+      dataDir: payload.dataDir || null,
+      checkpointWriter,
+    });
+
+    // Flush normal-run LLM logs before the terminal protocol frame so the parent can
+    // safely resolve and start cleanup. In private mode the queue is empty.
+    await flushLlmLogsBeforeExit();
+    await writeProtocolAndWait({ type: 'result', result });
   });
-
-  const checkpointWriter = {
-    saveCheckpoint(data: any) {
-      writeProtocol({ type: 'checkpoint', data });
-    },
-    saveHealthySnapshot(data: any) {
-      writeProtocol({ type: 'session_checkpoint_snapshot', data });
-    },
-  };
-
-  const result = await runDesktopAgent({
-    task: payload.task,
-    model: payload.model,
-    models: Array.isArray(payload.models) ? payload.models : [],
-    strategy: payload.strategy || 'race',
-    systemPrompt: payload.systemPrompt || '',
-    headless: payload.headless === true,
-    runId: payload.runId,
-    runRecord,
-    startedAt: payload.startedAt,
-    initialStep: payload.initialStep || 1,
-    initialHistory: Array.isArray(payload.initialHistory) ? payload.initialHistory : [],
-    conversationHistory: Array.isArray(payload.conversationHistory) ? payload.conversationHistory : [],
-    memory: payload.memory !== false,
-    onEvent: (event: any) => writeProtocol({ type: 'event', payload: event }),
-    cancelSignal: cancelAc.signal,
-    projectRoot: payload.projectRoot || null,
-    dataDir: payload.dataDir || null,
-    checkpointWriter,
-  });
-
-  await flushLlmLogsBeforeExit();
-  await writeProtocolAndWait({ type: 'result', result });
 }
 
 main()

--- a/agent/worker/runner.ts
+++ b/agent/worker/runner.ts
@@ -1,3 +1,13 @@
+/**
+ * Parent-side Agent Worker bridge.
+ *
+ * The parent sends commands as JSON lines on stdin; the child reserves stdout for
+ * JSON-line protocol messages and uses stderr for diagnostics. Normal runs persist
+ * stderr plus malformed stdout to worker-logs/<runId>.log; private runs keep both
+ * streams process-local. Checkpoint messages are serialized through the run's
+ * persistence queue before the result/error promise is settled.
+ */
+
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -152,7 +162,9 @@ export function createSandboxedWorkerAgentRunner({
       workerFile,
     });
 
-    const workerLog = createWorkerLogStream(dataDir, runId);
+    // stdout 是父子 JSON 行协议，stderr 是诊断输出；只有普通 run 才把 stderr
+    // 和无法解析的 stdout 行写入持久化 Worker 日志。
+    const workerLog = opts.privateMode === true ? null : createWorkerLogStream(dataDir, runId);
     const child = spawn(command, args, {
       cwd: REPO_ROOT,
       env: {
@@ -173,14 +185,18 @@ export function createSandboxedWorkerAgentRunner({
     let killTimer: NodeJS.Timeout | null = null;
 
     const persist = (task: () => Promise<any>) => {
+      // 父进程是 checkpoint 的最终落盘方；统一排队可保持 step 与 session 快照顺序。
       persistence.enqueue(task).catch(err => {
-        log.warn(`[Worker] persistence failed runId=${runId}: ${err?.message || err}`);
+        if (opts.privateMode !== true) {
+          log.warn(`[Worker] persistence failed runId=${runId}: ${err?.message || err}`);
+        }
       });
     };
 
     const finish = async (fn: () => void) => {
       if (settled) return;
       settled = true;
+      // 先等待所有已接收的 checkpoint 写完，再向路由暴露 result/error。
       await persistence.flush();
       fn();
     };
@@ -196,12 +212,12 @@ export function createSandboxedWorkerAgentRunner({
         return;
       }
       if (message.type === 'checkpoint') {
-        if (cancelRequested) return;
+        if (cancelRequested || opts.privateMode === true) return;
         persist(() => saveCheckpoint(dataDir, message.data));
         return;
       }
       if (message.type === 'session_checkpoint_snapshot') {
-        if (cancelRequested) return;
+        if (cancelRequested || opts.privateMode === true) return;
         persist(() => saveHealthySnapshot({ ...message.data, dir: dataDir }));
         return;
       }
@@ -221,7 +237,9 @@ export function createSandboxedWorkerAgentRunner({
             writeWorkerMessage(child, { type: 'approval_response', approvalId, decision });
           });
         } catch (err: any) {
-          log.warn(`[Worker] approval bridge failed runId=${runId}: ${err?.message || err}`);
+          if (opts.privateMode !== true) {
+            log.warn(`[Worker] approval bridge failed runId=${runId}: ${err?.message || err}`);
+          }
           writeWorkerMessage(child, { type: 'approval_response', approvalId: message.approvalId, decision: 'reject' });
         }
         return;
@@ -236,6 +254,7 @@ export function createSandboxedWorkerAgentRunner({
     };
 
     child.stdout.on('data', (chunk: Buffer) => {
+      // 协议按换行切帧；非 JSON 行不参与控制流，普通模式下仅作为诊断保存。
       stdoutBuffer += chunk.toString();
       let idx: number;
       while ((idx = stdoutBuffer.indexOf('\n')) !== -1) {
@@ -267,6 +286,7 @@ export function createSandboxedWorkerAgentRunner({
     const abortHandler = () => {
       if (cancelRequested) return;
       cancelRequested = true;
+      // 先给 Worker 协议级取消机会；超时后再依次升级为 SIGTERM / SIGKILL。
       writeWorkerMessage(child, { type: 'cancel' });
       const { terminateAfterMs, killAfterMs } = getWorkerCancelDelays();
       terminateTimer = setTimeout(() => {
@@ -307,7 +327,9 @@ export function createSandboxedWorkerAgentRunner({
       }
     });
 
-    log.info(`[Worker] spawn runId=${runId} sandbox=${sandbox} projectRoot=${projectRoot}`);
+    if (opts.privateMode !== true) {
+      log.info(`[Worker] spawn runId=${runId} sandbox=${sandbox} projectRoot=${projectRoot}`);
+    }
     writeWorkerMessage(child, {
       type: 'start',
       payload: {
@@ -317,6 +339,7 @@ export function createSandboxedWorkerAgentRunner({
         strategy: opts.strategy,
         systemPrompt: opts.systemPrompt,
         headless: opts.headless,
+        privateMode: opts.privateMode,
         runId,
         startedAt: opts.startedAt,
         initialStep: opts.initialStep,

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -5825,6 +5825,20 @@ a.model-encyclopedia-field-value:hover {
 .toolbar-chip:hover { border-color: var(--c-primary-light); color: var(--c-primary); }
 .toolbar-chip.active { border-color: var(--c-primary); color: var(--c-primary); background: var(--c-primary-bg); }
 
+.private-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+}
+.private-mode-toggle:disabled { opacity: 0.5; cursor: not-allowed; }
+.private-mode-toggle svg { flex: 0 0 auto; }
+.agent-composer--hero .private-mode-toggle {
+  height: 34px;
+  padding: 0 12px;
+  border-radius: var(--r-sm);
+}
+
 textarea {
   width: 100%;
   resize: none;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Menu, Settings } from 'lucide-react';
+import { Menu, Settings, ShieldCheck } from 'lucide-react';
 import './App.css';
 import { fetchAgentTrace } from './api/streams.js';
 import { ensureServiceWorker, notificationPermission, notificationsSupported, requestNotificationPermission } from './notifications.js';
@@ -101,14 +101,16 @@ function getTraceModels(trace) {
 }
 
 export default function App() {
+  const [agentPrivateMode, setAgentPrivateMode] = usePersistentState('agent_private_mode', false, booleanStorage);
   const {
     setChatState,
     sessions,
     activeSession,
     messages,
     updateSession,
+    preparePrivateMode,
     sessionsLoading,
-  } = useChatSessions();
+  } = useChatSessions({ privateMode: agentPrivateMode });
   const {
     projects,
     activeProjectId,
@@ -333,6 +335,12 @@ export default function App() {
         const data = await res.json();
         if (!data.active || aborted) return;
 
+        // 后端 run 元数据是隐私状态的权威来源。先冻结当前普通会话，再切换开关，
+        // 避免下面的重连占位消息被误当成“进入隐私前状态”并在退出后补写。
+        if (data.meta?.privateMode === true) {
+          preparePrivateMode();
+          setAgentPrivateMode(true);
+        }
         setAgentRunning(true);
         setAgentTrace([]);
         setReconnectedRun(true);
@@ -562,11 +570,10 @@ export default function App() {
   }, [sessionsLoading]);
 
   // 手机后台/切 tab 时浏览器会冻结 JS、节流网络，SSE reader 可能在后台错过
-  // done/error 事件；切回前台时如果前端还以为任务在跑，就调一次持久化的 trace
-  // 接口兜底：trace 里如果已经包含 done/error，把 answer 灌回对应 session 并
-  // 把 running 状态收掉，避免出现"任务已结束但 UI 一直转圈"。
+  // done/error 事件。普通 run 切回前台时可用持久化 trace 兜底；隐私 run 没有
+  // 磁盘 trace，只依赖当前 SSE/内存链路。
   useEffect(() => {
-    if (!agentRunning) return;
+    if (!agentRunning || agentPrivateMode) return;
     let cancelled = false;
 
     const checkOnVisible = async () => {
@@ -651,7 +658,7 @@ export default function App() {
     };
   // setter 引用稳定，rid 用 ref 读最新值
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentRunning]);
+  }, [agentPrivateMode, agentRunning]);
 
   useEffect(() => {
     textareaRef.current?.focus();
@@ -814,6 +821,7 @@ export default function App() {
     selectedAgentModels,
     agentStrategy,
     agentMemory,
+    agentPrivateMode,
     availableModels: agentAvailableModels,
     agentRunIdRef,
     agentAbortRef,
@@ -906,8 +914,7 @@ export default function App() {
     return usage;
   }, [sessions]);
 
-  // 工具栏控件实例化一次，在 hero 和 layout header 中复用——
-  // 行为/状态完全一致，没必要在两处分别构造。
+  // 工具栏元素集中构造，再传给 hero/workspace 两种布局；两处共享同一套状态和行为。
   const modelSelect = (
     <ModelSelector
       availableModels={agentAvailableModels}
@@ -998,6 +1005,24 @@ export default function App() {
       multiple
     />
   );
+  const privateModeToggle = (
+    // 这是 run 级开关；运行中锁定，避免同一 run 中途改变持久化策略。
+    <button
+      type="button"
+      className={`toolbar-chip private-mode-toggle${agentPrivateMode ? ' active' : ''}`}
+      onClick={() => {
+        if (!agentPrivateMode) preparePrivateMode();
+        setAgentPrivateMode(enabled => !enabled);
+      }}
+      disabled={sessionLocked}
+      aria-pressed={agentPrivateMode}
+      aria-label={t('input.privateMode')}
+      title={t(agentPrivateMode ? 'input.privateModeOn' : 'input.privateModeOff')}
+    >
+      <ShieldCheck size={14} strokeWidth={2} />
+      <span>{t('input.privateMode')}</span>
+    </button>
+  );
   const attachmentBar = (
     <AttachmentBar attachments={attachments} onRemove={removeAttachment} />
   );
@@ -1076,7 +1101,7 @@ export default function App() {
           onKeyDown={handleKeyDown}
           textareaRef={textareaRef}
           sessionLocked={sessionLocked}
-          toolbarSlots={{ modelSelect, sendButton, attachButton }}
+          toolbarSlots={{ modelSelect, sendButton, attachButton, privateModeToggle }}
           attachmentBar={attachmentBar}
           contextMeter={contextMeter}
           suggestions={suggestions}
@@ -1144,6 +1169,7 @@ export default function App() {
               disabled={sessionLocked}
               sendButton={sendButton}
               attachButton={attachButton}
+              privateModeToggle={privateModeToggle}
               attachmentBar={attachmentBar}
               contextMeter={contextMeter}
               renderMessageContent={props => <MessageContent {...props} />}

--- a/client/src/api/config.js
+++ b/client/src/api/config.js
@@ -1,5 +1,5 @@
 // Agent 行为参数配置 + API Key 只读状态 API。
-// GET 拉取当前配置/默认值/Key 状态；POST 保存参数；reset 恢复默认。
+// GET 拉取当前配置/内置默认值/Key 状态；POST 保存 Agent 参数；execution 单独 PUT，reset 只重置 Agent 覆盖。
 import { apiFetch } from './http.js';
 
 export async function fetchConfig(projectId) {
@@ -26,6 +26,18 @@ export async function saveConfig(patch) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(patch),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+  return data;
+}
+
+// Worker/Sandbox 是后端启动配置，保存后需重启后端才会重新创建运行器。
+export async function saveExecution(execution) {
+  const res = await apiFetch('/api/config/execution', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(execution),
   });
   const data = await res.json().catch(() => ({}));
   if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);

--- a/client/src/components/AgentComposer.jsx
+++ b/client/src/components/AgentComposer.jsx
@@ -9,11 +9,12 @@ export function AgentComposer({
   disabled = false,
   modelSelect = null,
   attachButton = null,
+  privateModeToggle = null,
   sendButton = null,
   attachmentBar = null,
   contextMeter = null,
 }) {
-  const hasToolbar = Boolean(modelSelect || attachButton || contextMeter || sendButton);
+  const hasToolbar = Boolean(modelSelect || attachButton || privateModeToggle || contextMeter || sendButton);
 
   return (
     <div className={`agent-composer agent-composer--${variant}`}>
@@ -31,6 +32,7 @@ export function AgentComposer({
         <div className="agent-composer-toolbar">
           {modelSelect}
           {attachButton}
+          {privateModeToggle}
           {contextMeter && <div className="agent-composer-context">{contextMeter}</div>}
           {sendButton}
         </div>

--- a/client/src/components/AgentWorkspacePane.jsx
+++ b/client/src/components/AgentWorkspacePane.jsx
@@ -26,6 +26,7 @@ export function AgentWorkspacePane({
   disabled,
   sendButton,
   attachButton,
+  privateModeToggle,
   attachmentBar,
   contextMeter,
   renderMessageContent,
@@ -96,6 +97,7 @@ export function AgentWorkspacePane({
             rows={1}
             disabled={disabled}
             attachButton={attachButton}
+            privateModeToggle={privateModeToggle}
             sendButton={sendButton}
             attachmentBar={attachmentBar}
             contextMeter={contextMeter}

--- a/client/src/components/HeroScreen.jsx
+++ b/client/src/components/HeroScreen.jsx
@@ -16,8 +16,8 @@ function readSuggestionsHidden() {
 
 // 首屏：输入卡 + 推荐列表。
 // 会话/设置入口由父组件渲染在 main-area 右上角(.hero-corner-actions),不在 hero 容器内。
-// 工具栏控件（ModelSelector / SendButton / AttachButton）
-// 由父组件传 slot 进来——它们在 hero 和 layout header 两处会复用同一个实例。
+// 工具栏控件（模型、附件、隐私模式、发送）由父组件传 slot 进来，
+// hero 和 workspace 布局共用同一组状态与元素定义。
 export function HeroScreen({
   input,
   setInput,
@@ -35,17 +35,17 @@ export function HeroScreen({
   onPickSuggestion,
   onSubmitSuggestion,
 }) {
-  const { modelSelect, sendButton, attachButton } = toolbarSlots;
+  const { modelSelect, sendButton, attachButton, privateModeToggle } = toolbarSlots;
   const t = useT();
   const [suggestionsHidden, setSuggestionsHidden] = useState(readSuggestionsHidden);
 
   const hideSuggestions = () => {
     setSuggestionsHidden(true);
-    try { localStorage.setItem(SUGGESTIONS_HIDDEN_KEY, '1'); } catch { /* 隐私模式下忽略写入失败 */ }
+    try { localStorage.setItem(SUGGESTIONS_HIDDEN_KEY, '1'); } catch { /* localStorage 不可用时忽略 */ }
   };
   const showSuggestions = () => {
     setSuggestionsHidden(false);
-    try { localStorage.removeItem(SUGGESTIONS_HIDDEN_KEY); } catch { /* 隐私模式下忽略写入失败 */ }
+    try { localStorage.removeItem(SUGGESTIONS_HIDDEN_KEY); } catch { /* localStorage 不可用时忽略 */ }
   };
 
   return (
@@ -67,6 +67,7 @@ export function HeroScreen({
           disabled={sessionLocked}
           modelSelect={modelSelect}
           attachButton={attachButton}
+          privateModeToggle={privateModeToggle}
           sendButton={sendButton}
           attachmentBar={attachmentBar}
           contextMeter={contextMeter}

--- a/client/src/components/dialogs/SettingsDialog.jsx
+++ b/client/src/components/dialogs/SettingsDialog.jsx
@@ -127,7 +127,7 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
       .catch(e => { if (alive) setError(e.message); })
       .finally(() => { if (alive) setLoading(false); });
     return () => { alive = false; };
-  }, []);
+  }, [activeProjectId]);
 
   const setField = (key, value) => {
     setAgent(prev => ({ ...prev, [key]: value }));

--- a/client/src/components/dialogs/SettingsDialog.jsx
+++ b/client/src/components/dialogs/SettingsDialog.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Palette, SlidersHorizontal, Brain, KeyRound, Minus, Plus, Plug, ChevronDown, ChevronRight, Trash2, Boxes } from 'lucide-react';
-import { fetchConfig, saveConfig, saveTools, resetConfig, applyConfigProfile, saveMcpServer, deleteMcpServer, testMcpServer } from '../../api/config.js';
+import { fetchConfig, saveConfig, saveExecution, saveTools, resetConfig, applyConfigProfile, saveMcpServer, deleteMcpServer, testMcpServer } from '../../api/config.js';
 import { useTheme } from '../../theme/ThemeProvider.jsx';
 import { useI18n, useT } from '../../i18n/I18nProvider.jsx';
 import { DialogShell } from './DialogShell.jsx';
 
-// Agent 行为参数（可写，热生效）。单位与 .env 一致，换算放后端消费点。
+// Agent 行为参数（可写，下一次任务生效）。单位与后端 schema 一致，换算放消费点。
 // label 改为 i18n key，渲染时经 t() 取文案。
 const BASIC_AGENT_FIELDS = [
   { key: 'maxSteps', labelKey: 'settings.maxSteps' },
@@ -40,6 +40,11 @@ const FONT_SIZE_OPTIONS = [
 
 const PROFILE_OPTIONS = ['fast', 'balanced', 'deep', 'safe'];
 
+const DEFAULT_EXECUTION = {
+  sandboxedWorkers: true,
+  workerSandbox: true,
+};
+
 const DEFAULT_MCP_SERVERS = {
   chrome: {
     enabled: false,
@@ -66,7 +71,7 @@ const GROUPS = [
 
 // 设置面板：左导航分组 + 右内容。
 // 外观（主题/语言，前台即时生效）、Agent 参数（保存后下次任务生效）、
-// 记忆（记忆开关为前端偏好即时生效 + 记忆最大条数后端参数）、API Key 只读展示。
+// Worker 部署开关（保存后需重启）、记忆前端偏好和 API Key 只读展示。
 export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activeProjectId = null, projects = [] }) {
   const t = useT();
   const { theme, setTheme, fontSize, setFontSize } = useTheme();
@@ -76,6 +81,9 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
   const [tools, setTools] = useState({ vision: {}, distill: {} });
   const [toolsScope, setToolsScope] = useState(activeProjectId || '');
   const [sources, setSources] = useState({});
+  const [execution, setExecution] = useState(DEFAULT_EXECUTION);
+  const [executionSources, setExecutionSources] = useState({});
+  const [executionDirty, setExecutionDirty] = useState(false);
   const [schema, setSchema] = useState({});
   const [profile, setProfile] = useState('custom');
   const [profiles, setProfiles] = useState({});
@@ -88,11 +96,14 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [saved, setSaved] = useState(false);
+  const [restartRequired, setRestartRequired] = useState(false);
 
   const applyConfigData = data => {
     if (data.agent) setAgent(data.agent);
     if (data.tools) setTools({ vision: data.tools.vision || {}, distill: data.tools.distill || {} });
     if (data.sources) setSources(data.sources);
+    if (data.execution) setExecution({ ...DEFAULT_EXECUTION, ...data.execution });
+    if (data.executionSources) setExecutionSources(data.executionSources);
     if (data.schema) setSchema(data.schema);
     if (data.profile) setProfile(data.profile);
     if (data.profiles) setProfiles(data.profiles);
@@ -120,6 +131,12 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
 
   const setField = (key, value) => {
     setAgent(prev => ({ ...prev, [key]: value }));
+    setSaved(false);
+  };
+
+  const setExecutionField = (key, value) => {
+    setExecution(current => ({ ...current, [key]: value }));
+    setExecutionDirty(true);
     setSaved(false);
   };
 
@@ -178,9 +195,21 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
   const handleSave = async () => {
     setSaving(true);
     setError('');
+    const shouldSaveExecution = executionDirty;
     try {
-      const data = await saveConfig(agent);
+      // 先保存热生效的 Agent 参数，再按需保存需要重启的 Worker 部署选项。
+      const agentData = await saveConfig(agent);
+      let data = agentData;
+      if (shouldSaveExecution) {
+        const executionPatch = { sandboxedWorkers: execution.sandboxedWorkers };
+        // 环境变量覆盖的字段不可由 UI 回写，避免覆盖用户在配置文件里保存的值。
+        if (executionSources.workerSandbox !== 'env') executionPatch.workerSandbox = execution.workerSandbox;
+        const executionData = await saveExecution(executionPatch);
+        data = { ...agentData, ...executionData };
+      }
       applyConfigData(data);
+      setExecutionDirty(false);
+      if (shouldSaveExecution) setRestartRequired(true);
       setSaved(true);
     } catch (e) {
       setError(e.message);
@@ -195,6 +224,7 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
     try {
       const data = await resetConfig();
       applyConfigData(data);
+      setExecutionDirty(false);
       setSaved(true);
     } catch (e) {
       setError(e.message);
@@ -209,6 +239,7 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
     try {
       const data = await applyConfigProfile(nextProfile);
       applyConfigData(data);
+      setExecutionDirty(false);
       setSaved(true);
     } catch (e) {
       setError(e.message);
@@ -320,6 +351,8 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
     if (!agent) return <p className="settings-error">{error || t('common.loadFailed')}</p>;
     return null;
   };
+
+  const workerSandboxDisabled = !execution.sandboxedWorkers || executionSources.workerSandbox === 'env';
 
   const renderMcpServer = name => {
     const fallback = DEFAULT_MCP_SERVERS[name] || { enabled: false, transport: { type: 'stdio', command: '', args: [], cwd: '.' } };
@@ -521,17 +554,51 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
                 {t('settings.advanced')}
               </button>
               {advancedOpen && (
-                <div className="settings-grid settings-advanced-grid">
-                  {ADVANCED_AGENT_FIELDS.map(f => numberField(f.key, f.labelKey))}
-                  <label className="settings-field settings-field-switch">
-                    <span>{t('settings.observeDesktop')}</span>
-                    <input
-                      type="checkbox"
-                      checked={!!agent.observeDesktop}
-                      onChange={e => setField('observeDesktop', e.target.checked)}
-                    />
-                  </label>
-                </div>
+                <>
+                  <div className="settings-grid settings-advanced-grid">
+                    {ADVANCED_AGENT_FIELDS.map(f => numberField(f.key, f.labelKey))}
+                    <label className="settings-field settings-field-switch">
+                      <span className="settings-field-label">
+                        <span>{t('settings.observeDesktop')}</span>
+                        {sources.observeDesktop && <small>{t(`settings.source.${sources.observeDesktop}`)}</small>}
+                      </span>
+                      <input
+                        type="checkbox"
+                        checked={!!agent.observeDesktop}
+                        onChange={e => setField('observeDesktop', e.target.checked)}
+                      />
+                    </label>
+                    <label className="settings-field settings-field-switch">
+                      <span className="settings-field-label">
+                        <span>{t('settings.sandboxedWorkers')}</span>
+                        {executionSources.sandboxedWorkers && <small>{t(`settings.source.${executionSources.sandboxedWorkers}`)}</small>}
+                      </span>
+                      <input
+                        type="checkbox"
+                        checked={!!execution.sandboxedWorkers}
+                        onChange={e => setExecutionField('sandboxedWorkers', e.target.checked)}
+                        disabled={saving}
+                      />
+                    </label>
+                    <label className="settings-field settings-field-switch">
+                      <span className="settings-field-label">
+                        <span>{t('settings.workerSandbox')}</span>
+                        {executionSources.workerSandbox && <small>{t(`settings.source.${executionSources.workerSandbox}`)}</small>}
+                      </span>
+                      <input
+                        type="checkbox"
+                        checked={!!execution.workerSandbox}
+                        onChange={e => setExecutionField('workerSandbox', e.target.checked)}
+                        disabled={saving || workerSandboxDisabled}
+                        title={executionSources.workerSandbox === 'env' ? t('settings.workerSandboxEnvOverride') : undefined}
+                      />
+                    </label>
+                  </div>
+                  <p className="dialog-desc">{t('settings.executionRestartDesc')}</p>
+                  {executionSources.workerSandbox === 'env' && (
+                    <p className="dialog-desc">{t('settings.workerSandboxEnvOverride')}</p>
+                  )}
+                </>
               )}
             </>
           )}
@@ -648,7 +715,8 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
     );
   };
 
-  // 保存/重置只对后端 agent 配置生效，外观/记忆开关是前端偏好（即时生效，无需保存）。
+  // Agent 页保存热配置及已修改的 execution，Models 页保存工具覆盖；
+  // 外观/记忆是即时前端偏好，Memory 页沿用现有共享 footer。
   const showSaveBar = activeGroup === 'agent' || activeGroup === 'memory' || activeGroup === 'models';
   const activeGroupLabel = t(GROUPS.find(group => group.id === activeGroup)?.labelKey || 'settings.title');
 
@@ -687,6 +755,7 @@ export function SettingsDialog({ onClose, agentMemory, setAgentMemory, activePro
             {renderGroup()}
             {showSaveBar && error && <p className="settings-error">{error}</p>}
             {showSaveBar && saved && !error && <p className="settings-ok">{t('common.saved')}</p>}
+            {activeGroup === 'agent' && restartRequired && !error && <p className="settings-ok">{t('settings.executionRestartSaved')}</p>}
           </div>
         </div>
 

--- a/client/src/hooks/useAgentTransport.js
+++ b/client/src/hooks/useAgentTransport.js
@@ -32,6 +32,7 @@ export function useAgentTransport({
   selectedAgentModels,
   agentStrategy,
   agentMemory,
+  agentPrivateMode,
   availableModels,
   // refs
   agentRunIdRef,
@@ -143,6 +144,7 @@ export function useAgentTransport({
         models: runModels,
         strategy: runStrategy,
         memory: agentMemory,
+        privateMode: agentPrivateMode,
         // 当前会话归属的项目，后端据此隔离记忆/文件根/trace/checkpoint。
         projectId: activeSession.projectId ?? null,
         sessionId,

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -204,8 +204,9 @@ function stripAgentRunTraces(agentRuns) {
 
 function stripAgentTrace(sessions) {
   // agentTrace 是 SSE 事件流的客户端镜像，单个 run 可达几 MB。
-  // 服务端已经在 data/traces/<runId>.jsonl 全量落盘，并通过 /api/agent/traces/:runId 提供按需拉取，
-  // localStorage 只需要保存 agentRunId，刷新后由 App.jsx 的 useEffect 触发拉取重建。
+  // 普通 run 的 trace 由服务端 JSONL 保存，并通过 /api/agent/traces/:runId 按需拉取；
+  // chat-sessions.json 只保存消息/运行摘要，前端在需要时由 App.jsx 重新拉取 trace。
+  // 隐私 run 不会写入上述两类文件，因此其 trace 只在当前内存状态中短暂存在。
   return sessions.map(session => {
     const agentRuns = stripAgentRunTraces(session.agentRuns);
     if ((session.agentTrace && session.agentTrace.length) || agentRuns !== session.agentRuns) {
@@ -215,8 +216,32 @@ function stripAgentTrace(sessions) {
   });
 }
 
-export function useChatSessions() {
+function cloneJson(value) {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    // 会话状态应始终是 JSON 可序列化的；如果未来加入非 JSON 字段，
+    // 至少保留引用让页面继续可用，而不因为隐私清理导致崩溃。
+    return value;
+  }
+}
+
+function cloneChatState(state) {
+  return {
+    sessions: cloneJson(state.sessions),
+    activeSessionId: state.activeSessionId,
+  };
+}
+
+function cloneSyncedSessions(sessions) {
+  return new Map([...sessions].map(([id, session]) => [id, cloneJson(session)]));
+}
+
+export function useChatSessions({ privateMode = false } = {}) {
+  const privateModeEnabled = privateMode === true;
   const [chatState, setChatState] = useState(() => normalizeChatState({ sessions: [], activeSessionId: null }));
+  const chatStateRef = useRef(chatState);
+  chatStateRef.current = chatState;
   const [sessionsLoading, setSessionsLoading] = useState(true);
   const [sessionsError, setSessionsError] = useState(null);
   const hydratedRef = useRef(false);
@@ -224,12 +249,33 @@ export function useChatSessions() {
   // 上一次成功同步到后端的快照(id -> 已 strip 的会话)。diff 只针对本客户端自己
   // 见过的会话——因此过期客户端永远无法删除它从未见过的会话。
   const lastSyncedRef = useRef(new Map());
+  // 隐私模式期间的会话只存在于内存。退出隐私模式时恢复进入前的快照，
+  // 防止用户稍后切回普通模式时把隐私消息补写进 chat-sessions.json。
+  const privateModeRef = useRef(privateModeEnabled);
+  const privateSnapshotRef = useRef(null);
+  const restoringPrivateRef = useRef(false);
   const { sessions, activeSessionId } = chatState;
   const activeSession = sessions.find(session => session.id === activeSessionId) || sessions[0];
 
+  const preparePrivateMode = useCallback(() => {
+    if (privateModeRef.current || !hydratedRef.current) return;
+    // 某些入口（例如刷新后重连）会在同一批 React 更新里切换隐私模式并写入
+    // 临时占位消息；必须在这些更新之前显式冻结普通会话快照，避免退出隐私
+    // 模式时把占位消息当成“进入前状态”恢复并补写到后端。
+    privateSnapshotRef.current = {
+      chatState: cloneChatState(chatStateRef.current),
+      lastSynced: cloneSyncedSessions(lastSyncedRef.current),
+    };
+    // 立即挡住 300ms debounce/串行队列中尚未发出的普通同步请求，不必等 effect 执行。
+    privateModeRef.current = true;
+  }, []);
+
   useEffect(() => {
     const controller = new AbortController();
-    apiFetch('/api/sessions', { signal: controller.signal })
+    apiFetch('/api/sessions', {
+      signal: controller.signal,
+      ...(privateModeEnabled ? { headers: { 'X-Private-Mode': 'true' } } : {}),
+    })
       .then(async response => {
         const data = await response.json().catch(() => ({}));
         if (!response.ok) throw new Error(data.error || `HTTP ${response.status}`);
@@ -239,8 +285,14 @@ export function useChatSessions() {
           activeSessionId: data.activeSessionId,
         });
         setChatState(next);
-        lastSyncedRef.current = new Map(stripAgentTrace(next.sessions).map(session => [session.id, session]));
+        lastSyncedRef.current = new Map(stripAgentTrace(next.sessions).map(session => [session.id, cloneJson(session)]));
         hydratedRef.current = true;
+        if (privateModeRef.current) {
+          privateSnapshotRef.current = {
+            chatState: cloneChatState(next),
+            lastSynced: cloneSyncedSessions(lastSyncedRef.current),
+          };
+        }
         setSessionsError(null);
         setSessionsLoading(false);
       })
@@ -252,6 +304,30 @@ export function useChatSessions() {
     return () => controller.abort();
   }, []);
 
+  useEffect(() => {
+    const previous = privateModeRef.current;
+    if (privateModeEnabled && !previous) {
+      if (hydratedRef.current) {
+        privateSnapshotRef.current = {
+          chatState: cloneChatState(chatState),
+          lastSynced: cloneSyncedSessions(lastSyncedRef.current),
+        };
+      }
+    } else if (!privateModeEnabled && previous) {
+      const snapshot = privateSnapshotRef.current;
+      privateSnapshotRef.current = null;
+      if (snapshot) {
+        // persistence effect 会在本轮看到这个标志并跳过一次，等待恢复后的
+        // state 重新渲染；若进入隐私前还有普通模式未同步的改动，下一轮 diff
+        // 仍会正常补写它们。
+        restoringPrivateRef.current = true;
+        lastSyncedRef.current = cloneSyncedSessions(snapshot.lastSynced);
+        setChatState(snapshot.chatState);
+      }
+    }
+    privateModeRef.current = privateModeEnabled;
+  }, [privateModeEnabled]);
+
   // 只把“发生变化的那一条”同步到后端,永不推整份列表:
   //   - 新建 / 内容变化(updatedAt 改变) → 单条 PUT /api/sessions/:id
   //   - 从本客户端列表消失(仅永久删除会走这条) → 单条 DELETE /api/sessions/:id
@@ -259,6 +335,11 @@ export function useChatSessions() {
   // 绝不会误删它从未见过的会话——这正是历史上“整列表覆盖写”丢会话的根因。
   useEffect(() => {
     if (!hydratedRef.current) return undefined;
+    if (privateModeEnabled) return undefined;
+    if (restoringPrivateRef.current) {
+      restoringPrivateRef.current = false;
+      return undefined;
+    }
     const current = stripAgentTrace(sessions);
     const currentById = new Map(current.map(session => [session.id, session]));
     const previous = lastSyncedRef.current;
@@ -273,15 +354,22 @@ export function useChatSessions() {
       persistChainRef.current = persistChainRef.current
         .catch(() => {})
         .then(async () => {
+          // 模式可能在 300ms 延迟或串行队列等待期间切换；再次检查，
+          // 避免已经排队的普通模式请求把隐私 state 发送出去。
+          if (privateModeRef.current) return;
           for (const session of deletes) {
+            if (privateModeRef.current) return;
             const query = session.projectId ? `?projectId=${encodeURIComponent(session.projectId)}` : '';
-            const response = await apiFetch(`/api/sessions/${encodeURIComponent(session.id)}${query}`, { method: 'DELETE' });
+            const response = await apiFetch(`/api/sessions/${encodeURIComponent(session.id)}${query}`, {
+              method: 'DELETE',
+            });
             if (!response.ok && response.status !== 404) {
               const data = await response.json().catch(() => ({}));
               throw new Error(data.error || `HTTP ${response.status}`);
             }
           }
           for (const session of upserts) {
+            if (privateModeRef.current) return;
             const response = await apiFetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
               method: 'PUT',
               headers: { 'Content-Type': 'application/json' },
@@ -292,6 +380,7 @@ export function useChatSessions() {
               throw new Error(data.error || `HTTP ${response.status}`);
             }
           }
+          if (privateModeRef.current) return;
           lastSyncedRef.current = currentById;
           setSessionsError(null);
         })
@@ -302,7 +391,7 @@ export function useChatSessions() {
         });
     }, 300);
     return () => clearTimeout(timer);
-  }, [sessions]);
+  }, [privateModeEnabled, sessions]);
 
   const updateSession = useCallback((sessionId, updater) => {
     setChatState(prev =>
@@ -320,6 +409,7 @@ export function useChatSessions() {
     activeSession,
     messages: activeSession.messages,
     updateSession,
+    preparePrivateMode,
     sessionsLoading,
     sessionsError,
   };

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -241,7 +241,6 @@ export function useChatSessions({ privateMode = false } = {}) {
   const privateModeEnabled = privateMode === true;
   const [chatState, setChatState] = useState(() => normalizeChatState({ sessions: [], activeSessionId: null }));
   const chatStateRef = useRef(chatState);
-  chatStateRef.current = chatState;
   const [sessionsLoading, setSessionsLoading] = useState(true);
   const [sessionsError, setSessionsError] = useState(null);
   const hydratedRef = useRef(false);
@@ -252,10 +251,15 @@ export function useChatSessions({ privateMode = false } = {}) {
   // 隐私模式期间的会话只存在于内存。退出隐私模式时恢复进入前的快照，
   // 防止用户稍后切回普通模式时把隐私消息补写进 chat-sessions.json。
   const privateModeRef = useRef(privateModeEnabled);
+  const initialPrivateModeRef = useRef(privateModeEnabled);
   const privateSnapshotRef = useRef(null);
   const restoringPrivateRef = useRef(false);
   const { sessions, activeSessionId } = chatState;
   const activeSession = sessions.find(session => session.id === activeSessionId) || sessions[0];
+
+  useEffect(() => {
+    chatStateRef.current = chatState;
+  }, [chatState]);
 
   const preparePrivateMode = useCallback(() => {
     if (privateModeRef.current || !hydratedRef.current) return;
@@ -274,7 +278,7 @@ export function useChatSessions({ privateMode = false } = {}) {
     const controller = new AbortController();
     apiFetch('/api/sessions', {
       signal: controller.signal,
-      ...(privateModeEnabled ? { headers: { 'X-Private-Mode': 'true' } } : {}),
+      ...(initialPrivateModeRef.current ? { headers: { 'X-Private-Mode': 'true' } } : {}),
     })
       .then(async response => {
         const data = await response.json().catch(() => ({}));
@@ -309,7 +313,7 @@ export function useChatSessions({ privateMode = false } = {}) {
     if (privateModeEnabled && !previous) {
       if (hydratedRef.current) {
         privateSnapshotRef.current = {
-          chatState: cloneChatState(chatState),
+          chatState: cloneChatState(chatStateRef.current),
           lastSynced: cloneSyncedSessions(lastSyncedRef.current),
         };
       }

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -56,6 +56,9 @@ export const en = {
 
   // Input box
   'input.agentPlaceholder': 'Describe the task for the Agent…',
+  'input.privateMode': 'Private mode',
+  'input.privateModeOff': 'Enable private mode: this task will not save chat sessions, run logs, LLM logs, or screenshots; the built-in browser uses a temporary profile.',
+  'input.privateModeOn': 'Private mode is on: this task will not save chat sessions, run logs, LLM logs, or screenshots, and built-in browser data is cleared when it ends.',
   'context.label': 'Context estimate',
   'context.actualLabel': 'Actual context',
   'context.summary': 'First {used}/{limit} tok · {percent}%',
@@ -103,6 +106,11 @@ export const en = {
   'settings.maxResultChars': 'Max chars per step result',
   'settings.memoryEnabled': 'Enable memory',
   'settings.memoryDesc': 'Whether the agent uses project knowledge and the code graph to assist tasks (frontend preference, applies immediately).',
+  'settings.sandboxedWorkers': 'Enable isolated Workers',
+  'settings.workerSandbox': 'Enable macOS Sandbox',
+  'settings.executionRestartDesc': 'These are startup settings: restart the backend after saving for them to take effect. Worker Sandbox is unavailable when isolated Workers are disabled.',
+  'settings.workerSandboxEnvOverride': 'The AGENT_WORKER_SANDBOX environment variable is overriding this setting.',
+  'settings.executionRestartSaved': 'Worker startup settings saved; restart the backend for them to take effect.',
   'settings.observeDesktop': 'Observe macOS desktop',
   'settings.autoModelRouting': 'Dynamic model routing',
   'settings.profile': 'Execution profile',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -57,6 +57,9 @@ export const zh = {
 
   // 输入框
   'input.agentPlaceholder': '描述要让 Agent 完成的任务…',
+  'input.privateMode': '隐私模式',
+  'input.privateModeOff': '开启隐私模式：本次任务不保存聊天会话、运行日志、LLM 日志和截图；内置浏览器使用一次性 profile。',
+  'input.privateModeOn': '隐私模式已开启：本次任务不保存聊天会话、运行日志、LLM 日志和截图，任务结束后清除内置浏览器数据。',
   'context.label': 'Context 预估',
   'context.actualLabel': 'Context 实际',
   'context.summary': '首轮 {used}/{limit} tok · {percent}%',
@@ -104,6 +107,11 @@ export const zh = {
   'settings.maxResultChars': '每步结果最大字符数',
   'settings.memoryEnabled': '启用记忆',
   'settings.memoryDesc': 'Agent 是否使用项目知识和代码图谱辅助任务（前端偏好，即时生效）。',
+  'settings.sandboxedWorkers': '启用独立 Worker',
+  'settings.workerSandbox': '启用 macOS Sandbox',
+  'settings.executionRestartDesc': '这是启动配置：保存后需重启后端才会生效。关闭独立 Worker 后，Worker Sandbox 也会不可用。',
+  'settings.workerSandboxEnvOverride': 'AGENT_WORKER_SANDBOX 环境变量正在覆盖此设置。',
+  'settings.executionRestartSaved': 'Worker 启动配置已保存；重启后端后生效。',
   'settings.observeDesktop': '观测 macOS 桌面',
   'settings.autoModelRouting': '动态模型路由',
   'settings.profile': '运行配置',

--- a/helpers/agent-logging.ts
+++ b/helpers/agent-logging.ts
@@ -68,7 +68,9 @@ function summarizeAgentActionForLog(action) {
   return base;
 }
 
-export function logAgentEvent(event) {
+export function logAgentEvent(event, { persist = true }: { persist?: boolean } = {}) {
+  // private run 仍由上层发送 SSE；这里仅控制传统 app 运行日志是否持久化。
+  if (!persist) return;
   const time = formatLogTime();
 
   if (event.type === 'status') {

--- a/helpers/logger.ts
+++ b/helpers/logger.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getLogPolicy, pruneLogTreeSync, rotateLogFileSync } from './log-policy.ts';
 import { redactSensitiveData, redactText } from './redact.ts';
+import { isPrivateRun } from './private-run.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LOG_DIR = join(__dirname, '..', 'data', 'logs');
@@ -37,6 +38,9 @@ function fmt(level, args) {
 }
 
 function writeToFile(level, args) {
+  // 隐私任务仍允许输出仅存于当前进程的控制台诊断，
+  // 但绝不能把本次运行内容追加到持久化 app 日志。
+  if (isPrivateRun()) return;
   const ts = new Date().toISOString();
   const line = args.map(a => {
     if (typeof a === 'string') return redactText(a);

--- a/helpers/private-run-artifacts.ts
+++ b/helpers/private-run-artifacts.ts
@@ -1,0 +1,26 @@
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { removeCheckpoint, removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
+import { deleteTrace } from './trace-store.ts';
+
+const SAFE_RUN_ID_RE = /^run_[a-z0-9]+_[a-z0-9]+$/i;
+
+/**
+ * 删除单个隐私 run 可能留下的、且能按 runId 定位的持久化产物。
+ *
+ * 只接受标准 runId，并且所有目标都是 dataDir 下的固定子路径，避免把清理范围
+ * 扩大到项目目录中的其他数据。该函数用于启动前清掉复用 runId 的旧产物，
+ * 以及正常结束或可捕获异常收尾时清理半成品；无法覆盖进程硬崩溃/断电场景。
+ * 普通日志、LLM 日志和 chat-sessions 不在这里按 runId 删除，而是依靠写入前拦截。
+ */
+export async function removePrivateRunArtifacts(dataDir: string | undefined, runId: string): Promise<void> {
+  if (!dataDir || !SAFE_RUN_ID_RE.test(runId)) return;
+
+  await Promise.all([
+    deleteTrace(dataDir, runId),
+    removeCheckpoint(dataDir, runId),
+    removeSessionCheckpoints(dataDir, runId),
+    rm(join(dataDir, 'worker-logs', `${runId}.log`), { force: true }).catch(() => {}),
+    rm(join(dataDir, 'screenshots', runId), { recursive: true, force: true }).catch(() => {}),
+  ]);
+}

--- a/helpers/private-run.ts
+++ b/helpers/private-run.ts
@@ -1,0 +1,23 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface PrivateRunContext {
+  privateMode: boolean;
+}
+
+const privateRunStorage = new AsyncLocalStorage<PrivateRunContext>();
+
+/**
+ * 在一次 Agent 运行的异步调用链中标记隐私模式。
+ *
+ * 运行期间仍可以把事件发送到当前页面；已接入该上下文的持久化适配器
+ * （普通日志、LLM 日志、trace、checkpoint 等）会跳过磁盘写入。
+ */
+export function withPrivateRun<T>(privateMode: boolean, fn: () => T): T {
+  // 嵌套调用不能用 false 关闭外层隐私标记，避免异步子流程意外恢复写盘。
+  const inheritedPrivateMode = privateRunStorage.getStore()?.privateMode === true;
+  return privateRunStorage.run({ privateMode: inheritedPrivateMode || privateMode === true }, fn);
+}
+
+export function isPrivateRun(): boolean {
+  return privateRunStorage.getStore()?.privateMode === true;
+}

--- a/helpers/run-agent.ts
+++ b/helpers/run-agent.ts
@@ -1,10 +1,10 @@
 /**
  * Run Agent — 任务执行的共享工具函数
  *
- * 从 server.ts 和 routes/agent.ts 提取的公共逻辑：
+ * 从 server.ts 和 routes/agent-run-*.ts 提取的公共逻辑：
  *   - 事件分发（store + reconnect 转发）
  *   - 记忆加载 + systemPrompt 构建
- *   - 运行后清理（checkpoint + run 关闭）
+ *   - 运行收尾（持久化 flush、checkpoint/隐私产物清理、Chrome MCP 状态清理、run 关闭）
  */
 
 import { loadMemory, buildMemoryPrompt } from '../agent/core/memory.ts';
@@ -13,6 +13,8 @@ import { shutdownChromeMcp, closeAllChromePagesQuiet, loadChromeMcpConfig } from
 import { resetChromeSnapshotState } from '../agent/tools/chrome/execute.ts';
 import { appendTraceEvent } from './trace-store.ts';
 import { log } from './logger.ts';
+import { isPrivateRun, withPrivateRun } from './private-run.ts';
+import { removePrivateRunArtifacts } from './private-run-artifacts.ts';
 import type { AgentEvent, AgentRunStore, TerminalRunStatus } from '../agent/core/contracts.ts';
 import { redactSensitiveData } from './redact.ts';
 
@@ -63,7 +65,12 @@ function buildOperation(payload: any) {
   return payload?.type || 'event';
 }
 
-export function createBaseEventSender(runId: string, agentRunStore: AgentRunStore, memoryDir?: string) {
+export function createBaseEventSender(
+  runId: string,
+  agentRunStore: AgentRunStore,
+  memoryDir?: string,
+  { persistTrace = true }: { persistTrace?: boolean } = {},
+) {
   const stageTimes = new Map<string, number>();
   const modelTimes = new Map<string, number>();
 
@@ -121,11 +128,14 @@ export function createBaseEventSender(runId: string, agentRunStore: AgentRunStor
 
     const sequencedEvent = agentRunStore.addEvent(runId, event);
     const run = agentRunStore.getRun(runId);
-    const writeTrace = () => appendTraceEvent(memoryDir, runId, sequencedEvent);
-    const traceWrite = run?.persistence ? run.persistence.enqueue(writeTrace) : writeTrace();
-    traceWrite.catch((err: any) => {
-      log.warn(`[TraceStore] append failed runId=${runId}: ${err.message}`);
-    });
+    // 事件先进入内存 run store 并发送给 SSE；隐私任务只跳过 JSONL trace 的持久化。
+    if (persistTrace && !isPrivateRun()) {
+      const writeTrace = () => appendTraceEvent(memoryDir, runId, sequencedEvent);
+      const traceWrite = run?.persistence ? run.persistence.enqueue(writeTrace) : writeTrace();
+      traceWrite.catch((err: any) => {
+        log.warn(`[TraceStore] append failed runId=${runId}: ${err.message}`);
+      });
+    }
     if (run?._reconnectWriters) {
       for (const writer of run._reconnectWriters) {
         writer(sequencedEvent);
@@ -147,17 +157,24 @@ export async function loadMemoryForPrompt(memoryDir: string) {
 }
 
 export async function cleanupAgentRun(
-  checkpointDir: string | undefined,
+  checkpointDir: string | null | undefined,
   runId: string,
   agentRunStore: AgentRunStore,
   { removeSnapshots = false, finalStatus }: { removeSnapshots?: boolean; finalStatus?: TerminalRunStatus } = {},
 ) {
+  // start 路由、取消路径和 checkpoint resume 都会调用这里；先 flush 串行写队列，
+  // 再清理文件并关闭 run，保证最后一个事件/快照不会在清理之后落盘。
   const run = agentRunStore.getRun(runId);
+  const privateMode = run?.meta?.privateMode === true;
   await run?.persistence?.flush();
-  if (checkpointDir) {
+  if (privateMode) {
+    const dataDir = typeof run?.meta?.dataDir === 'string' ? run.meta.dataDir : checkpointDir;
+    await withPrivateRun(true, () => removePrivateRunArtifacts(dataDir, runId));
+  }
+  if (checkpointDir && !privateMode) {
     // step-level checkpoint 只用于崩溃恢复，任务完成后可删除
     await removeCheckpoint(checkpointDir, runId).catch(() => {});
-    // session snapshots 用于回滚，只在启动新任务时才清理
+    // Session 快照用于回滚，默认保留；只有调用方明确要求批量收尾时才删除。
     if (removeSnapshots) {
       await removeSessionCheckpoints(checkpointDir, runId).catch(() => {});
     }
@@ -171,14 +188,18 @@ export async function cleanupAgentRun(
   const chromeConfig = loadChromeMcpConfig();
   if (!chromeConfig.keepTabs) {
     await closeAllChromePagesQuiet().catch(err => {
-      log.warn(`[cleanupAgentRun] closeAllChromePages 失败 runId=${runId} ${err?.message || err}`);
+      if (!privateMode) {
+        log.warn(`[cleanupAgentRun] closeAllChromePages 失败 runId=${runId} ${err?.message || err}`);
+      }
     });
   }
   // 只关闭本进程里的 Chrome MCP SSE client；外部 chrome:mcp bridge 和 Chrome 继续由独立进程管理。
   // 如果更看重复用连接，可在 .env 设 CHROME_MCP_KEEP_OPEN=true 跳过。
   if (!chromeConfig.keepOpen) {
     await shutdownChromeMcp().catch(err => {
-      log.warn(`[cleanupAgentRun] shutdownChromeMcp 失败 runId=${runId} ${err?.message || err}`);
+      if (!privateMode) {
+        log.warn(`[cleanupAgentRun] shutdownChromeMcp 失败 runId=${runId} ${err?.message || err}`);
+      }
     });
   }
 }

--- a/helpers/run-store.ts
+++ b/helpers/run-store.ts
@@ -2,9 +2,9 @@
  * Agent Run Store — 管理 Agent 运行记录和 SSE 事件存储
  *
  * 调用场景：
- *   - server.js 启动时创建唯一实例
- *   - 传入 routes/agent.js 使用
- *   - POST /api/agent → createRun → 整个运行周期 → closeRun
+ *   - server.ts 启动时创建唯一实例并注入 Agent 路由/runner
+ *   - POST /api/agent → tryCreateRun → 整个运行周期 → closeRun
+ *   - checkpoint 恢复 → createRun(existingRunId) → closeRun
  *   - POST /api/agent/cancel → cancelRun
  *   - GET /api/agent/active → getActiveRun（前端刷新后检测是否有进行中的任务）
  *   - GET /api/agent/stream/:runId → getRun（SSE 重连回放事件）
@@ -14,7 +14,7 @@
  *     → addEvent × N（每个 SSE 事件追加到 events 数组）
  *     → cancelRun（可选，running → cancelling）
  *     → closeRun（completed / failed / cancelled）
- *     → 5 分钟后自动从内存中删除（给 SSE 重连留窗口）
+ *     → 普通 run 保留 5 分钟给 SSE 重连；隐私 run 立即从内存删除
  */
 
 import {
@@ -33,7 +33,7 @@ function createRunId() {
   return `run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-/** 运行结束后保留在内存中的时长，超时自动清理 */
+/** 普通运行结束后保留在内存中的时长，超时自动清理 */
 const RUN_TTL_MS = 5 * 60 * 1000;
 
 export function createAgentRunStore({
@@ -59,6 +59,7 @@ export function createAgentRunStore({
       events: [],
       status,
       meta,
+      pendingRollback: null,
       nextEventSeq: Math.max(1, Math.floor(initialEventSeq)),
       persistence: createPersistenceQueue(),
     };
@@ -93,7 +94,7 @@ export function createAgentRunStore({
   return {
     /**
      * 创建新的运行记录
-     * 调用时机：POST /api/agent 收到任务后立即创建
+     * 调用时机：checkpoint 恢复，或无需原子占锁的内部调用
      */
     createRun(meta: RunMeta = {}, startedAt = Date.now(), existingRunId?: string, initialEventSeq = 1) {
       return insertRun(meta, startedAt, existingRunId, 'running', initialEventSeq);
@@ -166,9 +167,9 @@ export function createAgentRunStore({
 
     /**
      * 关闭运行（完成或出错后调用）
-     * 调用时机：POST /api/agent 的 finally 块
+     * 调用时机：新任务与 checkpoint 恢复的统一 cleanupAgentRun 收尾
      * 清理重连写入器，迁移到终态，
-     * 然后启动 5 分钟倒计时自动删除该记录
+     * 普通 run 启动 5 分钟倒计时自动删除；隐私 run 立即清除内存事件和记录。
      */
     closeRun(runId: string, outcome?: TerminalRunStatus) {
       const run = getRun(runId);
@@ -177,6 +178,12 @@ export function createAgentRunStore({
       run._reconnectWriters = null;
       const terminalStatus = outcome || (run.status === 'cancelling' ? 'cancelled' : 'completed');
       transitionRun(runId, terminalStatus);
+      if (run.meta?.privateMode === true) {
+        // 隐私任务不提供终态重连窗口，避免事件和运行元数据继续留在进程内存。
+        run.events.length = 0;
+        runs.delete(runId);
+        return run;
+      }
       run.cleanupTimer = setTimeout(() => {
         if (runs.get(runId) === run) runs.delete(runId);
       }, RUN_TTL_MS);

--- a/helpers/trace-store.ts
+++ b/helpers/trace-store.ts
@@ -1,6 +1,9 @@
+/** Trace JSONL 的读写与按 runId 清理；写入端同时受隐私 AsyncLocalStorage 保护。 */
+
 import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { log } from './logger.ts';
+import { isPrivateRun } from './private-run.ts';
 
 function tracesDir(memoryDir: string) {
   return join(memoryDir, 'traces');
@@ -15,6 +18,8 @@ function validRunId(runId: string) {
 }
 
 export async function appendTraceEvent(memoryDir: string | undefined, runId: string, event: any) {
+  // 作为底层防线：只要调用链已标记为隐私，即使调用方漏传 persistTrace 也不落盘。
+  if (isPrivateRun()) return;
   if (!memoryDir || !validRunId(runId)) return;
 
   const dir = tracesDir(memoryDir);

--- a/routes/agent-checkpoints.ts
+++ b/routes/agent-checkpoints.ts
@@ -20,6 +20,10 @@ export function createAgentCheckpointRouter({ checkpointDir, agentRunStore, memo
     }
     // 会话快照目录优先取 run 记录里的 dataDir；否则按 ?projectId 解析；都没有回退全局。
     const run = agentRunStore.getRun(runId);
+    if (run?.meta?.privateMode === true) {
+      // 隐私 run 从不创建快照；即使目录里有旧残留，也不能暴露给前端。
+      return res.json({ runId, checkpoints: [] });
+    }
     const pid = typeof req.query.projectId === 'string' ? req.query.projectId : null;
     const dir = run?.meta?.dataDir || resolveRunPaths(projectStore, pid, memoryDir).dataDir;
     try {
@@ -41,6 +45,10 @@ export function createAgentCheckpointRouter({ checkpointDir, agentRunStore, memo
     const activeRun = agentRunStore.getActiveRun();
     if (!activeRun) {
       return res.status(404).json({ error: tReq(req, 'checkpoint.noActiveRun') });
+    }
+    if (activeRun.meta?.privateMode === true) {
+      // 隐私 run 没有可恢复的快照；同时避免把 runId 写入持久化应用日志。
+      return res.status(400).json({ error: tReq(req, 'checkpoint.notEnabled') });
     }
     if (activeRun.rolledBack) {
       return res.status(409).json({ error: tReq(req, 'checkpoint.rollbackInProgress') });

--- a/routes/agent-config.ts
+++ b/routes/agent-config.ts
@@ -90,13 +90,17 @@ export function createAgentConfigRouter({ configStore, projectStore }: AgentRout
       profiles: configStore.profiles(),
       profile: configStore.document().profile || 'custom',
       tools: configStore.tools(),
+      // execution 是启动期配置；返回 effective 值与来源，便于 UI 解释环境变量覆盖。
+      execution: configStore.execution(),
+      executionSources: configStore.executionSources(),
       mcpServers: mcp.servers,
       mcpSources: mcp.sources,
     };
   };
 
-  // 当前 Agent 行为参数 + env 默认值（供前端「恢复默认」对照）+ Key 只读状态。
-  // ?projectId=<id> 时返回该项目的 tools override(vision/distill model);否则返回全局 tools。
+  // 当前 Agent 行为参数 + schema 内置默认值（供前端「恢复默认」对照）+ Key 只读状态。
+  // ?projectId=<id> 时只返回项目级 vision/distill override；否则返回全局 tools，
+  // 其中全局段还可能包含 screenshots 配置。
   router.get('/api/config', async (req, res) => {
     const payload: any = { ...configPayload(), keys: describeKeys() };
     const projectId = typeof req.query.projectId === 'string' ? req.query.projectId.trim() : '';
@@ -109,7 +113,7 @@ export function createAgentConfigRouter({ configStore, projectStore }: AgentRout
     res.json(payload);
   });
 
-  // 更新 tools.model(vision/distill)。body: { tools, projectId? };有 projectId 写项目级,否则全局。
+  // 更新 tools。项目级仅接受 vision/distill model；全局由 configStore 归一化并保留 screenshots。
   router.put('/api/config/tools', async (req, res) => {
     try {
       const projectId = typeof req.body?.projectId === 'string' ? req.body.projectId.trim() : '';
@@ -133,7 +137,18 @@ export function createAgentConfigRouter({ configStore, projectStore }: AgentRout
     }
   });
 
-  // 清空前台覆盖，回到内置默认值。
+  // 更新 Worker 启动配置；body: { sandboxedWorkers, workerSandbox }。
+  // 该配置只在后端下一次启动时读取，成功响应仍返回完整配置供前端同步状态。
+  router.put('/api/config/execution', async (req, res) => {
+    try {
+      await configStore.updateExecution(req.body ?? {});
+      res.json(configPayload());
+    } catch (err: any) {
+      res.status(400).json({ error: err?.message || tReq(req, 'config.validationFailed') });
+    }
+  });
+
+  // 只清空 Agent 参数覆盖并回到内置默认值；tools/MCP/execution 保持不变。
   router.post('/api/config/reset', async (_req, res) => {
     const agent = await configStore.reset();
     res.json(configPayload(agent));

--- a/routes/agent-run-control.ts
+++ b/routes/agent-run-control.ts
@@ -1,3 +1,9 @@
+/**
+ * Agent run control routes: cancel, active-run discovery, and SSE reconnect.
+ * Active-run reconnect registers a live writer before replaying persisted/in-memory
+ * history, then drains buffered live events so replay and new events cannot interleave.
+ */
+
 import { Router } from 'express';
 import type { AgentRouterContext } from './agent-types.ts';
 import { removeCheckpoint, removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
@@ -46,13 +52,14 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
     if (typeof runId !== 'string' || !runId) {
       return res.status(400).json({ error: tReq(req, 'approval.runIdEmpty') });
     }
-    log.warn(`[Cancel] 用户手动停止任务 runId=${runId}`);
     const run = agentRunStore.getRun(runId);
+    const privateMode = run?.meta?.privateMode === true;
+    if (run && !privateMode) log.warn(`[Cancel] 用户手动停止任务 runId=${runId}`);
     agentRunStore.cancelRun(runId);
-    log.warn(`[Cancel] cancelRun 完成 runId=${runId}`);
+    if (run && !privateMode) log.warn(`[Cancel] cancelRun 完成 runId=${runId}`);
     approvalStore.rejectAll();
-    log.warn(`[Cancel] rejectAll 完成 runId=${runId}`);
-    // 立即清理 checkpoint，防止重启后恢复已取消的任务
+    if (run && !privateMode) log.warn(`[Cancel] rejectAll 完成 runId=${runId}`);
+    // 立即清理 Step checkpoint 和 Session 快照，防止取消任务被恢复或回滚。
     try {
       const removeCancelledCheckpoints = () => Promise.all([
         removeCheckpoint(run?.meta?.dataDir || checkpointDir, runId),
@@ -60,9 +67,9 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
       ]);
       if (run?.persistence) await run.persistence.enqueue(removeCancelledCheckpoints);
       else await removeCancelledCheckpoints();
-      log.warn(`[Cancel] checkpoint 清理完成 runId=${runId}`);
+      if (run && !privateMode) log.warn(`[Cancel] checkpoint 清理完成 runId=${runId}`);
     } catch (err: any) {
-      log.warn(`[Cancel] checkpoint 清理失败 runId=${runId}: ${err.message}`);
+      if (run && !privateMode) log.warn(`[Cancel] checkpoint 清理失败 runId=${runId}: ${err.message}`);
     }
     return res.json({ ok: true });
   });
@@ -91,6 +98,8 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
     const cursor = parseCursor(req);
     const run = agentRunStore.getRun(runId);
     if (!run) {
+      // 内存 TTL 已过时仍可从普通 run 的持久化 trace 回放；隐私 run 没有 trace，
+      // 且结束时立即删除内存记录，因此会自然返回 404。
       const pid = typeof req.query.projectId === 'string' ? req.query.projectId : null;
       const traceDir = resolveRunPaths(projectStore, pid, memoryDir).dataDir;
       const traceEvents = await readTraceEvents(traceDir, runId);
@@ -130,11 +139,14 @@ export function createAgentRunControlRouter({ agentRunStore, approvalStore, chec
       sessionId: run.meta?.sessionId,
       projectId: run.meta?.projectId ?? null,
       strategy: run.meta?.strategy,
+      privateMode: run.meta?.privateMode === true,
       attempt: run.meta?.attempt,
     })}\n\n`);
 
     let writer = null;
     if (ACTIVE_RUN_STATUSES.has(run.status)) {
+      // 先挂 live writer 再读取历史；回放期间到达的新事件暂存到 liveBuffer，
+      // 最后按 seq 接在 replayUpperSeq 之后发送，避免“读取历史”的时间窗丢事件。
       writer = (payload: AgentEvent) => {
         if (Number(payload.seq) <= cursor) return;
         if (replaying) liveBuffer.push(payload);

--- a/routes/agent-run-execution.ts
+++ b/routes/agent-run-execution.ts
@@ -1,3 +1,9 @@
+/**
+ * Execute one Agent runner invocation and translate its outcome into terminal SSE events.
+ * On failure, normal runs attach the latest prior healthy snapshot as a rollback hint;
+ * private runs have no checkpointDir and therefore return no rollback suggestion.
+ */
+
 import { loadLatestHealthySnapshot } from '../agent/core/checkpoint.ts';
 import { log } from '../helpers/logger.ts';
 import type {
@@ -19,7 +25,7 @@ async function buildRollbackSuggestion({
   completedStepCount,
   observedStepCount,
 }: {
-  checkpointDir: string;
+  checkpointDir: string | null | undefined;
   runId: string;
   completedStepCount: number;
   observedStepCount: number;
@@ -55,6 +61,7 @@ export async function executeAgentRun({
   strategy,
   systemPrompt,
   headless,
+  privateMode,
   runId,
   runRecord,
   session,
@@ -74,6 +81,7 @@ export async function executeAgentRun({
   strategy: string;
   systemPrompt: string;
   headless: boolean;
+  privateMode: boolean;
   runId: string;
   runRecord: RunRecord;
   session: AgentRunSession;
@@ -82,7 +90,7 @@ export async function executeAgentRun({
   useMemory: boolean;
   checkpointInitialStep?: number;
   checkpointInitialHistory?: AgentStep[];
-  checkpointDir: string;
+  checkpointDir: string | null | undefined;
   projectRoot?: string;
   dataDir?: string;
 }) {
@@ -92,6 +100,7 @@ export async function executeAgentRun({
   let finalStatus: TerminalRunStatus = 'completed';
 
   try {
+    // Worker and direct runners share this contract, so route-level terminal handling is identical.
     agentResult = await runDesktopAgent({
       task,
       model,
@@ -99,6 +108,7 @@ export async function executeAgentRun({
       strategy,
       systemPrompt,
       headless,
+      privateMode,
       runId,
       runRecord,
       onEvent: session.sendEvent,
@@ -132,8 +142,9 @@ export async function executeAgentRun({
     const err = asError(value);
     agentError = err;
     finalStatus = err.message === 'Agent 已取消' ? 'cancelled' : 'failed';
-    log.error('Desktop agent error:', err.message);
+    if (!privateMode) log.error('Desktop agent error:', err.message);
     const { completedStepCount, observedStepCount } = session.getTrackingState();
+    // Suggest the last completed healthy step before the failing/observed step.
     const rollbackSuggestion = await buildRollbackSuggestion({
       checkpointDir,
       runId,

--- a/routes/agent-run-memory-persist.ts
+++ b/routes/agent-run-memory-persist.ts
@@ -1,8 +1,11 @@
+/** Project-memory persistence shared by fresh runs and checkpoint recovery. */
+
 import {
   saveMemory,
   loadMemory,
   extractProjectKnowledge,
 } from '../agent/core/memory.ts';
+import { isPrivateRun } from '../helpers/private-run.ts';
 import type { ProviderRegistry } from '../agent/core/providers/registry.ts';
 import type { DesktopAgentResult } from '../agent/core/contracts.ts';
 
@@ -27,6 +30,9 @@ export async function persistAgentRunMemory({
   stepModels: Record<number, string>;
   registry: ProviderRegistry;
 }) {
+  // Bottom-layer guard: callers already skip private runs, but recovered/indirect paths
+  // must also be unable to write project knowledge while the private context is active.
+  if (isPrivateRun()) return;
   const answer = finalAnswer || (agentError ? `失败: ${agentError.message.slice(0, 60)}` : '无结果');
   const steps = agentResult?.steps || [];
   extractProjectKnowledge(memory, { task: normalizedTask, result: { answer, steps } });
@@ -46,6 +52,7 @@ export async function persistRecoveredAgentRunMemory({
   model: string;
   registry: ProviderRegistry;
 }) {
+  if (isPrivateRun()) return;
   const memory = await loadMemory(memoryDir);
   await persistAgentRunMemory({
     memory,

--- a/routes/agent-run-request.ts
+++ b/routes/agent-run-request.ts
@@ -1,3 +1,5 @@
+/** 解析 POST /api/agent 输入，并把 fromCheckpoint 转换成 runtime 的起始 step/history。 */
+
 import { loadLatestHealthySnapshot } from '../agent/core/checkpoint.ts';
 
 function uniqueModelIds(value: any) {
@@ -18,6 +20,7 @@ export function parseAgentRunRequest(reqBody: any) {
     models: reqModels,
     strategy = 'race',
     headless,
+    privateMode,
     memory: useMemory = true,
     messages: conversationHistory,
     fromCheckpoint,
@@ -48,6 +51,7 @@ export function parseAgentRunRequest(reqBody: any) {
     agentModels,
     strategy,
     headless,
+    privateMode: privateMode === true,
     useMemory,
     conversationHistory,
     fromCheckpoint,
@@ -56,10 +60,11 @@ export function parseAgentRunRequest(reqBody: any) {
   };
 }
 
-export async function resolveCheckpointSeed(checkpointDir: string, fromCheckpoint: any) {
+export async function resolveCheckpointSeed(checkpointDir: string | null | undefined, fromCheckpoint: any) {
   let checkpointInitialStep;
   let checkpointInitialHistory;
 
+  // 隐私模式传入 null checkpointDir，因此即使请求带 fromCheckpoint 也不会读取磁盘快照。
   if (fromCheckpoint && checkpointDir) {
     const cpRunId = fromCheckpoint.runId;
     const cpStep = fromCheckpoint.step;
@@ -70,7 +75,7 @@ export async function resolveCheckpointSeed(checkpointDir: string, fromCheckpoin
         checkpointInitialStep = cpStep;
         checkpointInitialHistory = snapshot.history || [];
       } else {
-        // 目标是第 1 步且无更早快照 → 从头开始
+        // 找不到目标步之前的健康快照（包括回滚到第 1 步）→ 从头开始。
         checkpointInitialStep = 1;
         checkpointInitialHistory = [];
       }

--- a/routes/agent-run-session.ts
+++ b/routes/agent-run-session.ts
@@ -1,3 +1,12 @@
+/**
+ * One Agent run's SSE boundary.
+ *
+ * It owns heartbeat/connection lifecycle, enriches events with attempt and trace fields,
+ * tracks steps/models for terminal metadata, and fans each event into the in-memory run
+ * store plus the live response. Normal runs also persist app/trace logs; private runs keep
+ * the same live UI event channel but skip those persistence paths.
+ */
+
 import { safeJson, cleanText, displayWidth, padEndW } from '../agent/core/utils.ts';
 import { formatLogTime, buildAgentMetrics, buildSseWriter, logAgentEvent } from '../helpers/agent-logging.ts';
 import { createBaseEventSender } from '../helpers/run-agent.ts';
@@ -25,6 +34,7 @@ export function createAgentRunSession({
   res,
   model,
   agentHeadless,
+  agentPrivateMode,
   normalizedTask,
   agentModels,
   strategy,
@@ -40,6 +50,7 @@ export function createAgentRunSession({
   res: Response;
   model: string;
   agentHeadless: boolean;
+  agentPrivateMode: boolean;
   normalizedTask: string;
   agentModels: string[];
   strategy: string;
@@ -73,17 +84,25 @@ export function createAgentRunSession({
     if (sseClosed) return;
     sseClosed = true;
     clearInterval(heartbeat);
-    log.debug(`[${formatLogTime()}] POST /api/agent client_disconnected model=${model} run_id=${runId}`);
+    if (!agentPrivateMode) {
+      log.debug(`[${formatLogTime()}] POST /api/agent client_disconnected model=${model} run_id=${runId}`);
+    }
   });
 
-  log.info(
-    `[${formatLogTime()}] POST /api/agent model=${model} headless=${agentHeadless} task=${safeJson(normalizedTask)} ` +
-      `run_id=${runId}`
-  );
+  if (!agentPrivateMode) {
+    log.info(
+      `[${formatLogTime()}] POST /api/agent model=${model} headless=${agentHeadless} task=${safeJson(normalizedTask)} ` +
+        `run_id=${runId}`
+    );
+  }
 
   const rawSendEvent = buildSseWriter(res);
-  const baseSendEvent = createBaseEventSender(runId, agentRunStore, memoryDir);
+  const baseSendEvent = createBaseEventSender(runId, agentRunStore, memoryDir, {
+    persistTrace: !agentPrivateMode,
+  });
   const sendEvent = (payload: AgentEvent) => {
+    // Tracking happens before storage/streaming so terminal metrics and model attribution
+    // reflect exactly the same sequenced events seen by reconnect clients.
     const attemptPayload = { ...payload, attempt } as AgentEvent;
     if (attemptPayload.type === 'step') {
       observedStepCount = Math.max(observedStepCount, attemptPayload.step || 0);
@@ -100,7 +119,7 @@ export function createAgentRunSession({
     if (attemptPayload.type === 'model_plan' && attemptPayload.model && ['winner', 'success', 'thinking'].includes(attemptPayload.stage)) {
       modelsUsed.add(attemptPayload.model);
     }
-    logAgentEvent(attemptPayload);
+    logAgentEvent(attemptPayload, { persist: !agentPrivateMode });
     const event = baseSendEvent(attemptPayload);
     if (!sseClosed && !res.writableEnded) {
       try { rawSendEvent(event); } catch { sseClosed = true; }
@@ -120,11 +139,14 @@ export function createAgentRunSession({
     model,
     agentModels,
     strategy,
+    privateMode: agentPrivateMode,
     task: normalizedTask,
     sessionId: sessionId || undefined,
     projectId,
   });
-  log.debug(`[SSE] stream started, writableEnded=${res.writableEnded} writableFinished=${res.writableFinished}`);
+  if (!agentPrivateMode) {
+    log.debug(`[SSE] stream started, writableEnded=${res.writableEnded} writableFinished=${res.writableFinished}`);
+  }
 
   function getTrackingState(): AgentRunTrackingState {
     return {
@@ -137,6 +159,8 @@ export function createAgentRunSession({
   }
 
   function close({ finalAnswer, agentError, approvalStore }: { finalAnswer: string | null; agentError: Error | null; approvalStore: ApprovalStore }) {
+    // close() only owns the HTTP/SSE side; checkpoint/run-store cleanup remains in
+    // cleanupAgentRun() so success and error paths share one persistence boundary.
     const status = agentError
       ? agentError.message === 'Agent 已取消'
         ? 'cancelled'
@@ -174,7 +198,7 @@ export function createAgentRunSession({
       ...innerLines.map(line => `  ║${padEndW(line, W)}║`),
       `  ╚${bRow.slice(2)}╝`,
     ].join('\n');
-    log.info(`\n${box}`);
+    if (!agentPrivateMode) log.info(`\n${box}`);
     clearInterval(heartbeat);
     approvalStore.rejectAll();
     if (!sseClosed && !res.writableEnded) {

--- a/routes/agent-run-start.ts
+++ b/routes/agent-run-start.ts
@@ -10,6 +10,8 @@ import { executeAgentRun } from './agent-run-execution.ts';
 import { removeSessionCheckpoints } from '../agent/core/checkpoint.ts';
 import { resolveRunPathsForExecution } from '../agent/core/project-store.ts';
 import { readTraceEvents } from '../helpers/trace-store.ts';
+import { withPrivateRun } from '../helpers/private-run.ts';
+import { removePrivateRunArtifacts } from '../helpers/private-run-artifacts.ts';
 
 export function nextAgentAttempt(existingTraceEvents: any[] = []) {
   const explicitAttempt = existingTraceEvents.reduce((max, event) => {
@@ -34,15 +36,23 @@ export function createAgentRunStartRouter({
   const router = Router();
 
   router.post('/api/agent', async (req, res) => {
-    let session: ReturnType<typeof createAgentRunSession> | null = null;
-    let runId: string | null = null;
-    let runCheckpointDir = checkpointDir;
-    try {
+    // Wrap request parsing, run creation, execution and cleanup in one AsyncLocalStorage scope;
+    // lower-level log/trace/checkpoint/session writers can then enforce privacy independently.
+    return withPrivateRun(req.body?.privateMode === true, async () => {
+      let session: ReturnType<typeof createAgentRunSession> | null = null;
+      let runId: string | null = null;
+      let runCheckpointDir = checkpointDir;
+      try {
       const parsed = parseAgentRunRequest(req.body);
       if ('error' in parsed) {
         return res.status(400).json({ error: tReq(req, parsed.error) });
       }
-      const { task, model, agentModels, strategy, headless, useMemory, conversationHistory, fromCheckpoint, projectId, sessionId } = parsed;
+      const { task, model, agentModels, strategy, headless, privateMode, useMemory, conversationHistory, fromCheckpoint, projectId, sessionId } = parsed;
+      const agentPrivateMode = privateMode === true;
+      if (agentPrivateMode && fromCheckpoint) {
+        // 隐私 run 没有可读取的健康快照；明确拒绝，而不是复用旧 runId 后从头执行。
+        return res.status(400).json({ error: tReq(req, 'checkpoint.notEnabled') });
+      }
       const incompatibleModels = agentModels.filter(modelId => (
         modelConfig.find(item => item.id === modelId)?.agentCompatible === false
       ));
@@ -54,11 +64,12 @@ export function createAgentRunStartRouter({
 
       // 解析本次 run 的落盘目录与文件工具根：命中项目用项目目录，否则回退全局（无项目态）。
       const { projectId: resolvedProjectId, projectRoot, dataDir } = await resolveRunPathsForExecution(projectStore, projectId, memoryDir);
-      runCheckpointDir = dataDir;
+      runCheckpointDir = agentPrivateMode ? null : dataDir;
 
       const { checkpointInitialStep, checkpointInitialHistory } = await resolveCheckpointSeed(runCheckpointDir, fromCheckpoint);
 
-      // 清理上一个 run 的 session snapshots（fromCheckpoint 回滚时保留当前 run 的快照）
+      // 新任务启动前清理该 dataDir 下所有历史 Session 快照；fromCheckpoint 回滚
+      // 需要继续读取当前 run 的快照，因此跳过这次批量清理。
       if (runCheckpointDir && !fromCheckpoint) {
         const { listSessionCheckpointRuns } = await import('../agent/core/checkpoint.ts');
         const runs = await listSessionCheckpointRuns(runCheckpointDir);
@@ -70,7 +81,9 @@ export function createAgentRunStartRouter({
       const startedAt = Date.now();
       // fromCheckpoint 回滚时复用原 runId，保持 trace 连续性
       const existingRunId = fromCheckpoint?.runId;
-      const existingTraceEvents = existingRunId ? await readTraceEvents(dataDir, existingRunId) : [];
+      const existingTraceEvents = !agentPrivateMode && existingRunId
+        ? await readTraceEvents(dataDir, existingRunId)
+        : [];
       const attempt = existingRunId ? nextAgentAttempt(existingTraceEvents) : 1;
       const initialEventSeq = existingTraceEvents.reduce(
         (next, event, index) => Number.isFinite(event?.seq)
@@ -83,6 +96,7 @@ export function createAgentRunStartRouter({
         agentModels,
         task: normalizedTask,
         attempt,
+        privateMode: agentPrivateMode,
         // 项目信息盖到 run 记录上，供 trace/checkpoint 读取端点定位落盘目录
         projectId: resolvedProjectId,
         sessionId,
@@ -94,6 +108,12 @@ export function createAgentRunStartRouter({
       }
       const runRecord = acquired.run;
       runId = runRecord.runId;
+      if (agentPrivateMode) {
+        // retry 可能复用旧 runId；启动前先清掉该 ID 的可定位历史产物，
+        // 正常结束或可捕获异常时 cleanupAgentRun 再兜底一次。
+        await Promise.all([...new Set([dataDir, memoryDir])]
+          .map(dir => removePrivateRunArtifacts(dir, runId!)));
+      }
       let finalAnswer: string | null = null;
       let agentError: any = null;
       session = createAgentRunSession({
@@ -101,6 +121,7 @@ export function createAgentRunStartRouter({
         res,
         model,
         agentHeadless,
+        agentPrivateMode,
         normalizedTask,
         agentModels,
         strategy,
@@ -121,6 +142,7 @@ export function createAgentRunStartRouter({
         models: agentModels,
         startedAt,
         retry: Boolean(fromCheckpoint),
+        privateMode: agentPrivateMode,
       });
       agentRunStore.transitionRun(runId, 'running');
 
@@ -140,6 +162,7 @@ export function createAgentRunStartRouter({
         strategy,
         systemPrompt,
         headless: agentHeadless,
+        privateMode: agentPrivateMode,
         runId,
         runRecord,
         session,
@@ -155,7 +178,7 @@ export function createAgentRunStartRouter({
       const { agentResult, finalAnswer: nextFinalAnswer, agentError: nextAgentError, finalStatus } = result;
       finalAnswer = nextFinalAnswer;
       agentError = nextAgentError;
-      if (memory) {
+      if (memory && !agentPrivateMode) {
         try {
           await runRecord.persistence?.enqueue(async () => {
             const { stepModels } = session!.getTrackingState();
@@ -189,30 +212,32 @@ export function createAgentRunStartRouter({
         startedAt,
         endedAt: Date.now(),
         meta: { step_count: Math.max(tracking.completedStepCount, tracking.observedStepCount) },
+        privateMode: agentPrivateMode,
       });
       session.close({ finalAnswer, agentError, approvalStore });
       await cleanupAgentRun(runCheckpointDir, runId, agentRunStore, { finalStatus });
       return;
-    } catch (err: any) {
-      const message = err?.message || String(err);
-      log.error('Agent start failed:', message);
-      if (session && runId) {
-        session.sendEvent({ type: 'error', runId, error: message });
-        session.close({ finalAnswer: null, agentError: err, approvalStore });
-        const finalStatus = agentRunStore.getRun(runId)?.status === 'cancelling' ? 'cancelled' : 'failed';
-        await cleanupAgentRun(runCheckpointDir, runId, agentRunStore, { finalStatus }).catch(() => {});
-        return;
+      } catch (err: any) {
+        const message = err?.message || String(err);
+        if (req.body?.privateMode !== true) log.error('Agent start failed:', message);
+        if (session && runId) {
+          session.sendEvent({ type: 'error', runId, error: message });
+          session.close({ finalAnswer: null, agentError: err, approvalStore });
+          const finalStatus = agentRunStore.getRun(runId)?.status === 'cancelling' ? 'cancelled' : 'failed';
+          await cleanupAgentRun(runCheckpointDir, runId, agentRunStore, { finalStatus }).catch(() => {});
+          return;
+        }
+        if (runId) {
+          const finalStatus = agentRunStore.getRun(runId)?.status === 'cancelling' ? 'cancelled' : 'failed';
+          await cleanupAgentRun(runCheckpointDir, runId, agentRunStore, { finalStatus }).catch(() => {});
+        }
+        if (!res.headersSent) {
+          const status = Number(err?.status) || 500;
+          return res.status(status).json({ error: message, ...(err?.code ? { code: err.code } : {}) });
+        }
+        try { res.end(); } catch {}
       }
-      if (runId) {
-        const finalStatus = agentRunStore.getRun(runId)?.status === 'cancelling' ? 'cancelled' : 'failed';
-        await cleanupAgentRun(runCheckpointDir, runId, agentRunStore, { finalStatus }).catch(() => {});
-      }
-      if (!res.headersSent) {
-        const status = Number(err?.status) || 500;
-        return res.status(status).json({ error: message, ...(err?.code ? { code: err.code } : {}) });
-      }
-      try { res.end(); } catch {}
-    }
+    });
   });
 
   return router;

--- a/routes/agent-sessions.ts
+++ b/routes/agent-sessions.ts
@@ -4,9 +4,17 @@ import type { AgentRouterContext } from './agent-types.ts';
 export function createAgentSessionsRouter({ sessionStore }: AgentRouterContext) {
   const router = Router();
 
-  router.get('/api/sessions', async (_req, res) => {
+  // 隐私模式允许读取已有会话供页面显示，但所有会改变 chat-sessions.json 的
+  // 请求都转成只读操作。X-Private-Mode 是前端主路径，body/query 仅保留兼容。
+  const isPrivateRequest = (req: any) => (
+    req.get('X-Private-Mode') === 'true'
+    || req.body?.privateMode === true
+    || req.query?.privateMode === 'true'
+  );
+
+  router.get('/api/sessions', async (req, res) => {
     try {
-      return res.json(await sessionStore.loadAll());
+      return res.json(await sessionStore.loadAll({ persist: !isPrivateRequest(req) }));
     } catch (err: any) {
       return res.status(500).json({ error: err?.message || String(err) });
     }
@@ -18,7 +26,10 @@ export function createAgentSessionsRouter({ sessionStore }: AgentRouterContext) 
       if (!session || typeof session !== 'object') {
         return res.status(400).json({ error: 'session 不能为空' });
       }
-      return res.json(await sessionStore.upsertSession({ ...session, id: req.params.id }));
+      return res.json(await sessionStore.upsertSession(
+        { ...session, id: req.params.id },
+        { persist: !isPrivateRequest(req) },
+      ));
     } catch (err: any) {
       return res.status(400).json({ error: err?.message || String(err) });
     }
@@ -27,7 +38,11 @@ export function createAgentSessionsRouter({ sessionStore }: AgentRouterContext) 
   router.delete('/api/sessions/:id', async (req, res) => {
     try {
       const projectId = typeof req.query.projectId === 'string' && req.query.projectId ? req.query.projectId : null;
-      return res.json(await sessionStore.deleteSession(projectId, req.params.id));
+      return res.json(await sessionStore.deleteSession(
+        projectId,
+        req.params.id,
+        { persist: !isPrivateRequest(req) },
+      ));
     } catch (err: any) {
       return res.status(400).json({ error: err?.message || String(err) });
     }

--- a/routes/agent-traces.ts
+++ b/routes/agent-traces.ts
@@ -10,6 +10,10 @@ export function createAgentTraceRouter({ memoryDir, agentRunStore, projectStore 
   router.get('/api/agent/traces/:runId', async (req, res) => {
     const { runId } = req.params;
     const run = agentRunStore.getRun(runId);
+    if (run?.meta?.privateMode === true) {
+      // 隐私 run 的 trace 只存在内存事件流；不回读同 runId 的旧磁盘文件。
+      return res.status(404).json({ error: tReq(req, 'trace.notFound') });
+    }
     await run?.persistence?.flush();
     // trace 落盘目录优先取 run 记录里的 dataDir；run 已过期则用 ?projectId 解析；都没有回退全局。
     const pid = typeof req.query.projectId === 'string' ? req.query.projectId : null;

--- a/server.ts
+++ b/server.ts
@@ -3,16 +3,16 @@
  * Main entry point — Express middleware, routing, agent runner setup, checkpoint resume
  *
  * 启动流程 / Startup:
- *   1. 加载 .env 配置
- *   2. 创建 LLM 客户端（NVIDIA / Gemini）
- *   3. 初始化 Agent 运行器、审批存储、记忆目录
- *   4. 挂载路由：agent、completions
- *   5. 检查断点（checkpoint），自动恢复上次未完成的任务
- *   6. 输出图形化启动信息（表格样式）
+ *   1. 加载 .env，并安装 Origin/CORS/API Auth/JSON 等安全中间件
+ *   2. 创建 Provider Registry，同步加载可用模型；全部供应商失败则终止启动
+ *   3. 初始化日志、WebView data store、结构化配置和项目注册表
+ *   4. 创建 run/approval store，并按启动配置一次性选择 Worker 或直跑 runner
+ *   5. 挂载截图、Agent、Completions、Suggestions 和前端静态资源路由
+ *   6. 开始监听，输出启动信息，再按配置扫描并恢复最后一个 checkpoint
  *
  * 配置 / Configuration:
  *   .env             — API Key、监听地址、认证和本地二进制覆盖
- *   data/config.json — Agent profile、上下文、工具和 MCP server
+ *   data/config.json — Agent profile/参数、工具、MCP server 和 execution 启动配置
  */
 
 import 'dotenv/config';
@@ -49,6 +49,8 @@ import { flushAllPersistenceTasks } from './helpers/persistence-queue.ts';
 import { persistRecoveredAgentRunMemory } from './routes/agent-run-memory-persist.ts';
 import { warnLegacyConfiguration } from './helpers/config-deprecations.ts';
 import { cleanupScreenshots } from './helpers/screenshot-store.ts';
+import { withPrivateRun } from './helpers/private-run.ts';
+import { removePrivateRunArtifacts } from './helpers/private-run-artifacts.ts';
 
 const securityConfig = loadServerSecurityConfig();
 const app = express();
@@ -107,6 +109,8 @@ const directRunDesktopAgent = createDesktopAgentRunner({
   visionModel: VISION_MODEL,
   distillModel: DISTILL_MODEL,
 });
+// runner 类型与 macOS Sandbox 都在启动时固定；UI 保存 execution 后必须重启，
+// 后端才会重新创建 Worker runner 或切回进程内直跑。
 const runDesktopAgent = agentSandboxedWorkers
   ? createSandboxedWorkerAgentRunner({
       memoryDir: MEMORY_DIR,
@@ -169,18 +173,28 @@ function defaultShutdownGraceMs() {
 }
 
 async function resumeFromCheckpoint(cp) {
-  const { runId, task, model, headless, history, step, maxSteps: _maxSteps, startedAt } = cp;
+  const { runId, task, model, headless, privateMode, history, step, maxSteps: _maxSteps, startedAt } = cp;
+  const agentPrivateMode = privateMode === true;
+  return withPrivateRun(agentPrivateMode, async () => {
   // checkpoint 自带项目落盘目录与项目根；旧 checkpoint（无项目）回退全局 MEMORY_DIR / process.cwd()。
   const dataDir = cp.dataDir || MEMORY_DIR;
   const projectRoot = cp.projectRoot || null;
+  if (agentPrivateMode) {
+    // 新版本隐私 run 根本不会创建 checkpoint；这里只兼容旧版本或异常残留，
+    // 恢复前先删除能按 runId 定位的历史产物，后续仍由隐私上下文禁止新写入。
+    await Promise.all([...new Set([dataDir, MEMORY_DIR])]
+      .map(dir => removePrivateRunArtifacts(dir, runId)));
+  }
   log.info(`[Resume] 恢复运行 run_id=${runId} step=${step} task=${task.slice(0, 60)}…`);
 
-  const sendEventWithTrace = createBaseEventSender(runId, agentRunStore, dataDir);
+  const sendEventWithTrace = createBaseEventSender(runId, agentRunStore, dataDir, {
+    persistTrace: !agentPrivateMode,
+  });
 
   const { systemPrompt } = await loadMemoryForPrompt(dataDir);
 
   // 旧 checkpoint 可能没有 trace；仅在 trace 缺失时重建历史，避免恢复时重复写入旧步骤。
-  const existingTraceEvents = await readTraceEvents(dataDir, runId);
+  const existingTraceEvents = agentPrivateMode ? [] : await readTraceEvents(dataDir, runId);
   if (existingTraceEvents.length === 0) {
     sendEventWithTrace({ type: 'status', status: 'starting', runId, message: '准备启动桌面 Agent' });
     for (const h of history) {
@@ -199,6 +213,7 @@ async function resumeFromCheckpoint(cp) {
       strategy: cp.strategy || 'race',
       systemPrompt,
       headless,
+      privateMode: privateMode === true,
       runId,
       runRecord,
       startedAt,
@@ -212,7 +227,7 @@ async function resumeFromCheckpoint(cp) {
       dataDir,
     });
     sendEventWithTrace({ type: 'done', runId, answer: result.answer, steps: result.steps, meta: { elapsed_ms: Date.now() - startedAt, step_count: result.steps.length } });
-    if (cp.memory !== false) {
+    if (cp.memory !== false && !agentPrivateMode) {
       try {
         const runRecord = agentRunStore.getRun(runId);
         const persistMemory = () => persistRecoveredAgentRunMemory({
@@ -234,6 +249,7 @@ async function resumeFromCheckpoint(cp) {
   } finally {
     await cleanupAgentRun(dataDir, runId, agentRunStore);
   }
+  });
 }
 
 /** 跨「全局 + 各项目」目录收集所有未完成 checkpoint，附带各自所在目录，按 startedAt 升序 */
@@ -302,16 +318,27 @@ const httpServer = app.listen(Number(PORT), HOST, async () => {
       } else {
         console.log(`[Resume] 发现 ${found.length} 个未完成任务，恢复最后一个: ${cp.runId}`);
         const resumeDataDir = cp.dataDir || MEMORY_DIR;
-        const existingTraceEvents = await readTraceEvents(resumeDataDir, cp.runId);
+        const existingTraceEvents = cp.privateMode === true
+          ? []
+          : await readTraceEvents(resumeDataDir, cp.runId);
         const initialEventSeq = existingTraceEvents.reduce(
           (next: number, event: any, index: number) => Number.isFinite(event?.seq)
             ? Math.max(next, Number(event.seq) + 1)
             : Math.max(next, index + 2),
           1,
         );
-        agentRunStore.createRun({ model: cp.model, task: cp.task, projectId: cp.dataDir ? undefined : null, dataDir: resumeDataDir, projectRoot: cp.projectRoot || null }, cp.startedAt, cp.runId, initialEventSeq);
+        agentRunStore.createRun({
+          model: cp.model,
+          task: cp.task,
+          privateMode: cp.privateMode === true,
+          projectId: cp.dataDir ? undefined : null,
+          dataDir: resumeDataDir,
+          projectRoot: cp.projectRoot || null,
+        }, cp.startedAt, cp.runId, initialEventSeq);
         resumeFromCheckpoint(cp).catch(err => {
-          log.error(`[Resume] 恢复失败 run_id=${cp.runId}:`, err.message);
+          if (cp.privateMode !== true) {
+            log.error(`[Resume] 恢复失败 run_id=${cp.runId}:`, err.message);
+          }
         });
         for (const other of found.slice(0, -1)) {
           removeCheckpoint(other.dir, other.cp.runId).catch(() => {});
@@ -343,8 +370,11 @@ function shutdown(signal: string) {
   shuttingDown = true;
 
   const activeRuns = agentRunStore.getRunningRuns();
-  const activeRunIds = activeRuns.map((run: any) => run.runId);
-  log.warn(`[Shutdown] 收到 ${signal}，关闭 HTTP server，取消 ${activeRuns.length} 个 active run${activeRunIds.length ? `: ${activeRunIds.join(', ')}` : ''}`);
+  // 关闭流程仍取消全部任务，但日志只展开普通 runId，避免泄露隐私任务标识。
+  const visibleActiveRunIds = activeRuns
+    .filter((run: any) => run.meta?.privateMode !== true)
+    .map((run: any) => run.runId);
+  log.warn(`[Shutdown] 收到 ${signal}，关闭 HTTP server，取消 ${activeRuns.length} 个 active run${visibleActiveRunIds.length ? `: ${visibleActiveRunIds.join(', ')}` : ''}`);
 
   httpServer.close(err => {
     if (err) log.warn(`[Shutdown] HTTP server close failed: ${err.message}`);

--- a/test/agent-api.test.ts
+++ b/test/agent-api.test.ts
@@ -33,6 +33,7 @@ let app;
 let agentRunStore;
 let approvalStore;
 let projectStore;
+let lastRunOptions;
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-api-test-'));
@@ -47,9 +48,13 @@ beforeEach(async () => {
   // 空注册表 → resolveRunPaths 回退到 tmpDir/process.cwd()，与无项目态一致。
   projectStore = createProjectStore(tmpDir);
   await projectStore.init();
+  lastRunOptions = null;
 
   const router = createAgentRouter({
-    runDesktopAgent: async () => ({ answer: 'done', steps: [] }),
+    runDesktopAgent: async options => {
+      lastRunOptions = options;
+      return { answer: 'done', steps: [] };
+    },
     agentRunStore,
     approvalStore,
     memoryDir: tmpDir,
@@ -159,6 +164,48 @@ describe('approval ownership', () => {
 });
 
 describe('POST /api/agent', () => {
+  it('passes private mode through without persisting trace or checkpoint files', async () => {
+    const res = await request(app)
+      .post('/api/agent')
+      .send({ task: 'private browse', model: 'test-model', memory: false, privateMode: true })
+      .buffer(true)
+      .parse((response, callback) => {
+        let body = '';
+        response.setEncoding('utf8');
+        response.on('data', chunk => { body += chunk; });
+        response.on('end', () => callback(null, body));
+      });
+
+    expect(res.status).toBe(200);
+    expect(lastRunOptions).toMatchObject({ privateMode: true });
+    const responseText = typeof res.text === 'string' ? res.text : String(res.body || '');
+    expect(responseText).toContain('"privateMode":true');
+    await expect(fs.access(path.join(tmpDir, 'traces'))).rejects.toThrow();
+    await expect(fs.access(path.join(tmpDir, 'checkpoints'))).rejects.toThrow();
+    await expect(fs.access(path.join(tmpDir, 'chat-sessions.json'))).rejects.toThrow();
+  });
+
+  it('rejects checkpoint retry and rollback requests for private runs', async () => {
+    const retry = await request(app)
+      .post('/api/agent')
+      .send({
+        task: 'private retry',
+        model: 'test-model',
+        memory: false,
+        privateMode: true,
+        fromCheckpoint: { runId: 'run_old_private', step: 2 },
+      });
+    expect(retry.status).toBe(400);
+
+    const run = agentRunStore.createRun({ privateMode: true }, 1, 'run_private_rollback');
+    const rollback = await request(app)
+      .post('/api/agent/rollback')
+      .send({ targetStep: 1 });
+    expect(rollback.status).toBe(400);
+    expect(run.pendingRollback).toBeNull();
+    agentRunStore.closeRun(run.runId);
+  });
+
   it('requires an explicit model selection', async () => {
     const res = await request(app)
       .post('/api/agent')
@@ -210,6 +257,41 @@ describe('POST /api/agent', () => {
     expect(res.status).toBe(500);
     expect(res.headers['content-type']).toContain('application/json');
     expect(res.body.error).toBe('project lookup failed');
+  });
+});
+
+describe('/api/sessions private-mode guard', () => {
+  it('does not mutate chat-sessions.json when the private header is present', async () => {
+    const initial = await request(app)
+      .put('/api/sessions/session_normal')
+      .send({
+        session: {
+          id: 'session_normal',
+          messages: [{ role: 'user', content: '普通会话' }],
+          updatedAt: 1000,
+        },
+      });
+    expect(initial.status).toBe(200);
+    const file = path.join(tmpDir, 'chat-sessions.json');
+    const before = await fs.readFile(file, 'utf8');
+
+    const privateUpdate = await request(app)
+      .put('/api/sessions/session_private')
+      .set('X-Private-Mode', 'true')
+      .send({
+        session: {
+          id: 'session_private',
+          messages: [{ role: 'user', content: '不应写入' }],
+          updatedAt: 2000,
+        },
+      });
+    expect(privateUpdate.status).toBe(200);
+
+    const privateDelete = await request(app)
+      .delete('/api/sessions/session_normal')
+      .set('X-Private-Mode', 'true');
+    expect(privateDelete.status).toBe(200);
+    await expect(fs.readFile(file, 'utf8')).resolves.toBe(before);
   });
 });
 

--- a/test/agent-config.test.ts
+++ b/test/agent-config.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createAgentConfigRouter } from '../routes/agent-config.ts';
+import { configStore } from '../agent/core/config-store.ts';
+
+function createConfigRouter() {
+  return createAgentConfigRouter({
+    configStore,
+    projectStore: { dataDir: () => '' },
+  } as any);
+}
+
+async function invoke(router: any, method: string, pathName: string, body: any = {}) {
+  const layer = router.stack.find((item: any) => item.route?.path === pathName && item.route.methods[method.toLowerCase()]);
+  if (!layer) throw new Error(`route not found: ${method} ${pathName}`);
+  const response: any = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      this.body = payload;
+      return this;
+    },
+  };
+  await layer.route.stack[0].handle({ body, headers: {}, query: {} }, response);
+  return response;
+}
+
+describe('agent execution configuration API', () => {
+  it('returns and updates Worker startup settings', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-agent-config-api-'));
+    await configStore.init(dir);
+    const router = createConfigRouter();
+
+    const before = await invoke(router, 'GET', '/api/config');
+    expect(before.statusCode).toBe(200);
+    expect(before.body.execution).toMatchObject({ sandboxedWorkers: true, workerSandbox: true });
+    expect(before.body.executionSources).toMatchObject({ sandboxedWorkers: 'default', workerSandbox: 'default' });
+
+    const saved = await invoke(router, 'PUT', '/api/config/execution', { sandboxedWorkers: false, workerSandbox: false });
+    expect(saved.statusCode).toBe(200);
+    expect(saved.body.execution).toMatchObject({ sandboxedWorkers: false, workerSandbox: false });
+    expect(saved.body.executionSources).toMatchObject({ sandboxedWorkers: 'user', workerSandbox: 'user' });
+
+    const persisted = JSON.parse(await readFile(path.join(dir, 'config.json'), 'utf8'));
+    expect(persisted.execution).toMatchObject({ sandboxedWorkers: false, workerSandbox: false });
+  });
+
+  it('rejects non-boolean Worker settings', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-agent-config-api-invalid-'));
+    await configStore.init(dir);
+    const router = createConfigRouter();
+
+    const response = await invoke(router, 'PUT', '/api/config/execution', { sandboxedWorkers: 'false' });
+    expect(response.statusCode).toBe(400);
+    expect(response.body.error).toContain('sandboxedWorkers');
+  });
+});

--- a/test/agent-run-request.test.ts
+++ b/test/agent-run-request.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { parseAgentRunRequest } from '../routes/agent-run-request.ts';
+
+describe('parseAgentRunRequest private browser mode', () => {
+  it('normalizes the privateMode flag to a strict boolean', () => {
+    expect(parseAgentRunRequest({ task: 'browse', model: 'model-a', privateMode: true })).toMatchObject({ privateMode: true });
+    expect(parseAgentRunRequest({ task: 'browse', model: 'model-a' })).toMatchObject({ privateMode: false });
+    expect(parseAgentRunRequest({ task: 'browse', model: 'model-a', privateMode: 'true' })).toMatchObject({ privateMode: false });
+  });
+});

--- a/test/browser-webview.test.ts
+++ b/test/browser-webview.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { access, mkdtemp, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import {
@@ -10,6 +10,7 @@ import {
   resetWebViewFactoryForTests,
   setWebViewFactoryForTests,
 } from '../agent/tools/browser/webview-session.ts';
+import { buildEdgeLaunchArgs } from '../agent/tools/browser/edge-cdp-webview.ts';
 import { captureBrowserObservation, summarizeBrowserObservation } from '../agent/tools/browser/observe.ts';
 import { executeBrowserAction } from '../agent/tools/browser/execute.ts';
 import { createSharedBrowserSessionManager } from '../agent/desktop/browser-session-manager.ts';
@@ -124,6 +125,63 @@ describe('Bun.WebView browser session adapter', () => {
     expect(created.closed).toBe(true);
   });
 
+  it('uses a disposable data store for private browser sessions and removes it on close', async () => {
+    const memoryDir = await mkdtemp(path.join(os.tmpdir(), 'sagent-private-browser-test-'));
+    let created;
+    setWebViewFactoryForTests(options => {
+      created = new FakeWebView(options);
+      return created;
+    });
+    initWebViewDataStore(memoryDir);
+
+    try {
+      const session = createBrowserSession({ privateMode: true });
+      const profileDir = created.options.dataStore.directory;
+
+      expect(session.privateMode).toBe(true);
+      expect(created.options.privateMode).toBe(true);
+      expect(profileDir).toMatch(/sagent-private-browser-/);
+      await expect(access(profileDir)).resolves.toBeUndefined();
+
+      await closeBrowserSession(session);
+      await expect(access(profileDir)).rejects.toThrow();
+    } finally {
+      await rm(memoryDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps normal and private sessions separate and closes private sessions after a run', async () => {
+    const created: FakeWebView[] = [];
+    setWebViewFactoryForTests(options => {
+      const view = new FakeWebView(options);
+      created.push(view);
+      return view;
+    });
+    const manager = createSharedBrowserSessionManager();
+    const normalState: any = { headless: true, privateMode: false, browserSession: null };
+    const privateState: any = { headless: true, privateMode: true, browserSession: null };
+
+    await manager.ensureBrowserSession(normalState);
+    await manager.ensureBrowserSession(privateState);
+
+    expect(created).toHaveLength(2);
+    expect(created[0].closed).toBe(true);
+    expect(privateState.browserSession.privateMode).toBe(true);
+
+    await manager.cleanupBrowserSession(privateState);
+    expect(created[1].closed).toBe(true);
+    expect(privateState.browserSession).toBeNull();
+  });
+
+  it('adds Edge InPrivate only when private mode is enabled', () => {
+    const base = { port: 1234, profileDir: '/tmp/sagent-edge-test' };
+    const normalArgs = buildEdgeLaunchArgs(base);
+    const privateArgs = buildEdgeLaunchArgs({ ...base, privateMode: true });
+
+    expect(normalArgs).not.toContain('--inprivate');
+    expect(privateArgs).toContain('--inprivate');
+  });
+
   it('stores a browser preview and publishes a local screenshot URL', async () => {
     const memoryDir = await mkdtemp(path.join(os.tmpdir(), 'sagent-browser-preview-'));
     initWebViewDataStore(memoryDir);
@@ -140,6 +198,22 @@ describe('Bun.WebView browser session adapter', () => {
       expect(preview?.screenshotUrl).toMatch(/^\/screenshots\/run_preview\/browser-preview-\d+\.jpg$/);
       const relativePath = preview!.screenshotUrl.replace('/screenshots/', '');
       await expect(readFile(path.join(memoryDir, 'screenshots', relativePath), 'utf8')).resolves.toBe('fake-jpeg');
+    } finally {
+      await rm(memoryDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not call screenshot or create files in private mode', async () => {
+    const memoryDir = await mkdtemp(path.join(os.tmpdir(), 'sagent-browser-preview-private-'));
+    initWebViewDataStore(memoryDir);
+    const view = new FakeWebView();
+    view.url = 'https://example.com/private';
+
+    try {
+      await expect(captureBrowserPreview(view, { runId: 'run_private_preview', privateMode: true }))
+        .resolves.toBeNull();
+      expect(view.calls.some(call => call[0] === 'screenshot')).toBe(false);
+      await expect(access(path.join(memoryDir, 'screenshots', 'run_private_preview'))).rejects.toThrow();
     } finally {
       await rm(memoryDir, { recursive: true, force: true });
     }

--- a/test/config-store.test.ts
+++ b/test/config-store.test.ts
@@ -102,4 +102,26 @@ describe('structured configuration store', () => {
       resume: true,
     });
   });
+
+  it('persists Worker execution settings and validates boolean values', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-config-execution-update-'));
+    await configStore.init(dir);
+
+    await configStore.updateExecution({ sandboxedWorkers: false, workerSandbox: false });
+
+    expect(configStore.execution({})).toMatchObject({
+      sandboxedWorkers: false,
+      workerSandbox: false,
+    });
+    const saved = JSON.parse(await readFile(path.join(dir, 'config.json'), 'utf8'));
+    expect(saved.execution).toMatchObject({ sandboxedWorkers: false, workerSandbox: false });
+
+    await configStore.init(dir);
+    expect(configStore.execution({})).toMatchObject({
+      sandboxedWorkers: false,
+      workerSandbox: false,
+    });
+
+    await expect(configStore.updateExecution({ sandboxedWorkers: 'false' as any })).rejects.toThrow('sandboxedWorkers');
+  });
 });

--- a/test/llm-logger.test.ts
+++ b/test/llm-logger.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { access, mkdtemp, readFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { flushLlmLogs, initLlmLogger, logLlmRequest, logLlmResponse } from '../agent/core/llm-logger.ts';
+import { withPrivateRun } from '../helpers/private-run.ts';
 
 function todayDirName() {
   const d = new Date();
@@ -65,6 +66,22 @@ describe('llm-logger', () => {
       const raw = await readFile(file, 'utf8');
       expect(raw).toContain('"type":"request"');
       expect(raw).not.toContain('"role":"tools"');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not create a persistent LLM log during a private run', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'sagent-llm-logger-private-'));
+    try {
+      initLlmLogger(dir);
+      await withPrivateRun(true, async () => {
+        logLlmRequest('vendor/private-model', [{ role: 'user', content: 'secret' }]);
+        logLlmResponse('vendor/private-model', { usage: { prompt_tokens: 1 }, choices: [] });
+        await flushLlmLogs();
+      });
+
+      await expect(access(path.join(dir, 'llm-logs'))).rejects.toThrow();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/private-run.test.ts
+++ b/test/private-run.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isPrivateRun, withPrivateRun } from '../helpers/private-run.ts';
+import { removePrivateRunArtifacts } from '../helpers/private-run-artifacts.ts';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sagent-private-run-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('private run context', () => {
+  it('propagates through async work and cannot be disabled by a nested scope', async () => {
+    await withPrivateRun(true, async () => {
+      await Promise.resolve();
+      expect(isPrivateRun()).toBe(true);
+      withPrivateRun(false, () => expect(isPrivateRun()).toBe(true));
+    });
+    expect(isPrivateRun()).toBe(false);
+  });
+
+  it('removes only the selected run artifacts', async () => {
+    const runId = 'run_private_cleanup';
+    const paths = [
+      path.join(tmpDir, 'traces', `${runId}.jsonl`),
+      path.join(tmpDir, 'checkpoints', `${runId}.json`),
+      path.join(tmpDir, 'session-checkpoints', runId, 'session-healthy-1.json'),
+      path.join(tmpDir, 'worker-logs', `${runId}.log`),
+      path.join(tmpDir, 'screenshots', runId, 'screen-1.png'),
+    ];
+    for (const file of paths) {
+      await fs.mkdir(path.dirname(file), { recursive: true });
+      await fs.writeFile(file, 'private');
+    }
+    const unrelated = path.join(tmpDir, 'worker-logs', 'run_other_value.log');
+    await fs.writeFile(unrelated, 'keep');
+
+    await withPrivateRun(true, () => removePrivateRunArtifacts(tmpDir, runId));
+
+    for (const file of paths) {
+      await expect(fs.access(file)).rejects.toThrow();
+    }
+    await expect(fs.readFile(unrelated, 'utf8')).resolves.toBe('keep');
+  });
+});

--- a/test/run-store.test.ts
+++ b/test/run-store.test.ts
@@ -89,6 +89,17 @@ describe('agent run store', () => {
     expect(store.getActiveRun()).toBeNull();
   });
 
+  it('does not retain completed private runs in memory', () => {
+    const store = createAgentRunStore();
+    const run = store.createRun({ privateMode: true }, 1, 'run_private_memory');
+    store.addEvent(run.runId, { type: 'notification', level: 'info', message: 'secret' });
+
+    store.closeRun(run.runId, 'completed');
+
+    expect(run.events).toEqual([]);
+    expect(store.getRun(run.runId)).toBeNull();
+  });
+
   it('rejects invalid state transitions', () => {
     const store = createAgentRunStore();
     const run = store.createRun({}, 1, 'run_invalid');

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { createProjectStore, projectDataDir } from '../agent/core/project-store.js';
 import { createSessionStore } from '../agent/core/session-store.js';
 import { appendTraceEvent } from '../helpers/trace-store.js';
+import { withPrivateRun } from '../helpers/private-run.js';
 
 describe('backend session store', () => {
   let tmpDir: string;
@@ -128,6 +129,62 @@ describe('backend session store', () => {
     const reloaded = await store.loadAll();
     const s1 = reloaded.sessions.find(session => session.id === 's1');
     expect(s1?.messages?.[0]?.content).toBe('new');
+  });
+
+  it('does not persist private run sessions or read-only recovery changes', async () => {
+    const runId = 'run_private_session';
+    const store = createSessionStore({ memoryDir: tmpDir, projectStore });
+
+    await store.recordRunStart({
+      projectId: null,
+      sessionId: 'session_private',
+      runId,
+      task: '不应写入的任务',
+      model: 'model-private',
+      models: ['model-private'],
+      startedAt: 1000,
+      privateMode: true,
+    });
+    await store.recordRunTerminal({
+      projectId: null,
+      sessionId: 'session_private',
+      runId,
+      task: '不应写入的任务',
+      answer: '不应写入的答案',
+      error: null,
+      models: ['model-private'],
+      status: 'done',
+      startedAt: 1000,
+      endedAt: 2000,
+      privateMode: true,
+    });
+
+    await expect(fs.access(path.join(tmpDir, 'chat-sessions.json'))).rejects.toThrow();
+
+    // 即使调用方漏传 privateMode，异步隐私上下文也会挡住写入。
+    await withPrivateRun(true, () => store.upsertSession({
+      id: 'session_private_context',
+      messages: [{ role: 'user', content: '上下文隐私' }],
+      updatedAt: 3000,
+    }));
+    await expect(fs.access(path.join(tmpDir, 'chat-sessions.json'))).rejects.toThrow();
+
+    await appendTraceEvent(tmpDir, 'run_readonly_recovery', {
+      type: 'run_meta',
+      task: '只读恢复',
+      model: 'model-read-only',
+      startedAt: 4000,
+      timestamp: 4000,
+    });
+    await appendTraceEvent(tmpDir, 'run_readonly_recovery', {
+      type: 'done',
+      answer: '只读答案',
+      timestamp: 5000,
+      meta: {},
+    });
+    const readOnly = await store.loadAll({ persist: false });
+    expect(readOnly.sessions.some(session => session.messages.some(message => message.content === '只读恢复'))).toBe(true);
+    await expect(fs.access(path.join(tmpDir, 'chat-sessions.json'))).rejects.toThrow();
   });
 
   it('recovers project traces with the correct project ownership', async () => {

--- a/test/trace-store.test.ts
+++ b/test/trace-store.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import { appendTraceEvent, listTraceRuns, readTraceEvents } from '../helpers/trace-store.ts';
 import { createAgentRunStore } from '../helpers/run-store.ts';
 import { createBaseEventSender } from '../helpers/run-agent.ts';
+import { withPrivateRun } from '../helpers/private-run.ts';
 
 let tmpDir: string;
 
@@ -96,5 +97,20 @@ describe('trace store', () => {
     });
     expect(event.input_tokens).toBe(120);
     expect(event.output_tokens).toBe(30);
+  });
+
+  it('keeps private-run events in memory without writing a trace file', async () => {
+    const runId = 'run_private_trace';
+    const store = createAgentRunStore();
+    const run = store.createRun({ privateMode: true }, 1, runId);
+
+    await withPrivateRun(true, async () => {
+      const send = createBaseEventSender(runId, store, tmpDir);
+      send({ type: 'notification', level: 'info', message: 'secret event' });
+      await run.persistence?.flush();
+    });
+
+    expect(run.events).toHaveLength(1);
+    await expect(fs.access(path.join(tmpDir, 'traces'))).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## 概要

- 新增任务级 `privateMode`，从前端请求贯穿服务端、Worker 与桌面 Agent
- 隔离普通/隐私浏览器会话，并为 Edge 传入 `--inprivate`
- 私密任务不持久化 trace、checkpoint、会话、LLM 日志与截图，并禁用重试/回滚
- 补充执行配置界面、双语文档及隐私模式覆盖测试

## 验证

- `npm test`（61 个测试文件，433 项测试通过）
- `npm run build`
- `npm run lint`

Closes #25