### PR TITLE
perf(agent): 切会话不再整条铺开 trace，历史执行弹框放大并补状态标签

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -3223,7 +3223,8 @@ a.model-option-detail-value:hover {
   overflow: visible;
 }
 
-.agent-workspace-trace .agent-last-run,
+/* 面板顶部那句静态说明在 workspace 里是噪音；「最近执行」摘要卡则要留着——
+   历史会话默认折叠步骤流，这张卡就是唯一的运行摘要和展开入口。 */
 .agent-workspace-trace .agent-panel-note {
   display: none;
 }
@@ -3529,6 +3530,17 @@ a.model-option-detail-value:hover {
   color: var(--c-text-muted);
 }
 
+/* 折叠态下把「点我展开步骤流」写在卡片上——历史会话默认不铺开整轮步骤。 */
+.agent-last-run-toggle-hint {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  color: var(--c-text-muted);
+  font-size: var(--f-micro);
+  white-space: nowrap;
+}
+
 .agent-last-run-grid {
   display: flex;
   flex-wrap: wrap;
@@ -3574,22 +3586,63 @@ a.model-option-detail-value:hover {
   background: rgba(0, 0, 0, 0.48);
 }
 
-.model-picker-dialog.agent-history-dialog {
-  width: min(760px, 100%);
-  height: auto;
-  max-height: min(760px, calc(100vh - 48px));
-}
-
+/* 尺寸不再单独收窄，直接沿用「模型选择」弹框的 .model-picker-dialog
+   ——min(1280px, 100vw - 40px) × min(88dvh, 780px)，移动端同样退化成底部抽屉。
+   列表要吃满这个固定高度并在内部滚动，所以必须给 flex 尺寸。 */
 .agent-run-history--dialog {
+  flex: 1 1 0;
+  min-height: 0;
   margin: 0;
-  padding: 12px;
+  padding: 14px;
+  gap: 8px;
   overflow-y: auto;
 }
 
 @media (max-width: 639px) {
-  .model-picker-dialog.agent-history-dialog { max-height: calc(100vh - 20px); }
   .agent-history-btn > span:not(.agent-history-btn-count) { display: none; }
-  .agent-history-run-side > span:first-child { display: none; }
+  /* 窄屏优先保状态标签和时间，模型名先让位。
+     原来这条按 :first-child 写，状态标签插到最前面后会误伤标签本身。 */
+  .agent-history-run-models { display: none; }
+}
+
+/* 执行状态标签。配色走 --c-badge-* 令牌，暗色主题自动跟随。 */
+.agent-run-status-tag {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: var(--f-micro);
+  font-weight: 600;
+  white-space: nowrap;
+  background: var(--c-badge-default-bg);
+  color: var(--c-badge-default);
+}
+
+.agent-run-status-tag.done {
+  background: var(--c-badge-done-bg);
+  color: var(--c-badge-done);
+}
+
+.agent-run-status-tag.degraded {
+  background: var(--c-badge-rollback-bg);
+  color: var(--c-badge-rollback);
+}
+
+.agent-run-status-tag.unverified {
+  background: var(--c-badge-approval-bg);
+  color: var(--c-badge-approval);
+}
+
+.agent-run-status-tag.error {
+  background: var(--c-badge-error-bg);
+  color: var(--c-badge-error);
+}
+
+.agent-run-status-tag.cancelled {
+  background: var(--c-badge-default-bg);
+  color: var(--c-badge-default);
 }
 
 .agent-history-run {
@@ -3601,15 +3654,15 @@ a.model-option-detail-value:hover {
 
 .agent-history-run-toggle {
   width: 100%;
-  min-height: 44px;
-  padding: 8px 10px;
+  min-height: 56px;
+  padding: 11px 14px;
   border: 0;
   background: transparent;
   color: inherit;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
   text-align: left;
   cursor: pointer;
 }
@@ -3622,12 +3675,12 @@ a.model-option-detail-value:hover {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
 }
 
 .agent-history-run-main strong {
   color: var(--c-text);
-  font-size: var(--f-xs);
+  font-size: var(--f-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3636,14 +3689,14 @@ a.model-option-detail-value:hover {
 .agent-history-run-main span,
 .agent-history-run-side {
   color: var(--c-text-secondary);
-  font-size: var(--f-micro);
+  font-size: var(--f-xs);
 }
 
 .agent-history-run-side {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   white-space: nowrap;
 }
 
@@ -3652,12 +3705,12 @@ a.model-option-detail-value:hover {
 }
 
 .agent-history-trace {
-  padding: 0 10px 10px;
+  padding: 0 14px 14px;
   border-top: 1px solid var(--c-border);
 }
 
 .agent-trace.agent-trace--history {
-  max-height: 360px;
+  max-height: 460px;
   margin-top: 8px;
   padding-top: 2px;
   flex: initial;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -49,7 +49,7 @@ import {
 import { formatMsgTime } from './utils/format.js';
 import { shuffled } from './utils/random.js';
 import { hasThinkContent } from './utils/markdown.js';
-import { appendUniqueTraceEvent, settledTerminalEvent } from './utils/agent-trace.js';
+import { appendUniqueTraceEvent, dedupeTraceEvents, settledTerminalEvent } from './utils/agent-trace.js';
 import { buildActualContextEstimate } from './utils/context-usage.js';
 import { buildAgentMetaFromSession } from './utils/agent-stats.js';
 
@@ -732,7 +732,7 @@ export default function App() {
       fetchAgentTrace(savedRunId, { signal: controller.signal, projectId: activeSession.projectId ?? null })
         .then(events => {
           if (events.length === 0 || controller.signal.aborted) return;
-          const deduped = events.reduce((acc, event) => appendUniqueTraceEvent(acc, event), []);
+          const deduped = dedupeTraceEvents(events);
           setAgentTrace(deduped);
           const modelsUsed = getTraceModels(deduped);
           // 重建 trace 只是恢复客户端镜像，不算用户活动：保留原 updatedAt，

--- a/client/src/components/agent/AgentPanel.jsx
+++ b/client/src/components/agent/AgentPanel.jsx
@@ -14,10 +14,11 @@ import { getModelLabel } from './plan-stage.js';
 import { TraceDebugPanel } from './TraceDebugPanel.jsx';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
 import { usePersistentState, jsonStorage } from '../../hooks/usePersistentState.js';
+import { MAX_AGENT_RUN_HISTORY } from '../../hooks/useChatSessions.js';
 import { useT } from '../../i18n/I18nProvider.jsx';
 import { formatFullTime, formatRelativeTime } from '../../utils/format.js';
 import { fetchAgentTrace } from '../../api/streams.js';
-import { appendUniqueTraceEvent } from '../../utils/agent-trace.js';
+import { dedupeTraceEvents } from '../../utils/agent-trace.js';
 import { DialogShell } from '../dialogs/DialogShell.jsx';
 import { attemptStepKey, buildAttemptTraceIndex } from '../../utils/agent-attempts.js';
 
@@ -39,6 +40,16 @@ function statusLabel(status, t) {
   if (status === 'error') return t('agentStats.statusError');
   if (status === 'cancelled') return t('agentStats.statusCancelled');
   return t('agentStats.statusDone');
+}
+
+// 状态标签的配色分档，对应 App.css 里的 --c-badge-* 令牌(自带暗色变体)。
+// 缺省归到 done：老会话的 agentMeta 可能没有 status，但它们本来就是跑完的。
+function statusTone(status) {
+  if (status === 'error') return 'error';
+  if (status === 'cancelled') return 'cancelled';
+  if (status === 'done_degraded') return 'degraded';
+  if (status === 'done_unverified') return 'unverified';
+  return 'done';
 }
 
 function traceRunId(trace) {
@@ -224,7 +235,9 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
   const [traceDebugOpen, setTraceDebugOpen] = useState(false);
   const [traceDebugModelId, setTraceDebugModelId] = useState('all');
   const [headVisible, setHeadVisible] = useState(true);
-  const [recentRunExpanded, setRecentRunExpanded] = useState(true);
+  // 展开着完整步骤流的那一轮 run(按 runId 记，不是布尔量)：
+  // 只有“本次进来跑过的这一轮”默认展开，点开历史会话时一律先折叠成摘要卡。
+  const [expandedRunId, setExpandedRunId] = useState(null);
   const [selectedModelId, setSelectedModelId] = useState('all');
 
   // 运行悬浮框：默认贴在页面右上角(fixed，见 CSS)，桌面端可拖动、缩放；位置尺寸持久化。
@@ -336,18 +349,27 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
   );
   const currentRunId = lastRun?.runId || traceRunId(trace);
   const canToggleRecentRun = !running && trace.length > 0 && !!lastRun;
+  // 一轮 run 可以有几百个事件、上兆文本，点开历史会话就整条挂上去会明显卡一帧。
+  // 所以历史会话默认只渲染「最近执行」摘要卡，完整步骤流等用户点开再挂。
+  const recentRunExpanded = running || expandedRunId === currentRunId;
   const showCurrentTrace = running || !canToggleRecentRun || recentRunExpanded;
   const LastRunFrame = canToggleRecentRun ? 'button' : 'div';
   const lastRunClassName = `agent-last-run${lastRun?.status === 'error' ? ' error' : ''}${canToggleRecentRun ? ' agent-last-run-toggle' : ''}`;
   const historyRuns = useMemo(
-    () => previousRuns.filter((run, index) => runKey(run, index) !== currentRunId).slice(0, 8),
+    // 会话里最多就存这么多条，这里不再另设更小的显示上限——弹框够高，列表自己滚。
+    () => previousRuns.filter((run, index) => runKey(run, index) !== currentRunId).slice(0, MAX_AGENT_RUN_HISTORY),
     [currentRunId, previousRuns],
   );
 
   useEffect(() => {
-    setRecentRunExpanded(true);
     setSelectedModelId('all');
   }, [currentRunId]);
+
+  // 正在跑的这一轮登记为“已展开”，这样 run 结束、running 落回 false 之后，
+  // 刚看完的步骤流不会在收尾那一刻突然折叠起来。
+  useEffect(() => {
+    if (running && currentRunId) setExpandedRunId(currentRunId);
+  }, [running, currentRunId]);
 
   useEffect(() => {
     if (selectedModelId !== 'all' && !modelIds.includes(selectedModelId)) setSelectedModelId('all');
@@ -362,7 +384,7 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
     setHistoryTraceLoading(key);
     try {
       const events = await fetchAgentTrace(run.runId, { projectId });
-      const deduped = events.reduce((acc, event) => appendUniqueTraceEvent(acc, event), []);
+      const deduped = dedupeTraceEvents(events);
       setHistoryTraceCache(prev => ({ ...prev, [key]: deduped }));
     } catch {
       setHistoryTraceCache(prev => ({ ...prev, [key]: [] }));
@@ -588,7 +610,7 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
               className={lastRunClassName}
               {...(canToggleRecentRun ? {
                 type: 'button',
-                onClick: () => setRecentRunExpanded(v => !v),
+                onClick: () => setExpandedRunId(prev => (prev === currentRunId ? null : currentRunId)),
                 'aria-expanded': recentRunExpanded,
               } : {})}
             >
@@ -601,7 +623,12 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
                   <span className="agent-last-run-status" title={lastRun.endedAt ? formatFullTime(lastRun.endedAt) : ''}>
                     {lastRun.endedAt ? formatRelativeTime(lastRun.endedAt) : statusLabel(lastRun.status, t)}
                   </span>
-                  {canToggleRecentRun && (recentRunExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />)}
+                  {canToggleRecentRun && (
+                    <span className="agent-last-run-toggle-hint">
+                      {recentRunExpanded ? t('agentPanel.collapseTrace') : t('agentPanel.expandTrace')}
+                      {recentRunExpanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                    </span>
+                  )}
                 </span>
               </div>
               <div className="agent-last-run-grid">
@@ -716,7 +743,7 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
     {historyDialogOpen && (
       <DialogShell
         title={t('agentPanel.previousRuns')}
-        subtitle={historyRuns.length}
+        subtitle={t('agentPanel.previousRunsCap', { n: historyRuns.length, max: MAX_AGENT_RUN_HISTORY })}
         onClose={() => setHistoryDialogOpen(false)}
         escapeDisabled={!!lightboxSrc}
         maskClassName="agent-history-dialog-mask"
@@ -740,8 +767,11 @@ export function AgentPanel({ running, trace, startedAt, lastRun, previousRuns = 
                       <span>{formatDurationMs(meta.elapsedMs || 0)} · {formatTokenCount(meta.totalTokens || 0)} tok · {t('agentPanel.stepCount', { n: meta.stepCount || 0 })}</span>
                     </span>
                     <span className="agent-history-run-side">
-                      <span>{models.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
-                      <span title={meta.endedAt ? formatFullTime(meta.endedAt) : ''}>{meta.endedAt ? formatRelativeTime(meta.endedAt) : statusLabel(meta.status, t)}</span>
+                      <span className={`agent-run-status-tag ${statusTone(meta.status)}`}>{statusLabel(meta.status, t)}</span>
+                      <span className="agent-history-run-models">{models.slice(0, 2).join(' + ') || t('session.unknownModel')}</span>
+                      {meta.endedAt && (
+                        <span title={formatFullTime(meta.endedAt)}>{formatRelativeTime(meta.endedAt)}</span>
+                      )}
                       {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
                     </span>
                   </button>

--- a/client/src/hooks/useChatSessions.js
+++ b/client/src/hooks/useChatSessions.js
@@ -3,7 +3,9 @@ import { tStatic } from '../i18n/locale.js';
 import { normalizeAgentMeta } from '../utils/agent-stats.js';
 import { apiFetch } from '../api/http.js';
 
-const MAX_AGENT_RUN_HISTORY = 30;
+// 单个会话保留的 Agent 执行记录上限。服务端 session-store 的 normalizeAgentRuns
+// 也切在 30，两边必须一致，否则前端显示的条数会比落盘的多。
+export const MAX_AGENT_RUN_HISTORY = 30;
 
 function generateSessionId() {
   return `session_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;

--- a/client/src/i18n/locales/en.js
+++ b/client/src/i18n/locales/en.js
@@ -299,6 +299,8 @@ export const en = {
   'agentPanel.browserStatus.recovering': 'Rebuilding',
   'agentPanel.browserStatus.degraded': 'Degraded',
   'agentPanel.recentRun': 'Recent run',
+  'agentPanel.expandTrace': 'Show steps',
+  'agentPanel.collapseTrace': 'Hide steps',
   'agentPanel.mcpPhase.connecting': 'Connecting',
   'agentPanel.mcpPhase.connected': 'Connected',
   'agentPanel.mcpPhase.discovering': 'Discovering tools',
@@ -308,6 +310,7 @@ export const en = {
   'agentPanel.mcpPhase.completed': 'Completed',
   'agentPanel.mcpPhase.error': 'Failed',
   'agentPanel.previousRuns': 'Previous runs',
+  'agentPanel.previousRunsCap': '{n} runs · each chat keeps the latest {max}',
   'agentPanel.historyLoading': 'Loading previous steps…',
   'agentPanel.historyTraceUnavailable': 'No saved steps were found for this run',
 

--- a/client/src/i18n/locales/zh.js
+++ b/client/src/i18n/locales/zh.js
@@ -300,6 +300,8 @@ export const zh = {
   'agentPanel.browserStatus.recovering': '正在重建',
   'agentPanel.browserStatus.degraded': '异常',
   'agentPanel.recentRun': '最近执行',
+  'agentPanel.expandTrace': '展开过程',
+  'agentPanel.collapseTrace': '收起过程',
   'agentPanel.mcpPhase.connecting': '正在连接',
   'agentPanel.mcpPhase.connected': '连接成功',
   'agentPanel.mcpPhase.discovering': '读取工具列表',
@@ -309,6 +311,7 @@ export const zh = {
   'agentPanel.mcpPhase.completed': '已完成',
   'agentPanel.mcpPhase.error': '执行失败',
   'agentPanel.previousRuns': '历史执行',
+  'agentPanel.previousRunsCap': '共 {n} 条 · 每个会话最多保留最近 {max} 条',
   'agentPanel.historyLoading': '正在加载历史步骤…',
   'agentPanel.historyTraceUnavailable': '未找到这次执行的历史步骤',
 

--- a/client/src/utils/agent-trace.js
+++ b/client/src/utils/agent-trace.js
@@ -39,6 +39,26 @@ export function appendUniqueTraceEvent(prev, event) {
   return [...prev, event];
 }
 
+// 整条 trace 一次性落地时(切换会话、SSE 重连回放)的批量去重。
+// appendUniqueTraceEvent 是为“逐个追加”写的：每追加一个事件都要重算一遍已有事件的
+// key 并复制整份数组，拿它 reduce 一条几百事件的 trace 就是 O(n²)，这笔开销全压在
+// 切会话那一帧上。语义保持一致：同 key 留先出现的那个，算不出 key 的事件一律保留。
+export function dedupeTraceEvents(events) {
+  if (!Array.isArray(events)) return [];
+
+  const seen = new Set();
+  const result = [];
+  for (const event of events) {
+    const key = agentTraceEventKey(event);
+    if (key) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+    }
+    result.push(event);
+  }
+  return result;
+}
+
 // 从 checkpoint 重跑会复用 runId，于是同一条 trace 里留着每个 attempt 的
 // done/error。取首个会读到早已被重跑覆盖的旧结果——成功的 run 因此被记成失败。
 // 语义上“这个 run 的结局”永远是最后一个终止事件。

--- a/test/agent-trace.test.js
+++ b/test/agent-trace.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { agentTraceEventKey, appendUniqueTraceEvent, latestTerminalEvent, settledTerminalEvent } from '../client/src/utils/agent-trace.js';
+import { agentTraceEventKey, appendUniqueTraceEvent, dedupeTraceEvents, latestTerminalEvent, settledTerminalEvent } from '../client/src/utils/agent-trace.js';
 
 describe('agent trace event de-duplication', () => {
   it('uses the server sequence as the primary event identity', () => {
@@ -37,6 +37,41 @@ describe('agent trace event de-duplication', () => {
     const replay = { ...action };
 
     expect(appendUniqueTraceEvent([action], replay)).toHaveLength(1);
+  });
+});
+
+// 切会话/重连回放会一次性落地整条 trace。逐个 appendUniqueTraceEvent 是 O(n²)，
+// 几百个事件时那一帧的开销肉眼可见，故批量路径走 Set，但结果必须逐字节等价。
+describe('bulk trace de-duplication', () => {
+  it('matches append-one-by-one results', () => {
+    const events = [
+      { runId: 'run_1', seq: 1, type: 'status', status: 'starting' },
+      { runId: 'run_1', seq: 2, type: 'step', step: 1, stage: 'observe' },
+      { runId: 'run_1', seq: 2, type: 'step', step: 1, stage: 'observe' },
+      { type: 'terminal_output', step: 1, phase: 'stdout', sequence: 1, chunk: 'a\n' },
+      { type: 'terminal_output', step: 1, phase: 'stdout', sequence: 1, chunk: 'a\n' },
+      { type: 'terminal_output', step: 1, phase: 'stdout', sequence: 2, chunk: 'b\n' },
+      { runId: 'run_1', seq: 9, type: 'done', answer: '完成' },
+    ];
+
+    const oneByOne = events.reduce((acc, event) => appendUniqueTraceEvent(acc, event), []);
+
+    expect(dedupeTraceEvents(events)).toEqual(oneByOne);
+    expect(dedupeTraceEvents(events)).toHaveLength(5);
+  });
+
+  it('keeps the first occurrence of a duplicated key', () => {
+    const first = { runId: 'run_1', seq: 3, type: 'step', step: 2, stage: 'action', tag: 'first' };
+    const later = { runId: 'run_1', seq: 3, type: 'step', step: 2, stage: 'action', tag: 'later' };
+
+    expect(dedupeTraceEvents([first, later])).toEqual([first]);
+  });
+
+  it('keeps events that produce no key instead of collapsing them', () => {
+    const events = [null, undefined, 'junk'];
+
+    expect(dedupeTraceEvents(events)).toEqual(events);
+    expect(dedupeTraceEvents(null)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## 起因

点开一个跑过多轮的会话会明显卡一帧。

本地实测：单次 run 最大 **48 步 / 434 个事件 / 1.2MB 文本**（`data/projects/default/traces/`）。AgentPanel 把这几百张 StepCard、模型计划卡一次性挂进 DOM，就是那一下卡顿的来源。

顺带查清一个误解：**之前几轮 run 其实早就不渲染了**，它们折叠在「历史执行」弹框里点开才懒加载；切会话时也只拉 `agentRunId` 那一条。真正"全都显示"的是最后这一次 run 自己的完整步骤流。

## 改了什么

### 1. 历史会话默认只渲染摘要卡

完整步骤流点开再挂。展开状态按 `runId` 记而不是布尔量 —— 这样正在跑和刚跑完的那一轮不受影响：run 结束时 `currentRunId` 不变，收尾那一刻不会突然折叠起来。

### 2. 放出 `.agent-last-run` 摘要卡（顺手修掉的死 UI）

它从 #332 起在 workspace 布局里被 `display: none`，而 `.agent-workspace-trace` 是 AgentPanel 唯一的挂载点 —— 所以那张卡、以及卡上的折叠箭头一直是**点不到的死 UI**，`recentRunExpanded` 因此永远为 `true`，整轮步骤流从来折不起来。现在它同时是展开入口。

### 3. 批量去重 O(n²) → O(n)

切会话 / 重连回放会把整条 trace 一次性落地，却复用了为"逐个追加"写的 `appendUniqueTraceEvent`：每追加一个事件都要重算一遍已有事件的 key 并复制整份数组，434 个事件约 **9.4 万次 key 计算**全压在同一帧。

新增 `dedupeTraceEvents` 走 Set 单遍，语义与逐个追加等价（同 key 留先出现的、算不出 key 的一律保留），并补了与 `appendUniqueTraceEvent` 的对拍测试。

### 4. 历史执行弹框

| | 之前 | 现在 |
|---|---|---|
| 弹框尺寸 | 单独收窄成 `min(760px, 100%)` | 沿用模型选择的 `.model-picker-dialog` |
| 显示上限 | `slice(0, 8)` | `MAX_AGENT_RUN_HISTORY`(30) |
| 行高 / 内边距 | 44px / 8px 10px | 56px / 11px 14px |
| 任务标题 / 元信息 | `--f-xs` / `--f-micro` | `--f-sm` / `--f-xs` |
| 展开后步骤区高度 | 360px | 460px |
| 运行状态 | 实际从未显示 | 彩色标签 |

- 高度从 auto 变成固定值后，列表要 `flex: 1 1 0; min-height: 0` 才能在内部滚动，否则会被弹框的 `overflow: hidden` 切掉。
- 上限常量从 `useChatSessions` 导出，与前端 `normalizeAgentRuns`、服务端 `session-store.ts` 的 30 同源。副标题标出「每个会话最多保留最近 30 条」—— 写"保留"而非"显示"，因为 30 是落盘上限，超出的旧记录会被丢弃。
- 状态标签修的是一个既有 bug：原来写的是 `endedAt ? 相对时间 : statusLabel(...)`，而跑完的 run 必有 `endedAt`，于是状态实际从未露面。配色走既有 `--c-badge-*` 令牌，暗色主题自动跟随。
- 移动端隐藏模型名那条规则原按 `:first-child` 写，状态标签插到最前面会误伤它自己，改为按 `.agent-history-run-models` 精确命中。

## 状态配色

| 状态 | 标签 | token |
|---|---|---|
| `done` | 已完成 | `--c-badge-done` 绿 |
| `done_degraded` | 降级完成 | `--c-badge-rollback` 橙 |
| `done_unverified` | 未验证 | `--c-badge-approval` 琥珀 |
| `error` | 失败 | `--c-badge-error` 红 |
| `cancelled` | 已取消 | `--c-badge-default` 灰 |

## 测试

- `npm test` — 68 文件 / 589 例通过，其中新增 `dedupeTraceEvents` 3 例（与逐个追加对拍、同 key 留先出现的、无 key 事件不塌缩）
- `npm run build`（后端 tsc + 前端 vite）通过
- `npm run lint` 与 client eslint 通过
