### PR TITLE
fix(agent): 重跑链路的输入与状态一致性修复（会话历史 / 失败留痕 / 误报失败 / 坏 JSON）

### DIFF
--- a/agent/core/nvidia-response-parsers.ts
+++ b/agent/core/nvidia-response-parsers.ts
@@ -114,6 +114,15 @@ function getMessageText(content) {
     .join('\n');
 }
 
+/**
+ * 解析失败兜底原文：走 native tool-call 路径时 content 往往是空串，
+ * 坏掉的 arguments 才是模型唯一的原文，必须留给错误信息和解析失败语料。
+ */
+function getToolCallRawText(message) {
+  const args = message?.tool_calls?.[0]?.function?.arguments;
+  return typeof args === 'string' ? args : '';
+}
+
 // ── MiniMax Tool Call Block Parsing ──
 
 function parseToolCallBlock(raw) {
@@ -167,12 +176,18 @@ function tryToolCalls(message) {
   const toolCalls = message?.tool_calls || [];
   if (toolCalls.length === 0) return null;
 
-  const toolCall = toolCalls[0];
-  let input = toolCall.function.arguments;
+  const fn = toolCalls[0]?.function;
+  if (!fn?.name) return null;
+
+  let input = fn.arguments;
   if (typeof input === 'string') {
-    input = JSON.parse(input);
+    // 模型会在 arguments 里吐坏 JSON（典型：shell 命令内的双引号没转义）。
+    // 必须吞掉 SyntaxError 让策略链继续往下走，否则异常会穿透 parseResponse，
+    // 用户只看到裸的 SyntaxError，原文也进不了解析失败语料。
+    input = tryParseJsonObject(input);
+    if (!input) return null;
   }
-  return { action: { type: toolCall.function.name, ...input } };
+  return { action: { type: fn.name, ...input } };
 }
 
 function tryToolCallBlocks(_message, content) {
@@ -353,6 +368,6 @@ export function createModelResponseParser(model) {
       }
     }
 
-    return { parseFailed: true, rawContent: content, usage, reasoning };
+    return { parseFailed: true, rawContent: content || getToolCallRawText(message), usage, reasoning };
   };
 }

--- a/agent/desktop/planner/shared.ts
+++ b/agent/desktop/planner/shared.ts
@@ -33,6 +33,23 @@ export function isTimeoutError(err: any) {
   return String(err?.message || '').includes('模型超时');
 }
 
+// 失败路径上传递请求原文的通道。挂在错误对象上而不改抛出类型，
+// 是为了不影响任何按 message/status 判定错误种类的既有逻辑。
+const ERROR_REQUESTS_KEY = '__agentPlanRequests';
+
+/** 记下这次模型调用已经发出的消息体，供后续 failed 事件还原当时的 prompt 输入。 */
+export function attachRequestsToError(err: any, requests: unknown[][]) {
+  if (!err || typeof err !== 'object' || requests.length === 0) return;
+  // 同一个错误对象会被多层 catch 依次传递，先到先得，不覆盖更贴近发起点的那份记录。
+  if (err[ERROR_REQUESTS_KEY] === undefined) err[ERROR_REQUESTS_KEY] = requests;
+}
+
+/** 取出失败调用发出过的消息体；没有则返回 undefined，事件里就不带 requests 字段。 */
+export function requestsFromError(err: any): unknown[][] | undefined {
+  const requests = err?.[ERROR_REQUESTS_KEY];
+  return Array.isArray(requests) && requests.length > 0 ? requests : undefined;
+}
+
 /** setTimeout 的可取消版本：用户取消时立即 reject，不必空等退避结束。 */
 export function sleepWithCancel(ms: number, cancelSignal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -83,6 +100,7 @@ export function handleModelFailure(
     model,
     step,
     error: String(err?.message || err).slice(0, 120),
+    requests: requestsFromError(err),
   });
 }
 

--- a/agent/desktop/planner/single-model-path.ts
+++ b/agent/desktop/planner/single-model-path.ts
@@ -13,6 +13,7 @@ import {
   isRateLimitError,
   isTimeoutError,
   planEventPayload,
+  requestsFromError,
   sleepWithCancel,
 } from './shared.ts';
 import type { PlanWithTimeout } from './single-model.ts';
@@ -53,7 +54,7 @@ export async function runSingleModel({
       if (isTimeoutError(err)) {
         pool.blacklistedModels.add(model);
         log.warn(`[MultiModel] ${model} 超时，已加入黑名单`);
-        onEvent?.({ type: 'model_plan', stage: 'failed', model, step, error: err.message });
+        onEvent?.({ type: 'model_plan', stage: 'failed', model, step, error: err.message, requests: requestsFromError(err) });
         throw err;
       }
       if (isRateLimitError(err) && attempt < SINGLE_MODEL_RATE_LIMIT_RETRY) {
@@ -65,7 +66,7 @@ export async function runSingleModel({
         onEvent?.({ type: 'model_plan', stage: 'thinking', model, step });
         continue;
       }
-      onEvent?.({ type: 'model_plan', stage: 'failed', model, step, error: err.message });
+      onEvent?.({ type: 'model_plan', stage: 'failed', model, step, error: err.message, requests: requestsFromError(err) });
       throw err;
     }
   }

--- a/agent/desktop/planner/single-model.ts
+++ b/agent/desktop/planner/single-model.ts
@@ -8,7 +8,7 @@ import { createAbortScope, throwIfAborted } from '../../core/abort.ts';
 import { displayWidth, padEndW } from '../../core/utils.ts';
 import { log } from '../../../helpers/logger.ts';
 import { extractErrorDiagnostics } from '../../../helpers/retry.ts';
-import { CANCELLED_MESSAGE, DEFAULT_MODEL_TIMEOUT_MS, cancelledError } from './shared.ts';
+import { CANCELLED_MESSAGE, DEFAULT_MODEL_TIMEOUT_MS, attachRequestsToError, cancelledError } from './shared.ts';
 
 function boxed(line: string) {
   const width = Math.max(displayWidth(line) + 4, 52);
@@ -108,6 +108,9 @@ export function createPlanWithTimeout({
       })
       .catch(err => {
         logModelFailure(model, Date.now() - startedAt, err);
+        // 把已发出的消息体挂到错误上：失败事件同样要能还原当时的 prompt 输入，
+        // 否则超时/解析失败这些最需要复盘的步骤在 trace 里反而查不到请求原文。
+        attachRequestsToError(err, requests);
         throw err;
       })
       .finally(() => timeoutScope.cleanup());

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -5993,6 +5993,9 @@ textarea:disabled {
   font-size: var(--f-xs);
   line-height: 1.5;
 }
+/* 档位级警告：档位承诺的行为在当前模型数下不成立。与字段级 warning 同底色，
+   但要顶到档位说明下方，故单独收一下外边距。 */
+.settings-profile-warning { margin: -8px 0 16px; }
 .settings-advanced-toggle { display: inline-flex; align-items: center; gap: 5px; margin-top: 14px; padding: 5px 0; border: 0; background: transparent; color: var(--c-text-secondary); cursor: pointer; font-size: var(--f-sm); }
 .settings-advanced-toggle:hover { color: var(--c-text); }
 .settings-advanced-grid { margin-top: 10px; }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1251,7 +1251,7 @@ export default function App() {
       />
 
       {showReset && <ResetDialog onConfirm={handleReset} onCancel={() => setShowReset(false)} />}
-      {showSettings && <SettingsDialog onClose={() => setShowSettings(false)} activeProjectId={activeProjectId} projects={projects} />}
+      {showSettings && <SettingsDialog onClose={() => setShowSettings(false)} activeProjectId={activeProjectId} projects={projects} selectedAgentModels={selectedAgentModels} />}
       {showPromptPreview && visibleContextEstimate?.promptPreview?.text && (
         <PromptPreviewDialog
           estimate={visibleContextEstimate}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -49,7 +49,7 @@ import {
 import { formatMsgTime } from './utils/format.js';
 import { shuffled } from './utils/random.js';
 import { hasThinkContent } from './utils/markdown.js';
-import { appendUniqueTraceEvent, latestTerminalEvent } from './utils/agent-trace.js';
+import { appendUniqueTraceEvent, settledTerminalEvent } from './utils/agent-trace.js';
 import { buildActualContextEstimate } from './utils/context-usage.js';
 import { buildAgentMetaFromSession } from './utils/agent-stats.js';
 
@@ -595,10 +595,11 @@ export default function App() {
           }
         }
         setAgentRunning(false);
-      } catch (err) {
-        if (err.name === 'AbortError') {
-          setAgentRunning(false);
-        }
+      } catch {
+        // 无论是主动 abort 还是读流中途失败（网络抖动、服务端重启）都要落回非运行态。
+        // 这个 effect 只在 sessionsLoading 变化时跑一次，不会重订阅：漏清一次
+        // 运行态就永久卡在“运行中”，输入框一直锁着，只能再刷新一次页面。
+        setAgentRunning(false);
       }
     })();
 
@@ -629,9 +630,11 @@ export default function App() {
       }
       if (cancelled || !Array.isArray(events) || events.length === 0) return;
 
-      // 重试会把多个 attempt 的 done/error 都留在同一条 trace 里，取首个会读到
-      // 早已被重跑覆盖的旧结果——成功的 run 因此被记成失败。
-      const terminal = latestTerminalEvent(events);
+      // 重试会把多个 attempt 的 done/error 都留在同一条 trace 里。取首个会读到
+      // 早已被重跑覆盖的旧结果；只取最后一个也不够——重跑跑到一半时，最后一个
+      // 终止事件仍是上一次 attempt 的失败，据此收尾会在任务正跑着时误报失败。
+      // 故只认属于最新 attempt 的终止事件，与重连回放的 isReplayedTerminal 同口径。
+      const terminal = settledTerminalEvent(events);
       if (!terminal) return;
 
       setAgentTrace(prev => appendUniqueTraceEvent(prev, terminal));

--- a/client/src/components/agent/ModelPlanCard.jsx
+++ b/client/src/components/agent/ModelPlanCard.jsx
@@ -76,6 +76,8 @@ export function ModelPlanCard({ event, previousRequest, isWinner, modelList, ste
       )}
       {stage === 'failed' && (
         <>
+          {/* 失败步骤同样带请求原文（超时/解析失败最需要复盘的就是当时发了什么）。 */}
+          <PromptRequestDetails requests={event.requests} previousRequest={previousRequest} response={null} reasoning={event.reasoning} t={t} />
           {event.rationale && <p className="model-card-sub">{event.rationale}</p>}
           {event.error && <p className="model-card-error">{event.error}</p>}
         </>

--- a/client/src/components/agent/StepCard.jsx
+++ b/client/src/components/agent/StepCard.jsx
@@ -28,6 +28,9 @@ export const StepCard = memo(function StepCard({ events, step, previousRequest, 
   // 从本步事件切片里拆出各阶段。action 信息优先取 step/action 事件，
   // 缺失时（如授权被拒只有 result）回退到 model_plan 决策事件。
   let observation = null, actionEvent = null, resultEvent = null, result = null, modelEvent = null;
+  // 本步没跑出决策时（超时、解析失败等），请求原文只挂在 failed 事件上，
+  // 单独存一份，让这类步骤照样能展开看当时发出去的 prompt。
+  let failedModelEvent = null;
   const terminalEvents = [];
   const mcpEvents = [];
   for (const e of events) {
@@ -35,6 +38,7 @@ export const StepCard = memo(function StepCard({ events, step, previousRequest, 
     else if (e.type === 'step' && e.stage === 'action') actionEvent = e;
     else if (e.type === 'step' && e.stage === 'result') { resultEvent = e; result = e.result; }
     else if (e.type === 'model_plan' && (e.stage === 'success' || e.stage === 'winner')) modelEvent = e;
+    else if (e.type === 'model_plan' && e.stage === 'failed') failedModelEvent = e;
     else if (e.type === 'terminal_output') terminalEvents.push(e);
     else if (e.type === 'mcp_output') mcpEvents.push(e);
   }
@@ -63,7 +67,7 @@ export const StepCard = memo(function StepCard({ events, step, previousRequest, 
       data-tool={action?.tool || undefined}
     >
       <div className="agent-trace-content">
-        <PromptRequestDetails requests={modelEvent?.requests} previousRequest={previousRequest} response={response} reasoning={reasoning} t={t} />
+        <PromptRequestDetails requests={modelEvent?.requests || failedModelEvent?.requests} previousRequest={previousRequest} response={response} reasoning={reasoning} t={t} />
         <div className="step-card-head">
           <span className="step-card-step">{step}</span>
           <span className="step-card-summary" title={summary}>{summary || t('agentPanel.badgeAction')}</span>

--- a/client/src/components/dialogs/SettingsDialog.jsx
+++ b/client/src/components/dialogs/SettingsDialog.jsx
@@ -3,6 +3,7 @@ import { Palette, SlidersHorizontal, KeyRound, Minus, Plus, Plug, ChevronDown, C
 import { fetchConfig, saveConfig, saveExecution, saveTools, resetConfig, applyConfigProfile, saveMcpServer, deleteMcpServer, testMcpServer } from '../../api/config.js';
 import { useTheme } from '../../theme/ThemeProvider.jsx';
 import { useI18n, useT } from '../../i18n/I18nProvider.jsx';
+import { multiModelTuningIdle } from '../../utils/agent-config-hints.js';
 import { DialogShell } from './DialogShell.jsx';
 
 // Agent 行为参数（可写，下一次任务生效）。单位与后端 schema 一致，换算放消费点。
@@ -73,7 +74,7 @@ const GROUPS = [
 // 设置面板：左导航分组 + 右内容。
 // 外观（主题/语言，前台即时生效）、Agent 参数（保存后下次任务生效）、
 // Worker 部署开关（保存后需重启）、记忆前端偏好和 API Key 只读展示。
-export function SettingsDialog({ onClose, activeProjectId = null, projects = [] }) {
+export function SettingsDialog({ onClose, activeProjectId = null, projects = [], selectedAgentModels = [] }) {
   const t = useT();
   const { theme, setTheme, fontSize, setFontSize } = useTheme();
   const { locale, setLocale } = useI18n();
@@ -574,6 +575,19 @@ export function SettingsDialog({ onClose, activeProjectId = null, projects = [] 
               <p className="settings-profile-hint">
                 {profile === 'custom' ? t('settings.profileCustomHint') : t(`settings.profileHint.${profile}`)}
               </p>
+              {/* 只选了一个模型时，并发/错峰不参与执行——档位说明里承诺的"备用模型顶上"
+                  这时并不存在。参数本身合法，故沿用字段级 warning 的样式，不阻断保存。
+                  提示挂在档位下方而非 batchSize/staggerDelaySec 字段上：那两项折在高级区里，
+                  而这条恰恰是折叠起来就看不见的搭配问题。 */}
+              {multiModelTuningIdle({
+                modelCount: selectedAgentModels.length,
+                batchSize: agent.batchSize,
+                staggerDelaySec: agent.staggerDelaySec,
+              }) && (
+                <p className="settings-field-warning settings-profile-warning">
+                  {t('settings.singleModelTuningIdle')}
+                </p>
+              )}
               <div className="settings-grid">
                 {BASIC_AGENT_FIELDS.map(f => numberField(f.key, f.labelKey))}
                 <label className="settings-field settings-field-switch">

--- a/client/src/hooks/useAgentTransport.js
+++ b/client/src/hooks/useAgentTransport.js
@@ -4,6 +4,7 @@ import { showAgentNotification } from '../notifications.js';
 import { touchSession, upsertAgentRun } from './useChatSessions.js';
 import { useT } from '../i18n/I18nProvider.jsx';
 import { agentTraceEventKey, appendUniqueTraceEvent } from '../utils/agent-trace.js';
+import { buildRunConversationHistory } from '../utils/agent-conversation.js';
 import { buildAgentMetaFromSession } from '../utils/agent-stats.js';
 
 function uniqueModelIds(value) {
@@ -149,7 +150,8 @@ export function useAgentTransport({
         projectId: activeSession.projectId ?? null,
         sessionId,
         signal: controller.signal,
-        messages: isRetry ? [] : messages.slice(-10).map(m => ({ role: m.role, content: m.content })),
+        // 重跑必须沿用与首跑相同的历史口径：清空会让模型丢失 task 里指代词的所指。
+        messages: buildRunConversationHistory(messages, { isRetry, task: text }),
         ...extraBody,
         async onEvent(event) {
           console.log(`[AgentUI] event type=${event.type} step=${event.step ?? '-'} stage=${event.stage ?? '-'} model=${event.model || '-'}`);

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -124,6 +124,7 @@ export const en = {
   'settings.profileHint.economy': 'One model at a time: the primary gets a long exclusive window, the next only steps in if it fails. Cheapest, but slowest.',
   'settings.profileHint.deep': 'More steps and a larger context window, for tasks that need many rounds. Takes the longest.',
   'settings.profileHint.besteffort': 'Optimized for finishing: generous step and timeout budgets, with backup models taking over on failure or a slow primary.',
+  'settings.singleModelTuningIdle': 'Only 1 model is selected, so batch size and stagger delay never come into play: there is no backup to take over, a single model timeout fails the whole task, and a manual rollback is the only way forward. Select a second model to enable failover.',
   'settings.warning.historyExceedsSteps': 'History window ({maxHistorySteps}) exceeds max steps ({maxSteps}); the extra capacity has no effect — history can never hold more than {maxSteps} entries.',
   'settings.resultCharsNote': 'Applies to the last 3 steps only. Steps 4-10 are capped at 2500 characters, earlier ones at 1000, and anything past the history window is compressed to a 200-character summary.',
   'settings.advanced': 'Advanced settings',

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -125,6 +125,7 @@ export const zh = {
   'settings.profileHint.economy': '单模型串行：主模型独占较长时间，确实不行才叫下一个。最省 token，但慢。',
   'settings.profileHint.deep': '步数与上下文都放宽，适合需要多步推进的复杂任务。耗时最长。',
   'settings.profileHint.besteffort': '以跑成功为目标：步数和超时都留有余量，主模型失败或迟迟不返回时由备用模型顶上。',
+  'settings.singleModelTuningIdle': '当前只选了 1 个模型，并发批量与错峰延迟不参与执行：没有备用模型可顶上，主模型一超时整个任务就失败，只能手动回滚重跑。多选一个模型即可启用补位。',
   'settings.warning.historyExceedsSteps': '历史窗口（{maxHistorySteps}）大于最大步数（{maxSteps}），多出的额度不会生效——历史里不可能有超过 {maxSteps} 条记录。',
   'settings.resultCharsNote': '仅作用于最近 3 步。第 4-10 步固定 2500 字符，更早的固定 1000 字符，被历史窗口丢弃的压成 200 字符摘要。',
   'settings.advanced': '高级设置',

--- a/client/src/utils/agent-attempts.js
+++ b/client/src/utils/agent-attempts.js
@@ -74,8 +74,8 @@ function buildPreviousRequestIndex(entries) {
     const previous = seen.get(event.model) ?? null;
     previousRequestByIndex.set(index, previous);
     previousRequestByEvent.set(event, previous);
-    // 只有真正发出过请求的事件才更新基准，failed/cancelled 等空事件跳过，
-    // 使基准能跨越无请求的步骤继续指向上一次有效请求。
+    // 只有真正发出过请求的事件才更新基准（失败事件带 requests 时同样计入，
+    // 请求确实发出去了），没有请求的事件跳过，使基准能跨越这些步骤继续指向上一次有效请求。
     const request = lastRequestOf(event);
     if (request != null) seen.set(event.model, request);
   }

--- a/client/src/utils/agent-config-hints.js
+++ b/client/src/utils/agent-config-hints.js
@@ -1,0 +1,22 @@
+// Agent 参数与「实际选了几个模型」搭配失效时的提示。
+// 取值本身都合法，只是在当前模型数下不参与执行，故只提示不阻断。
+
+/**
+ * 并发/错峰这两项只在多模型候选集上生效：
+ * planner 发现只有一个模型时直接走单模型路径（agent/desktop/planner/index.ts），
+ * batchSize / staggerDelaySec 完全不参与，模型一超时整个任务就失败，没有备胎顶上。
+ * fast / deep / besteffort 三档的容错都建立在这个前提上，只选一个模型时它们
+ * 只剩等待成本（更长的超时上限），拿不到补位收益。
+ *
+ * @param {{ modelCount?: number, batchSize?: unknown, staggerDelaySec?: unknown }} params
+ * @returns {boolean} 需要提示"这些参数当前不生效"时为 true
+ */
+export function multiModelTuningIdle({ modelCount, batchSize, staggerDelaySec } = {}) {
+  const count = Number(modelCount);
+  // 一个模型都没选时用户还没做出选择，此时提示没有指向性，不打扰。
+  if (!Number.isFinite(count) || count !== 1) return false;
+
+  const batch = Number(batchSize);
+  const stagger = Number(staggerDelaySec);
+  return (Number.isFinite(batch) && batch > 1) || (Number.isFinite(stagger) && stagger > 0);
+}

--- a/client/src/utils/agent-conversation.js
+++ b/client/src/utils/agent-conversation.js
@@ -1,0 +1,38 @@
+// 发给 Agent 的 conversationHistory：只包含「本轮任务之前」的对话，
+// 供模型理解当前 task 里的指代。本轮任务本身通过 task 字段单独下发，不重复放进来。
+
+const MAX_CONVERSATION_MESSAGES = 10;
+
+/**
+ * 从会话消息里切出本轮任务之前的部分。
+ *
+ * 首跑时 messages 还没追加本轮 user 消息，整条列表都属于"之前"，取尾部即可。
+ * 从 checkpoint 重跑时则不然：messages 已经包含本轮 user 任务、"运行中"占位助手消息，
+ * 以及上一次失败后追加的重试提示，直接取尾部会把这些噪声当成历史对话喂回模型。
+ * 所以重跑时回退到本轮 user 消息之前，使重跑与首跑的 prompt 输入保持一致——
+ * 否则模型会在重跑后突然失去 task 里指代词（"这几个""上面提到的"）的所指。
+ *
+ * @param {Array<{role?: string, content?: string, pending?: string}>} messages 当前会话消息
+ * @param {{ isRetry?: boolean, task?: string }} options isRetry 为从 checkpoint 重跑；task 为本轮任务原文
+ */
+export function buildRunConversationHistory(messages, { isRetry = false, task = '' } = {}) {
+  const list = Array.isArray(messages) ? messages : [];
+  let prior = list;
+
+  if (isRetry) {
+    const taskText = typeof task === 'string' ? task.trim() : '';
+    const taskIndex = taskText
+      ? list.findLastIndex(message => message?.role === 'user' && String(message?.content ?? '').trim() === taskText)
+      : -1;
+    prior = taskIndex >= 0
+      // 命中本轮任务：它及其之后的都是本轮产物，一律丢弃。
+      ? list.slice(0, taskIndex)
+      // 兜底（刷新后 lastAgentTaskRef 丢失、task 退化成占位文案时匹配不上）：
+      // 至少剔除 pending 占位消息，它们是 UI 运行态而非真实对话。
+      : list.filter(message => !message?.pending);
+  }
+
+  return prior
+    .slice(-MAX_CONVERSATION_MESSAGES)
+    .map(message => ({ role: message?.role, content: message?.content }));
+}

--- a/client/src/utils/agent-trace.js
+++ b/client/src/utils/agent-trace.js
@@ -51,3 +51,25 @@ export function latestTerminalEvent(events) {
   }
   return null;
 }
+
+function attemptOf(event) {
+  const attempt = Number(event?.attempt);
+  return Number.isInteger(attempt) && attempt > 0 ? attempt : 1;
+}
+
+/**
+ * 「这个 run 已经结束了吗」——只认属于最新一次 attempt 的终止事件。
+ *
+ * latestTerminalEvent 单看是不够的：重跑到一半时，trace 里最后一个终止事件
+ * 还是上一次 attempt 的失败，拿它当结局会在任务正跑着的时候报失败、把运行态
+ * 清掉，连带清掉待审批/待提问，而后端仍在继续执行。
+ * 新 attempt 一开跑就会追加更高 attempt 的事件，故以本批事件的最大 attempt 为界。
+ * 老 trace 没有 attempt 字段时统一按 1 处理，行为与加守卫前一致。
+ */
+export function settledTerminalEvent(events) {
+  const terminal = latestTerminalEvent(events);
+  if (!terminal) return null;
+
+  const maxAttempt = events.reduce((max, event) => Math.max(max, attemptOf(event)), 1);
+  return attemptOf(terminal) < maxAttempt ? null : terminal;
+}

--- a/test/agent-config-hints.test.js
+++ b/test/agent-config-hints.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { multiModelTuningIdle } from '../client/src/utils/agent-config-hints.js';
+
+// besteffort 档的取值：并发 2、错峰 10s，容错完全依赖多模型补位。
+const BEST_EFFORT = { batchSize: 2, staggerDelaySec: 10 };
+// economy 档：本就按单模型串行设计，但错峰仍是多模型才用得上的参数。
+const ECONOMY = { batchSize: 1, staggerDelaySec: 60 };
+
+describe('multi-model tuning idle hint', () => {
+  it('warns when a fallback-oriented profile runs on a single model', () => {
+    expect(multiModelTuningIdle({ modelCount: 1, ...BEST_EFFORT })).toBe(true);
+  });
+
+  it('warns on a single model whenever stagger delay is set, even at batch size 1', () => {
+    expect(multiModelTuningIdle({ modelCount: 1, ...ECONOMY })).toBe(true);
+  });
+
+  it('stays quiet once a second model is selected', () => {
+    expect(multiModelTuningIdle({ modelCount: 2, ...BEST_EFFORT })).toBe(false);
+  });
+
+  it('stays quiet when neither knob is in play', () => {
+    expect(multiModelTuningIdle({ modelCount: 1, batchSize: 1, staggerDelaySec: 0 })).toBe(false);
+  });
+
+  it('stays quiet before the user has picked any model', () => {
+    expect(multiModelTuningIdle({ modelCount: 0, ...BEST_EFFORT })).toBe(false);
+  });
+
+  it('tolerates missing or non-numeric config values', () => {
+    expect(multiModelTuningIdle()).toBe(false);
+    expect(multiModelTuningIdle({ modelCount: 1 })).toBe(false);
+    expect(multiModelTuningIdle({ modelCount: 1, batchSize: null, staggerDelaySec: undefined })).toBe(false);
+  });
+});

--- a/test/agent-conversation.test.js
+++ b/test/agent-conversation.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { buildRunConversationHistory } from '../client/src/utils/agent-conversation.js';
+
+const PRIOR = [
+  { role: 'user', content: '第一轮问题' },
+  { role: 'assistant', content: '第一轮回答' },
+];
+
+describe('agent run conversation history', () => {
+  it('takes the whole list on a first run (task is not in messages yet)', () => {
+    expect(buildRunConversationHistory(PRIOR, { isRetry: false, task: '第二轮任务' })).toEqual([
+      { role: 'user', content: '第一轮问题' },
+      { role: 'assistant', content: '第一轮回答' },
+    ]);
+  });
+
+  it('keeps prior turns on a checkpoint retry instead of dropping them', () => {
+    const messages = [
+      ...PRIOR,
+      { role: 'user', content: '第二轮任务' },
+      { role: 'assistant', content: 'Agent 运行中', pending: 'run' },
+    ];
+
+    expect(buildRunConversationHistory(messages, { isRetry: true, task: '第二轮任务' })).toEqual([
+      { role: 'user', content: '第一轮问题' },
+      { role: 'assistant', content: '第一轮回答' },
+    ]);
+  });
+
+  it('cuts at the latest occurrence when the same task text was sent before', () => {
+    const messages = [
+      { role: 'user', content: '重复任务' },
+      { role: 'assistant', content: '旧回答' },
+      { role: 'user', content: '重复任务' },
+      { role: 'assistant', content: '重试中', pending: 'run' },
+    ];
+
+    expect(buildRunConversationHistory(messages, { isRetry: true, task: '重复任务' })).toEqual([
+      { role: 'user', content: '重复任务' },
+      { role: 'assistant', content: '旧回答' },
+    ]);
+  });
+
+  it('falls back to dropping pending placeholders when the task text does not match', () => {
+    const messages = [
+      ...PRIOR,
+      { role: 'assistant', content: 'Agent 运行中', pending: 'run' },
+    ];
+
+    expect(buildRunConversationHistory(messages, { isRetry: true, task: '继续任务' })).toEqual([
+      { role: 'user', content: '第一轮问题' },
+      { role: 'assistant', content: '第一轮回答' },
+    ]);
+  });
+
+  it('caps history at the most recent 10 messages', () => {
+    const messages = Array.from({ length: 14 }, (_, index) => ({ role: 'user', content: `m${index}` }));
+    const history = buildRunConversationHistory(messages, { isRetry: false });
+
+    expect(history).toHaveLength(10);
+    expect(history[0].content).toBe('m4');
+    expect(history.at(-1).content).toBe('m13');
+  });
+
+  it('tolerates a missing message list', () => {
+    expect(buildRunConversationHistory(undefined, { isRetry: true, task: 'x' })).toEqual([]);
+  });
+});

--- a/test/agent-trace.test.js
+++ b/test/agent-trace.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { agentTraceEventKey, appendUniqueTraceEvent, latestTerminalEvent } from '../client/src/utils/agent-trace.js';
+import { agentTraceEventKey, appendUniqueTraceEvent, latestTerminalEvent, settledTerminalEvent } from '../client/src/utils/agent-trace.js';
 
 describe('agent trace event de-duplication', () => {
   it('uses the server sequence as the primary event identity', () => {
@@ -72,5 +72,46 @@ describe('terminal event selection across retry attempts', () => {
   it('returns null when the run has not finished', () => {
     expect(latestTerminalEvent([{ type: 'step', step: 1 }])).toBeNull();
     expect(latestTerminalEvent(null)).toBeNull();
+  });
+});
+
+// 切 tab 回来时的兜底只能用「已定局」的终止事件收尾。重跑跑到一半时 trace 里
+// 最后一个终止事件仍是上一次 attempt 的失败，据此收尾会在任务正跑着时误报失败、
+// 清掉运行态和待审批弹窗，而后端还在继续执行。
+describe('settled terminal event guards in-flight retries', () => {
+  it('ignores the previous attempt failure while a newer attempt is running', () => {
+    const events = [
+      { type: 'step', attempt: 1, step: 1, stage: 'result' },
+      { type: 'error', attempt: 1, error: '模型超时 (120s)' },
+      { type: 'run_meta', attempt: 2 },
+      { type: 'step', attempt: 2, step: 2, stage: 'observe' },
+    ];
+
+    expect(latestTerminalEvent(events)).toMatchObject({ type: 'error', attempt: 1 });
+    expect(settledTerminalEvent(events)).toBeNull();
+  });
+
+  it('accepts the terminal event once the newest attempt finishes', () => {
+    const events = [
+      { type: 'error', attempt: 1, error: '模型超时 (120s)' },
+      { type: 'run_meta', attempt: 2 },
+      { type: 'done', attempt: 2, answer: '完成' },
+    ];
+
+    expect(settledTerminalEvent(events)).toMatchObject({ type: 'done', answer: '完成' });
+  });
+
+  it('treats traces without attempt fields as a single attempt', () => {
+    const events = [
+      { type: 'step', step: 1, stage: 'result' },
+      { type: 'done', answer: '完成' },
+    ];
+
+    expect(settledTerminalEvent(events)).toMatchObject({ type: 'done', answer: '完成' });
+  });
+
+  it('returns null when nothing has finished yet', () => {
+    expect(settledTerminalEvent([{ type: 'step', step: 1 }])).toBeNull();
+    expect(settledTerminalEvent(null)).toBeNull();
   });
 });

--- a/test/desktop-planner-abort.test.ts
+++ b/test/desktop-planner-abort.test.ts
@@ -245,3 +245,64 @@ describe('race strategy batch scheduling', () => {
     }
   });
 });
+
+describe('desktop planner failure tracing', () => {
+  it('keeps the sent prompt on the failed event when a single model times out', async () => {
+    const sentMessages = [{ role: 'system', content: '协议' }, { role: 'user', content: '{"task":"test"}' }];
+    const agentPlan = vi.fn(({ signal, onRequest }: { signal: AbortSignal; onRequest: (m: unknown[]) => void }) => {
+      onRequest(sentMessages);
+      return new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+    const events: any[] = [];
+    const planner = createDesktopPlanner({
+      registry: { resolve: () => ({ agentPlan }) },
+      modelConfig: [],
+      blacklistedModels: new Set(),
+      modelTimeoutMs: 10,
+    });
+
+    await expect(planner({
+      model: 'slow-model',
+      agentModels: ['slow-model'],
+      strategy: 'race',
+      cancelSignal: new AbortController().signal,
+      step: 1,
+      task: 'test',
+      history: [],
+      observation: {},
+      onEvent: (event: any) => events.push(event),
+    })).rejects.toThrow('模型超时');
+
+    // 超时步骤的 prompt 输入必须留痕，否则最需要复盘的步骤在 trace 里反而查不到请求原文。
+    const failed = events.find(event => event.type === 'model_plan' && event.stage === 'failed');
+    expect(failed?.requests).toEqual([sentMessages]);
+  });
+
+  it('omits requests when the model never got as far as sending one', async () => {
+    const events: any[] = [];
+    const planner = createDesktopPlanner({
+      registry: { resolve: () => ({ agentPlan: () => Promise.reject(new Error('provider down')) }) },
+      modelConfig: [],
+      blacklistedModels: new Set(),
+      modelTimeoutMs: 1_000,
+    });
+
+    await expect(planner({
+      model: 'broken-model',
+      agentModels: ['broken-model'],
+      strategy: 'race',
+      cancelSignal: new AbortController().signal,
+      step: 1,
+      task: 'test',
+      history: [],
+      observation: {},
+      onEvent: (event: any) => events.push(event),
+    })).rejects.toThrow('provider down');
+
+    const failed = events.find(event => event.type === 'model_plan' && event.stage === 'failed');
+    expect(failed).toBeTruthy();
+    expect(failed.requests).toBeUndefined();
+  });
+});

--- a/test/nvidia-response-parsers.test.ts
+++ b/test/nvidia-response-parsers.test.ts
@@ -15,6 +15,63 @@ function wrapWithReasoning(content: string, reasoningContent: string) {
   };
 }
 
+function wrapToolCall(name: string, args: unknown, content = '') {
+  return {
+    choices: [{ message: { content, tool_calls: [{ function: { name, arguments: args } }] } }],
+    usage: null,
+  };
+}
+
+describe('nvidia response parsers: tryToolCalls guard', () => {
+  it('falls through to parseFailed instead of throwing on malformed tool_call arguments', () => {
+    const parse = createModelResponseParser('qwen/qwen3.5-397b-a17b');
+    // 模型把 shell 命令里的双引号原样吐出来，arguments 不是合法 JSON。
+    const raw = '{"command":"echo "---""}';
+
+    const result = parse(wrapToolCall('run_safe', raw));
+
+    expect(result.parseFailed).toBe(true);
+    // 原文必须留下来：错误信息和解析失败语料都靠它。
+    expect(result.rawContent).toBe(raw);
+  });
+
+  it('keeps content as raw output when the message also carries text', () => {
+    const parse = createModelResponseParser('qwen/qwen3.5-397b-a17b');
+    const result = parse(wrapToolCall('run_safe', '{"command":"echo "', '短文本'));
+
+    expect(result.parseFailed).toBe(true);
+    expect(result.rawContent).toBe('短文本');
+  });
+
+  it('lets a valid JSON action in content win when tool_call arguments are broken', () => {
+    const parse = createModelResponseParser('qwen/qwen3.5-397b-a17b');
+    const content = JSON.stringify({ rationale: '收尾', action: { type: 'finish', answer: '完成' } });
+
+    const result = parse(wrapToolCall('run_safe', '{"command":"echo "', content));
+
+    expect(result.parseFailed).toBeUndefined();
+    expect(result.action?.type).toBe('finish');
+  });
+
+  it('still parses well-formed tool_call arguments', () => {
+    const parse = createModelResponseParser('qwen/qwen3.5-397b-a17b');
+    const result = parse(wrapToolCall('finish', JSON.stringify({ answer: 'ok' })));
+
+    expect(result.action?.type).toBe('finish');
+    expect(result.action?.answer).toBe('ok');
+  });
+
+  it('skips tool_calls without a function name', () => {
+    const parse = createModelResponseParser('qwen/qwen3.5-397b-a17b');
+    const result = parse({
+      choices: [{ message: { content: '', tool_calls: [{ function: { arguments: '{}' } }] } }],
+      usage: null,
+    });
+
+    expect(result.parseFailed).toBe(true);
+  });
+});
+
 describe('nvidia response parsers: tryTextFinish guard', () => {
   it('rejects broken-JSON action wrapped in ```json fences instead of treating it as finish', () => {
     const parse = createModelResponseParser('z-ai/glm-5.1');


### PR DESCRIPTION
一条主线：**出问题的那一步，输入原文要么被改掉、要么被丢掉；而运行状态在重跑前后对不上。** 五处改动都从这里长出来，起点是排查一个「模型超时后重跑，prompt 输入变了」的真实 run。

---

## 1. checkpoint 重跑丢掉整段会话历史

前端从 checkpoint 重跑时把 `messages` 写死成 `[]`（`useAgentTransport.js`），后端只是原样透传给 `buildNvidiaTaskMessages` 的 conversationSummary，服务端没有会话副本可兜底，于是重跑后 system prompt 里「之前的对话」整块消失。

后果是 task 里的指代词（"这几个""上面提到的"）失去所指 —— 实际表现为模型在重跑后第一步就 `ask_user` 反问用户要分析什么，白烧一步。

写成 `[]` 原本是有意的：重跑时 `messages` 已被追加本轮 user 任务、"运行中"占位助手消息和重试提示，直接 `slice(-10)` 会把这些噪声当历史喂回模型。但用清空来躲，代价是把真正需要的旧对话一起扔了。

**改法**：新增纯函数 `buildRunConversationHistory`，重跑时从尾部回溯到本轮 user 消息**之前**，使重跑与首跑的历史口径一致；匹配不上时（刷新后 `lastAgentTaskRef` 丢失、task 退化成占位文案）回退到剔除 `pending` 占位消息。首跑行为不变。

## 2. 失败步骤不留 prompt 原文

`requests` 只在 `planWithTimeout` 成功时挂到结果上，抛错即丢。超时、解析失败这些最需要复盘的步骤，trace 里查不到当时发出去的消息体 —— 上面第 1 条的定位过程只能靠跟相邻 attempt 对比反推。

**改法**：把已发出的 `requests` 挂到错误对象上（私有键传递，不改抛出类型，避免影响按 message/status 判错种的既有逻辑：超时拉黑、429 冷却），由真正发过请求的 `model_plan failed` 事件带出。调度前的预检失败（模型全冷却、已拉黑）没发过请求，保持不带该字段。

UI 侧同步补上，否则记了也看不到：`StepCard` 原本只认 `success`/`winner` 事件取 requests，现在失败步骤回退到 `failed` 事件；`ModelPlanCard` 的 failed 分支加上请求详情面板。failed 事件带 requests 后会参与 prompt diff 基准，这是正确的（请求确实发出去了），相应注释已更新。

## 3. 重跑期间切回前台误报失败，而后端还在跑

现象：`⚠️ Desktop Agent 失败：模型超时 (120s)` 出现后，Agent 面板仍在继续走步骤 —— 失败消息是假的。

切 tab / 手机后台会冻结 JS，SSE 可能错过 done/error，所以 `visibilitychange` 时拉一次持久化 trace 兜底收尾。取的是「最后一个终止事件」（`latestTerminalEvent`），但从 checkpoint 重跑复用同一个 runId、追加到**同一个 trace 文件** —— 重跑跑到一半时，文件里最后一个终止事件仍是上一次 attempt 的失败。

拿一条真实 trace 验证，模拟 attempt 2 执行到 step 4 时前端拉到的前缀：

```
前缀事件数: 32
latestTerminalEvent -> {"type":"error","attempt":1,"error":"模型超时 (120s)"}
该前缀里的最大 attempt: 2  → 终态属于旧 attempt? true
```

于是任务正跑着却被判定失败：占位消息写成失败、`agentRunning` 清零、待审批/待提问弹窗一并清掉（还在跑的那一步就再也等不到答复），而后端继续执行。运行态解锁后发下一个任务还会撞 409。

"刷新后尤其明显"是因为这个监听器的开关是 `if (!agentRunning ...) return` —— 正是重连路径把 `agentRunning` 置 true 才把它武装起来，而会去刷新本身就说明任务在跑。

重连回放路径其实已有同款防护（`isReplayedTerminal`，专挡 `cursor=0` 全量回放里的旧 attempt 终态），兜底这条路径漏掉了。

**改法**：新增 `settledTerminalEvent`，只认 attempt 等于本批事件最大 attempt 的终止事件。新 attempt 一开跑就会追加更高 attempt 的事件，旧终态自然被否掉，无需额外状态。老 trace 没有 attempt 字段时统一按 1 处理，行为与加守卫前一致。

**顺带修的反向 bug**：重连 effect 的 catch 只在 `AbortError` 时清运行态，真出错反而不清。读流中途失败（网络抖动、服务端重启）会让 `agentRunning` 永久停在 true，而该 effect 依赖是 `[sessionsLoading]`、只跑一次不会重订阅 —— 输入框一直锁着，只能再刷新一次页面。改为无条件清理。

## 4. `tryToolCalls` 的 `JSON.parse` 无保护

模型在 tool_call arguments 里吐坏 JSON（典型：shell 命令内双引号没转义，如 `{"command":"echo "---""}`）时，SyntaxError 直接穿透 `parseResponse`，不被策略链的 try 覆盖。用户看到的是裸的 `SyntaxError: JSON Parse error`，而不是标准的 `模型动作解析失败: ...; 原始输出=<围栏原文>`，原文也进不了 `extractRawOutputFromError` 的解析失败语料，`npm run eval` 永远记录不到这类样本。

**改法**：解析失败即 `return null`，让策略链继续走到 `jsonContent` / `textFinish`，最终落到标准 parse-failure。另外 native tool-call 路径上 `content` 通常是空串，只 return null 的话 `rawContent: ''` 会让语料仍然记不到东西 —— 所以失败兜底原文改取坏掉的 arguments。顺带补了 `if (!fn?.name) return null`，原来 `function` 缺失会抛 TypeError。

## 5. 设置页提示：单模型时并发/错峰不生效

排查上面的超时问题时顺出来的配置错配。`fast` / `deep` / `besteffort` 三档的容错都建立在"主模型失败或迟迟不返回时备用模型顶上"之上，但 planner 发现候选集只有一个模型时直接走单模型路径（`agent/desktop/planner/index.ts`），`batchSize` / `staggerDelaySec` 完全不参与。只选一个模型时这些档位只剩等待成本（更长的超时上限），拿不到补位收益：模型一超时整条 run 就失败，只能手动回滚重跑。

统计本地全部 trace：**261 次 run 是单模型、52 次是多模型**，因模型超时导致整条 run 失败 **40 次涉及 33 个 run**。这个搭配问题在实际使用里占绝大多数，而这两个参数折在高级设置里，折叠状态下根本看不出它们没生效。

**改法**：在 Agent 档位说明下方加一条提示，沿用字段级 warning 的样式（取值合法、只是搭配失效，不阻断保存）。判定条件不绑定档位，而是"只选了 1 个模型且 `batchSize>1` 或 `staggerDelaySec>0`" —— `economy` 档同样命中，它的 60s 错峰一样用不上。一个模型都没选时不提示：用户还没做出选择，此时提示没有指向性。

---

## 测试

- `test/agent-conversation.test.js`（新，6 例）：首跑口径不变、重跑保住旧对话、同名任务取最后一次出现、匹配不上时的兜底、10 条上限、空列表。
- `test/agent-trace.test.js`（+4 例）：重跑中忽略旧 attempt 失败、新 attempt 结束后正常收尾、无 attempt 字段的老 trace、尚未结束返回 null。
- `test/desktop-planner-abort.test.ts`（+2 例）：单模型超时后 failed 事件带上发出的 messages；provider 直接拒绝、没发过请求时不带 `requests`。
- `test/nvidia-response-parsers.test.ts`（+5 例）：坏 arguments 不抛异常且 rawContent 保留原文、content 非空时优先用 content、content 里有合法 action JSON 时后者胜出、合法 arguments 照常解析、无 name 的 tool_call 被跳过。
- `test/agent-config-hints.test.js`（新，6 例）：besteffort 单模型命中、economy 仅靠错峰也命中、选第二个模型后消失、两个旋钮都不在场时不提示、零模型不提示、缺失/非数值配置不炸。

`npm run typecheck` / `lint` / `test`（67 文件 556 用例）/ 客户端 `eslint` + `vite build` 全部通过。

## 注意

第 1 条只影响新的 run，已落盘 trace 里缺失的会话历史补不回来。
